### PR TITLE
Updated relative path for parent pom

### DIFF
--- a/java/driver/validation/pom.xml
+++ b/java/driver/validation/pom.xml
@@ -15,6 +15,7 @@
     <artifactId>arrow-adbc-java-root</artifactId>
     <groupId>org.apache.arrow.adbc</groupId>
     <version>9.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>adbc-driver-validation</artifactId>


### PR DESCRIPTION
Updated relative path for parent pom in validation module. This fixes the following build error

[ERROR]     Non-resolvable parent POM for org.apache.arrow.adbc:adbc-driver-validation:9.0.0-SNAPSHOT: Could not find artifact org.apache.arrow.adbc:arrow-adbc-java-root:pom:9.0.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 14, column 11 -> [Help 2]
