### PR TITLE
Refactor error handling

### DIFF
--- a/adbc_driver_manager/adbc_driver_manager.h
+++ b/adbc_driver_manager/adbc_driver_manager.h
@@ -40,8 +40,11 @@ extern "C" {
 /// \param[out] driver The table of function pointers to initialize.
 /// \param[out] initialized How much of the table was actually
 ///   initialized (can be less than count).
+/// \param[out] error An optional location to return an error message
+///   if necessary.
 AdbcStatusCode AdbcLoadDriver(const char* connection, size_t count,
-                              struct AdbcDriver* driver, size_t* initialized);
+                              struct AdbcDriver* driver, size_t* initialized,
+                              struct AdbcError* error);
 
 #endif  // ADBC_DRIVER_MANAGER_H
 

--- a/adbc_driver_manager/adbc_driver_manager_test.cc
+++ b/adbc_driver_manager/adbc_driver_manager_test.cc
@@ -36,9 +36,9 @@ class DriverManager : public ::testing::Test {
  public:
   void SetUp() override {
     size_t initialized = 0;
-    ADBC_ASSERT_OK(
+    ADBC_ASSERT_OK_WITH_ERROR(error,
         AdbcLoadDriver("Driver=libadbc_driver_sqlite.so;Entrypoint=AdbcSqliteDriverInit",
-                       ADBC_VERSION_0_0_1, &driver, &initialized));
+                       ADBC_VERSION_0_0_1, &driver, &initialized, &error));
     ASSERT_EQ(initialized, ADBC_VERSION_0_0_1);
 
     AdbcDatabaseOptions db_options;
@@ -90,8 +90,6 @@ TEST_F(DriverManager, SqlExecute) {
 }
 
 TEST_F(DriverManager, SqlExecuteInvalid) {
-  GTEST_SKIP() << "AdbcError needs refactoring";
-
   std::string query = "INVALID";
   AdbcStatement statement;
   std::memset(&statement, 0, sizeof(statement));

--- a/drivers/test_util.h
+++ b/drivers/test_util.h
@@ -40,7 +40,7 @@ namespace adbc {
     auto code_ = (EXPR);                                                       \
     if (code_ != ADBC_STATUS_OK) {                                             \
       std::string errmsg_ = ERROR.message ? ERROR.message : "(unknown error)"; \
-      AdbcErrorRelease(&ERROR);                                                \
+      if (ERROR.message) error.release(&error);                                \
       ASSERT_EQ(code_, ADBC_STATUS_OK) << errmsg_;                             \
     }                                                                          \
   } while (false)
@@ -49,7 +49,7 @@ namespace adbc {
   do {                                                                       \
     ASSERT_NE(ERROR.message, nullptr);                                       \
     std::string errmsg_ = ERROR.message ? ERROR.message : "(unknown error)"; \
-    AdbcErrorRelease(&ERROR);                                                \
+      if (ERROR.message) error.release(&error);                                \
     ASSERT_THAT(errmsg_, PATTERN) << errmsg_;                                \
   } while (false)
 


### PR DESCRIPTION
It's hard for the driver manager to allocate/free errors since it
would have to manually intercept all calls. Also, it makes it hard
to provide error messages when there is no driver. Move the error
release callback to the error structure itself to make this easier.