### PR TITLE
[C][Java][Python] Add GetInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ docker_cache
 
 site/
 
+# Python
+dist/
+
 # R files
 **/.Rproj.user
 **/*.Rcheck/

--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -320,6 +320,17 @@ AdbcStatusCode AdbcConnectionCommit(struct AdbcConnection* connection,
   return connection->private_driver->ConnectionCommit(connection, error);
 }
 
+AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
+                                     uint32_t* info_codes, size_t info_codes_length,
+                                     struct AdbcStatement* statement,
+                                     struct AdbcError* error) {
+  if (!connection->private_driver) {
+    return ADBC_STATUS_INVALID_STATE;
+  }
+  return connection->private_driver->ConnectionGetInfo(
+      connection, info_codes, info_codes_length, statement, error);
+}
+
 AdbcStatusCode AdbcConnectionGetObjects(struct AdbcConnection* connection, int depth,
                                         const char* catalog, const char* db_schema,
                                         const char* table_name, const char** table_types,
@@ -681,6 +692,7 @@ AdbcStatusCode AdbcLoadDriver(const char* driver_name, const char* entrypoint,
   CHECK_REQUIRED(driver, DatabaseInit);
   CHECK_REQUIRED(driver, DatabaseRelease);
 
+  CHECK_REQUIRED(driver, ConnectionGetInfo);
   CHECK_REQUIRED(driver, ConnectionNew);
   CHECK_REQUIRED(driver, ConnectionInit);
   CHECK_REQUIRED(driver, ConnectionRelease);

--- a/c/driver_manager/adbc_driver_manager_test.cc
+++ b/c/driver_manager/adbc_driver_manager_test.cc
@@ -107,6 +107,51 @@ TEST_F(DriverManager, ConnectionInitRelease) {
   ADBC_ASSERT_OK_WITH_ERROR(error, AdbcConnectionRelease(&connection, &error));
 }
 
+TEST_F(DriverManager, MetadataGetInfo) {
+  static std::shared_ptr<arrow::Schema> kInfoSchema = arrow::schema({
+      arrow::field("info_name", arrow::uint32(), /*nullable=*/false),
+      arrow::field(
+          "info_value",
+          arrow::dense_union({
+              arrow::field("string_value", arrow::utf8()),
+              arrow::field("bool_value", arrow::boolean()),
+              arrow::field("int64_value", arrow::int64()),
+              arrow::field("int32_bitmask", arrow::int32()),
+              arrow::field("string_list", arrow::list(arrow::utf8())),
+              arrow::field("int32_to_int32_list_map",
+                           arrow::map(arrow::int32(), arrow::list(arrow::int32()))),
+          })),
+  });
+
+  AdbcStatement statement;
+  std::memset(&statement, 0, sizeof(statement));
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementNew(&connection, &statement, &error));
+  ADBC_ASSERT_OK_WITH_ERROR(
+      error, AdbcConnectionGetInfo(&connection, nullptr, 0, &statement, &error));
+
+  std::shared_ptr<arrow::Schema> schema;
+  arrow::RecordBatchVector batches;
+  ReadStatement(&statement, &schema, &batches);
+  ASSERT_SCHEMA_EQ(*schema, *kInfoSchema);
+  ASSERT_EQ(1, batches.size());
+
+  std::vector<uint32_t> info = {
+      ADBC_INFO_DRIVER_NAME,
+      ADBC_INFO_DRIVER_VERSION,
+      ADBC_INFO_VENDOR_NAME,
+      ADBC_INFO_VENDOR_VERSION,
+  };
+  ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementNew(&connection, &statement, &error));
+  ADBC_ASSERT_OK_WITH_ERROR(
+      error,
+      AdbcConnectionGetInfo(&connection, info.data(), info.size(), &statement, &error));
+  batches.clear();
+  ReadStatement(&statement, &schema, &batches);
+  ASSERT_SCHEMA_EQ(*schema, *kInfoSchema);
+  ASSERT_EQ(1, batches.size());
+  ASSERT_EQ(4, batches[0]->num_rows());
+}
+
 TEST_F(DriverManager, SqlExecute) {
   std::string query = "SELECT 1";
   AdbcStatement statement;

--- a/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcConnection.java
+++ b/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcConnection.java
@@ -54,6 +54,20 @@ public interface AdbcConnection extends AutoCloseable {
         "Connection does not support deserializePartitionDescriptor(ByteBuffer)");
   }
 
+  AdbcStatement getInfo(int[] infoCodes) throws AdbcException;
+
+  default AdbcStatement getInfo(AdbcInfoCode[] infoCodes) throws AdbcException {
+    int[] codes = new int[infoCodes.length];
+    for (int i = 0; i < infoCodes.length; i++) {
+      codes[i] = infoCodes[i].getValue();
+    }
+    return getInfo(codes);
+  }
+
+  default AdbcStatement getInfo() throws AdbcException {
+    return getInfo((int[]) null);
+  }
+
   /**
    * Get a hierarchical view of all catalogs, database schemas, tables, and columns.
    *

--- a/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcInfoCode.java
+++ b/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcInfoCode.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.adbc.core;
+
+/** Integer IDs used for requesting information about the database/driver. */
+public enum AdbcInfoCode {
+  /** The database vendor/product name (e.g. the server name) (type: utf8). */
+  VENDOR_NAME(0),
+  /** The database vendor/product version (type: utf8). */
+  VENDOR_VERSION(1),
+  /** The database vendor/product Arrow library version (type: utf8). */
+  VENDOR_ARROW_VERSION(2),
+
+  /** The driver name (type: utf8). */
+  DRIVER_NAME(100),
+  /** The driver version (type: utf8). */
+  DRIVER_VERSION(101),
+  /** The driver Arrow library version (type: utf8). */
+  DRIVER_ARROW_VERSION(102),
+  ;
+
+  private final int value;
+
+  AdbcInfoCode(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+}

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/InfoMetadataBuilder.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/InfoMetadataBuilder.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.adbc.driver.jdbc;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.arrow.adbc.core.AdbcInfoCode;
+import org.apache.arrow.adbc.core.StandardSchemas;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.AutoCloseables;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.DenseUnionVector;
+
+/** Helper class to track state needed to build up the info structure. */
+final class InfoMetadataBuilder implements AutoCloseable {
+  private static final byte STRING_VALUE_TYPE_ID = (byte) 0;
+  private static final Map<Integer, AddInfo> SUPPORTED_CODES = new HashMap<>();
+  private final Collection<Integer> requestedCodes;
+  private final DatabaseMetaData dbmd;
+  private VectorSchemaRoot root;
+
+  final UInt4Vector infoCodes;
+  final DenseUnionVector infoValues;
+  final VarCharVector stringValues;
+
+  @FunctionalInterface
+  interface AddInfo {
+    void accept(InfoMetadataBuilder builder, int rowIndex) throws SQLException;
+  }
+
+  static {
+    SUPPORTED_CODES.put(
+        AdbcInfoCode.VENDOR_NAME.getValue(),
+        (b, idx) -> {
+          b.setStringValue(idx, b.dbmd.getDatabaseProductName());
+        });
+    SUPPORTED_CODES.put(
+        AdbcInfoCode.VENDOR_VERSION.getValue(),
+        (b, idx) -> {
+          b.setStringValue(idx, b.dbmd.getDatabaseProductVersion());
+        });
+    SUPPORTED_CODES.put(
+        AdbcInfoCode.DRIVER_NAME.getValue(),
+        (b, idx) -> {
+          final String driverName = "ADBC JDBC Driver (" + b.dbmd.getDriverName() + ")";
+          b.setStringValue(idx, driverName);
+        });
+    SUPPORTED_CODES.put(
+        AdbcInfoCode.DRIVER_VERSION.getValue(),
+        (b, idx) -> {
+          final String driverVersion = b.dbmd.getDriverVersion() + " (ADBC Driver Version 0.0.1)";
+          b.setStringValue(idx, driverVersion);
+        });
+  }
+
+  InfoMetadataBuilder(BufferAllocator allocator, Connection connection, int[] infoCodes)
+      throws SQLException {
+    this.requestedCodes =
+        infoCodes == null
+            ? SUPPORTED_CODES.keySet()
+            : IntStream.of(infoCodes).boxed().collect(Collectors.toList());
+    this.root = VectorSchemaRoot.create(StandardSchemas.GET_INFO_SCHEMA, allocator);
+    this.dbmd = connection.getMetaData();
+    this.infoCodes = (UInt4Vector) root.getVector(0);
+    this.infoValues = (DenseUnionVector) root.getVector(1);
+    this.stringValues = this.infoValues.getVarCharVector((byte) 0);
+  }
+
+  void setStringValue(int index, final String value) {
+    infoValues.setValueCount(index + 1);
+    infoValues.setTypeId(index, STRING_VALUE_TYPE_ID);
+    stringValues.setSafe(index, value.getBytes(StandardCharsets.UTF_8));
+    infoValues
+        .getOffsetBuffer()
+        .setInt((long) index * DenseUnionVector.OFFSET_WIDTH, stringValues.getLastSet());
+  }
+
+  VectorSchemaRoot build() throws SQLException {
+    int rowIndex = 0;
+    for (final Integer code : requestedCodes) {
+      final AddInfo metadata = SUPPORTED_CODES.get(code);
+      if (metadata == null) {
+        continue;
+      }
+      infoCodes.setSafe(rowIndex, code);
+      metadata.accept(this, rowIndex++);
+    }
+    root.setRowCount(rowIndex);
+    VectorSchemaRoot result = root;
+    root = null;
+    return result;
+  }
+
+  @Override
+  public void close() throws Exception {
+    AutoCloseables.close(root);
+  }
+}

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcConnection.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcConnection.java
@@ -69,6 +69,17 @@ public class JdbcConnection implements AdbcConnection {
   }
 
   @Override
+  public AdbcStatement getInfo(int[] infoCodes) throws AdbcException {
+    try {
+      final VectorSchemaRoot root =
+          new InfoMetadataBuilder(allocator, connection, infoCodes).build();
+      return new FixedJdbcStatement(allocator, root);
+    } catch (SQLException e) {
+      throw JdbcDriverUtil.fromSqlException(e);
+    }
+  }
+
+  @Override
   public AdbcStatement getObjects(
       final GetObjectsDepth depth,
       final String catalogPattern,
@@ -80,7 +91,7 @@ public class JdbcConnection implements AdbcConnection {
     // Build up the metadata in-memory and then return a constant reader.
     try {
       final VectorSchemaRoot root =
-          new JdbcMetadataBuilder(
+          new ObjectMetadataBuilder(
                   allocator,
                   connection,
                   depth,

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/ObjectMetadataBuilder.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/ObjectMetadataBuilder.java
@@ -35,8 +35,8 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
 
-/** Helper class to track state needed to build up the metadata structure. */
-final class JdbcMetadataBuilder implements AutoCloseable {
+/** Helper class to track state needed to build up the object metadata structure. */
+final class ObjectMetadataBuilder implements AutoCloseable {
   private final AdbcConnection.GetObjectsDepth depth;
   private final String catalogPattern;
   private final String dbSchemaPattern;
@@ -73,7 +73,7 @@ final class JdbcMetadataBuilder implements AutoCloseable {
   final VarCharVector columnUsageFkTables;
   final VarCharVector columnUsageFkColumns;
 
-  JdbcMetadataBuilder(
+  ObjectMetadataBuilder(
       BufferAllocator allocator,
       Connection connection,
       final AdbcConnection.GetObjectsDepth depth,

--- a/python/adbc_driver_manager/.gitignore
+++ b/python/adbc_driver_manager/.gitignore
@@ -16,4 +16,5 @@
 # under the License.
 
 adbc_driver_manager/*.c
+adbc_driver_manager/*.cpp
 build/

--- a/python/adbc_driver_manager/adbc_driver_manager/__init__.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/__init__.py
@@ -19,6 +19,7 @@ from ._lib import (  # noqa: F401
     INGEST_OPTION_TARGET_TABLE,
     AdbcConnection,
     AdbcDatabase,
+    AdbcInfoCode,
     AdbcStatement,
     AdbcStatusCode,
     ArrowArrayHandle,

--- a/python/adbc_driver_manager/adbc_driver_manager/tests/test_lowlevel.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/tests/test_lowlevel.py
@@ -56,6 +56,28 @@ def test_database_init():
             pass
 
 
+def test_connection_get_info(sqlite):
+    _, conn = sqlite
+    codes = [
+        adbc_driver_manager.AdbcInfoCode.VENDOR_NAME,
+        adbc_driver_manager.AdbcInfoCode.VENDOR_VERSION.value,
+        adbc_driver_manager.AdbcInfoCode.DRIVER_NAME,
+        adbc_driver_manager.AdbcInfoCode.DRIVER_VERSION.value,
+    ]
+    with conn.get_info() as stmt:
+        table = _import(stmt.get_stream()).read_all()
+        assert table.num_rows > 0
+        data = dict(zip(table[0].to_pylist(), table[1].to_pylist()))
+        for code in codes:
+            assert code in data
+            assert data[code]
+
+    with conn.get_info(codes) as stmt:
+        table = _import(stmt.get_stream()).read_all()
+        assert table.num_rows > 0
+        assert set(codes) == set(table[0].to_pylist())
+
+
 def test_connection_get_objects(sqlite):
     _, conn = sqlite
     data = pyarrow.record_batch(

--- a/python/adbc_driver_manager/setup.py
+++ b/python/adbc_driver_manager/setup.py
@@ -25,12 +25,13 @@ setup(
     ext_modules=cythonize(
         Extension(
             name="adbc_driver_manager._lib",
+            extra_compile_args=["-ggdb", "-Og"],
+            include_dirs=["../../", "../../c/driver_manager"],
+            language="c++",
             sources=[
                 "adbc_driver_manager/_lib.pyx",
                 "../../c/driver_manager/adbc_driver_manager.cc",
             ],
-            include_dirs=["../../", "../../c/driver_manager"],
-            extra_compile_args=["-ggdb", "-Og"],
         ),
     ),
     packages=["adbc_driver_manager"],


### PR DESCRIPTION
Add a ConnectionGetInfo function to query basic metadata, like the driver/database name and version. This doesn't yet expose all the of the metadata that Flight SQL exposes, but otherwise follows a very similar design (including the use of integer metadatum IDs and a union of possible result types).