### PR TITLE
Make AdbcConnectionNew 2-adic for consistency

### DIFF
--- a/adbc.h
+++ b/adbc.h
@@ -322,8 +322,7 @@ struct ADBC_EXPORT AdbcConnection {
 
 /// \brief Allocate a new (but uninitialized) connection.
 ADBC_EXPORT
-AdbcStatusCode AdbcConnectionNew(struct AdbcDatabase* database,
-                                 struct AdbcConnection* connection,
+AdbcStatusCode AdbcConnectionNew(struct AdbcConnection* connection,
                                  struct AdbcError* error);
 
 ADBC_EXPORT
@@ -333,7 +332,7 @@ AdbcStatusCode AdbcConnectionSetOption(struct AdbcConnection* connection, const 
 /// \brief Finish setting options and initialize the connection.
 ADBC_EXPORT
 AdbcStatusCode AdbcConnectionInit(struct AdbcConnection* connection,
-                                  struct AdbcError* error);
+                                  struct AdbcDatabase* database, struct AdbcError* error);
 
 /// \brief Destroy this connection.
 /// \param[in] connection The connection to release.
@@ -813,11 +812,11 @@ struct ADBC_EXPORT AdbcDriver {
   AdbcStatusCode (*DatabaseInit)(struct AdbcDatabase*, struct AdbcError*);
   AdbcStatusCode (*DatabaseRelease)(struct AdbcDatabase*, struct AdbcError*);
 
-  AdbcStatusCode (*ConnectionNew)(struct AdbcDatabase*, struct AdbcConnection*,
-                                  struct AdbcError*);
+  AdbcStatusCode (*ConnectionNew)(struct AdbcConnection*, struct AdbcError*);
   AdbcStatusCode (*ConnectionSetOption)(struct AdbcConnection*, const char*, const char*,
                                         struct AdbcError*);
-  AdbcStatusCode (*ConnectionInit)(struct AdbcConnection*, struct AdbcError*);
+  AdbcStatusCode (*ConnectionInit)(struct AdbcConnection*, struct AdbcDatabase*,
+                                   struct AdbcError*);
   AdbcStatusCode (*ConnectionRelease)(struct AdbcConnection*, struct AdbcError*);
 
   AdbcStatusCode (*ConnectionDeserializePartitionDesc)(struct AdbcConnection*,

--- a/adbc_driver_manager/adbc_driver_manager_test.cc
+++ b/adbc_driver_manager/adbc_driver_manager_test.cc
@@ -58,8 +58,8 @@ class DriverManager : public ::testing::Test {
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcDatabaseInit(&database, &error));
     ASSERT_NE(database.private_data, nullptr);
 
-    ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&database, &connection, &error));
-    ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionInit(&connection, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&connection, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionInit(&connection, &database, &error));
     ASSERT_NE(connection.private_data, nullptr);
   }
 
@@ -87,6 +87,24 @@ class DriverManager : public ::testing::Test {
   AdbcConnection connection;
   AdbcError error = {};
 };
+
+TEST_F(DriverManager, DatabaseInitRelease) {
+  AdbcError error = {};
+  AdbcDatabase database;
+  std::memset(&database, 0, sizeof(database));
+
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcDatabaseNew(&database, &error));
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcDatabaseRelease(&database, &error));
+}
+
+TEST_F(DriverManager, ConnectionInitRelease) {
+  AdbcError error = {};
+  AdbcConnection connection;
+  std::memset(&connection, 0, sizeof(connection));
+
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&connection, &error));
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionRelease(&connection, &error));
+}
 
 TEST_F(DriverManager, SqlExecute) {
   std::string query = "SELECT 1";

--- a/drivers/flight_sql/flight_sql_test.cc
+++ b/drivers/flight_sql/flight_sql_test.cc
@@ -41,8 +41,9 @@ class AdbcFlightSqlTest : public ::testing::Test {
       ADBC_ASSERT_OK_WITH_ERROR(
           error, AdbcDatabaseSetOption(&database, "location", location, &error));
       ADBC_ASSERT_OK_WITH_ERROR(error, AdbcDatabaseInit(&database, &error));
-      ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&database, &connection, &error));
-      ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionInit(&connection, &error));
+      ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&connection, &error));
+      ADBC_ASSERT_OK_WITH_ERROR(error,
+                                AdbcConnectionInit(&connection, &database, &error));
     } else {
       FAIL() << "Must provide location of Flight SQL server at " << kServerEnvVar;
     }

--- a/drivers/sqlite/sqlite_test.cc
+++ b/drivers/sqlite/sqlite_test.cc
@@ -56,8 +56,8 @@ class Sqlite : public ::testing::Test {
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcDatabaseInit(&database, &error));
     ASSERT_NE(database.private_data, nullptr);
 
-    ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&database, &connection, &error));
-    ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionInit(&connection, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&connection, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionInit(&connection, &database, &error));
     ASSERT_NE(connection.private_data, nullptr);
   }
 
@@ -328,8 +328,8 @@ TEST_F(Sqlite, BulkIngestStream) {
 
 TEST_F(Sqlite, MultipleConnections) {
   struct AdbcConnection connection2;
-  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&database, &connection2, &error));
-  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionInit(&connection2, &error));
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&connection2, &error));
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionInit(&connection2, &database, &error));
   ASSERT_NE(connection.private_data, nullptr);
 
   {
@@ -661,12 +661,12 @@ TEST_F(Sqlite, Transactions) {
       AdbcDatabaseSetOption(&database, "filename",
                             "file:Sqlite_Transactions?mode=memory&cache=shared", &error));
   ADBC_ASSERT_OK_WITH_ERROR(error, AdbcDatabaseInit(&database, &error));
-  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&database, &connection, &error));
-  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionInit(&connection, &error));
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&connection, &error));
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionInit(&connection, &database, &error));
 
   struct AdbcConnection connection2;
-  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&database, &connection2, &error));
-  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionInit(&connection2, &error));
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionNew(&connection2, &error));
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionInit(&connection2, &database, &error));
   ASSERT_NE(connection.private_data, nullptr);
 
   AdbcStatement statement;

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -79,9 +79,9 @@ cdef extern from "adbc.h":
     AdbcStatusCode AdbcDatabaseInit(CAdbcDatabase* database, CAdbcError* error)
     AdbcStatusCode AdbcDatabaseRelease(CAdbcDatabase* database, CAdbcError* error)
 
-    AdbcStatusCode AdbcConnectionNew(CAdbcDatabase* database, CAdbcConnection* connection, CAdbcError* error)
+    AdbcStatusCode AdbcConnectionNew(CAdbcConnection* connection, CAdbcError* error)
     AdbcStatusCode AdbcConnectionSetOption(CAdbcConnection* connection, const char* key, const char* value, CAdbcError* error)
-    AdbcStatusCode AdbcConnectionInit(CAdbcConnection* connection, CAdbcError* error)
+    AdbcStatusCode AdbcConnectionInit(CAdbcConnection* connection, CAdbcDatabase* database, CAdbcError* error)
     AdbcStatusCode AdbcConnectionRelease(CAdbcConnection* connection, CAdbcError* error)
 
     AdbcStatusCode AdbcStatementBind(CAdbcStatement* statement, CArrowArray*, CArrowSchema*, CAdbcError* error)
@@ -247,7 +247,7 @@ cdef class AdbcConnection(_AdbcHandle):
         cdef const char* c_value
         memset(&self.connection, 0, cython.sizeof(CAdbcConnection))
 
-        status = AdbcConnectionNew(&database.database, &self.connection, &c_error)
+        status = AdbcConnectionNew(&self.connection, &c_error)
         check_error(status, &c_error)
 
         for key, value in kwargs.items():
@@ -258,7 +258,7 @@ cdef class AdbcConnection(_AdbcHandle):
             status = AdbcConnectionSetOption(&self.connection, c_key, c_value, &c_error)
             check_error(status, &c_error)
 
-        status = AdbcConnectionInit(&self.connection, &c_error)
+        status = AdbcConnectionInit(&self.connection, &database.database, &c_error)
         check_error(status, &c_error)
 
     def close(self) -> None:


### PR DESCRIPTION
Make AdbcConnectionNew consistent with AdbcDatabaseNew.

This mostly doesn't affect the driver implementations; it does make the driver manager a little more complex.