### PR TITLE
[Format][C][Java] Consolidate ExecuteQuery/ExecuteUpdate

### DIFF
--- a/adbc.h
+++ b/adbc.h
@@ -734,7 +734,8 @@ AdbcStatusCode AdbcStatementRelease(struct AdbcStatement* statement,
 /// This invalidates any prior result sets.
 ///
 /// \param[in] statement The statement to execute.
-/// \param[out] out The results.
+/// \param[out] out The results. Pass NULL if the client does not
+///   expect a result set.
 /// \param[out] rows_affected The number of rows affected if known,
 ///   else -1. Pass NULL if the client does not want this information.
 /// \param[out] error An optional location to return an error
@@ -743,18 +744,6 @@ ADBC_EXPORT
 AdbcStatusCode AdbcStatementExecuteQuery(struct AdbcStatement* statement,
                                          struct ArrowArrayStream* out,
                                          int64_t* rows_affected, struct AdbcError* error);
-
-/// \brief Execute a statement that does not generate a result set.
-///
-/// \param[in] statement The statement to execute.
-/// \param[out] rows_affected The number of rows affected if known,
-///   else -1. Pass NULL if the client does not want this information.
-/// \param[out] error An optional location to return an error
-///   message if necessary.
-ADBC_EXPORT
-AdbcStatusCode AdbcStatementExecuteUpdate(struct AdbcStatement* statement,
-                                          int64_t* rows_affected,
-                                          struct AdbcError* error);
 
 /// \brief Turn this statement into a prepared statement to be
 ///   executed multiple times.
@@ -1020,8 +1009,6 @@ struct ADBC_EXPORT AdbcDriver {
                                         struct AdbcError*);
   AdbcStatusCode (*StatementExecuteQuery)(struct AdbcStatement*, struct ArrowArrayStream*,
                                           int64_t*, struct AdbcError*);
-  AdbcStatusCode (*StatementExecuteUpdate)(struct AdbcStatement*, int64_t*,
-                                           struct AdbcError*);
   AdbcStatusCode (*StatementExecutePartitions)(struct AdbcStatement*, struct ArrowSchema*,
                                                struct AdbcPartitions*, int64_t*,
                                                struct AdbcError*);
@@ -1061,7 +1048,7 @@ typedef AdbcStatusCode (*AdbcDriverInitFunc)(size_t count, struct AdbcDriver* dr
                                              struct AdbcError* error);
 
 // For use with count
-#define ADBC_VERSION_0_0_1 27
+#define ADBC_VERSION_0_0_1 26
 
 /// @}
 

--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -487,16 +487,6 @@ AdbcStatusCode AdbcStatementExecuteQuery(struct AdbcStatement* statement,
                                                           error);
 }
 
-AdbcStatusCode AdbcStatementExecuteUpdate(struct AdbcStatement* statement,
-                                          int64_t* rows_affected,
-                                          struct AdbcError* error) {
-  if (!statement->private_driver) {
-    return ADBC_STATUS_INVALID_STATE;
-  }
-  return statement->private_driver->StatementExecuteUpdate(statement, rows_affected,
-                                                           error);
-}
-
 AdbcStatusCode AdbcStatementGetParameterSchema(struct AdbcStatement* statement,
                                                struct ArrowSchema* schema,
                                                struct AdbcError* error) {
@@ -732,7 +722,6 @@ AdbcStatusCode AdbcLoadDriver(const char* driver_name, const char* entrypoint,
 
   FILL_DEFAULT(driver, StatementExecutePartitions);
   CHECK_REQUIRED(driver, StatementExecuteQuery);
-  CHECK_REQUIRED(driver, StatementExecuteUpdate);
   CHECK_REQUIRED(driver, StatementNew);
   CHECK_REQUIRED(driver, StatementRelease);
   FILL_DEFAULT(driver, StatementBind);

--- a/c/driver_manager/adbc_driver_manager_test.cc
+++ b/c/driver_manager/adbc_driver_manager_test.cc
@@ -42,6 +42,9 @@ class DriverManager : public ::testing::Test {
  public:
   void SetUp() override {
     std::memset(&driver, 0, sizeof(driver));
+    std::memset(&database, 0, sizeof(database));
+    std::memset(&connection, 0, sizeof(connection));
+    std::memset(&error, 0, sizeof(error));
 
     size_t initialized = 0;
     ADBC_ASSERT_OK_WITH_ERROR(
@@ -274,8 +277,8 @@ TEST_F(DriverManager, BulkIngestStream) {
                                       "bulk_insert", &error));
     ADBC_ASSERT_OK_WITH_ERROR(
         error, AdbcStatementBindStream(&statement, &export_stream, &error));
-    ADBC_ASSERT_OK_WITH_ERROR(error,
-                              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(
+        error, AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementRelease(&statement, &error));
   }
 
@@ -285,8 +288,8 @@ TEST_F(DriverManager, BulkIngestStream) {
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementNew(&connection, &statement, &error));
     ADBC_ASSERT_OK_WITH_ERROR(
         error, AdbcStatementSetSqlQuery(&statement, "SELECT * FROM bulk_insert", &error));
-    ADBC_ASSERT_OK_WITH_ERROR(error,
-                              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(
+        error, AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
 
     std::shared_ptr<arrow::Schema> schema;
     arrow::RecordBatchVector batches;

--- a/c/drivers/flight_sql/flight_sql.cc
+++ b/c/drivers/flight_sql/flight_sql.cc
@@ -417,13 +417,6 @@ class FlightSqlStatementImpl {
     return FlightInfoReader::Export(connection_->client(), std::move(info), out, error);
   }
 
-  AdbcStatusCode ExecuteUpdate(const std::shared_ptr<FlightSqlStatementImpl>& self,
-                               int64_t* rows_affected, struct AdbcError* error) {
-    // TODO: update query
-    // TODO: bulk ingest isn't implemented
-    return ADBC_STATUS_NOT_IMPLEMENTED;
-  }
-
   AdbcStatusCode SetSqlQuery(const std::shared_ptr<FlightSqlStatementImpl>&,
                              const char* query, struct AdbcError* error) {
     query_ = query;
@@ -543,15 +536,6 @@ AdbcStatusCode FlightSqlStatementExecuteQuery(struct AdbcStatement* statement,
   return (*ptr)->ExecuteQuery(*ptr, out, rows_affected, error);
 }
 
-AdbcStatusCode FlightSqlStatementExecuteUpdate(struct AdbcStatement* statement,
-                                               int64_t* rows_affected,
-                                               struct AdbcError* error) {
-  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
-  auto* ptr =
-      reinterpret_cast<std::shared_ptr<FlightSqlStatementImpl>*>(statement->private_data);
-  return (*ptr)->ExecuteUpdate(*ptr, rows_affected, error);
-}
-
 AdbcStatusCode FlightSqlStatementNew(struct AdbcConnection* connection,
                                      struct AdbcStatement* statement,
                                      struct AdbcError* error) {
@@ -653,12 +637,6 @@ AdbcStatusCode AdbcStatementExecuteQuery(struct AdbcStatement* statement,
   return FlightSqlStatementExecuteQuery(statement, out, rows_affected, error);
 }
 
-AdbcStatusCode AdbcStatementExecuteUpdate(struct AdbcStatement* statement,
-                                          int64_t* rows_affected,
-                                          struct AdbcError* error) {
-  return FlightSqlStatementExecuteUpdate(statement, rows_affected, error);
-}
-
 AdbcStatusCode AdbcStatementNew(struct AdbcConnection* connection,
                                 struct AdbcStatement* statement,
                                 struct AdbcError* error) {
@@ -696,7 +674,6 @@ AdbcStatusCode AdbcDriverInit(size_t count, struct AdbcDriver* driver,
 
   driver->StatementExecutePartitions = FlightSqlStatementExecutePartitions;
   driver->StatementExecuteQuery = FlightSqlStatementExecuteQuery;
-  driver->StatementExecuteUpdate = FlightSqlStatementExecuteUpdate;
   driver->StatementNew = FlightSqlStatementNew;
   driver->StatementRelease = FlightSqlStatementRelease;
   driver->StatementSetSqlQuery = FlightSqlStatementSetSqlQuery;

--- a/c/drivers/postgres/postgres.cc
+++ b/c/drivers/postgres/postgres.cc
@@ -296,15 +296,6 @@ AdbcStatusCode PostgresStatementExecuteQuery(struct AdbcStatement* statement,
   return (*ptr)->ExecuteQuery(output, rows_affected, error);
 }
 
-AdbcStatusCode PostgresStatementExecuteUpdate(struct AdbcStatement* statement,
-                                              int64_t* rows_affected,
-                                              struct AdbcError* error) {
-  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
-  auto* ptr =
-      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
-  return (*ptr)->ExecuteUpdate(rows_affected, error);
-}
-
 AdbcStatusCode PostgresStatementGetPartitionDesc(struct AdbcStatement* statement,
                                                  uint8_t* partition_desc,
                                                  struct AdbcError* error) {
@@ -390,12 +381,6 @@ AdbcStatusCode AdbcStatementExecuteQuery(struct AdbcStatement* statement,
   return PostgresStatementExecuteQuery(statement, output, rows_affected, error);
 }
 
-AdbcStatusCode AdbcStatementExecuteUpdate(struct AdbcStatement* statement,
-                                          int64_t* rows_affected,
-                                          struct AdbcError* error) {
-  return PostgresStatementExecuteUpdate(statement, rows_affected, error);
-}
-
 AdbcStatusCode AdbcStatementGetPartitionDesc(struct AdbcStatement* statement,
                                              uint8_t* partition_desc,
                                              struct AdbcError* error) {
@@ -466,7 +451,6 @@ AdbcStatusCode AdbcDriverInit(size_t count, struct AdbcDriver* driver,
   driver->StatementBind = PostgresStatementBind;
   driver->StatementBindStream = PostgresStatementBindStream;
   driver->StatementExecuteQuery = PostgresStatementExecuteQuery;
-  driver->StatementExecuteUpdate = PostgresStatementExecuteUpdate;
   driver->StatementGetParameterSchema = PostgresStatementGetParameterSchema;
   driver->StatementNew = PostgresStatementNew;
   driver->StatementPrepare = PostgresStatementPrepare;

--- a/c/drivers/postgres/statement.h
+++ b/c/drivers/postgres/statement.h
@@ -75,7 +75,6 @@ class PostgresStatement {
   AdbcStatusCode Bind(struct ArrowArrayStream* stream, struct AdbcError* error);
   AdbcStatusCode ExecuteQuery(struct ArrowArrayStream* stream, int64_t* rows_affected,
                               struct AdbcError* error);
-  AdbcStatusCode ExecuteUpdate(int64_t* rows_affected, struct AdbcError* error);
   AdbcStatusCode GetParameterSchema(struct ArrowSchema* schema, struct AdbcError* error);
   AdbcStatusCode New(struct AdbcConnection* connection, struct AdbcError* error);
   AdbcStatusCode Prepare(struct AdbcError* error);

--- a/c/drivers/sqlite/sqlite_test.cc
+++ b/c/drivers/sqlite/sqlite_test.cc
@@ -93,7 +93,7 @@ class Sqlite : public ::testing::Test {
         error, AdbcStatementBind(&statement, &export_table, &export_schema, &error));
     int64_t rows_affected = 0;
     ADBC_ASSERT_OK_WITH_ERROR(
-        error, AdbcStatementExecuteUpdate(&statement, &rows_affected, &error));
+        error, AdbcStatementExecuteQuery(&statement, nullptr, &rows_affected, &error));
     ASSERT_EQ(bulk_table->num_rows(), rows_affected);
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementRelease(&statement, &error));
   }
@@ -258,8 +258,8 @@ TEST_F(Sqlite, BulkIngestTable) {
                                       "bulk_insert", &error));
     ADBC_ASSERT_OK_WITH_ERROR(
         error, AdbcStatementBind(&statement, &export_table, &export_schema, &error));
-    ADBC_ASSERT_OK_WITH_ERROR(error,
-                              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(
+        error, AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementRelease(&statement, &error));
   }
 
@@ -291,7 +291,7 @@ TEST_F(Sqlite, BulkIngestTable) {
     ADBC_ASSERT_OK_WITH_ERROR(
         error, AdbcStatementBind(&statement, &export_table, &export_schema, &error));
     ASSERT_EQ(ADBC_STATUS_ALREADY_EXISTS,
-              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+              AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementRelease(&statement, &error));
   }
 
@@ -311,8 +311,8 @@ TEST_F(Sqlite, BulkIngestTable) {
                                       ADBC_INGEST_OPTION_MODE_APPEND, &error));
     ADBC_ASSERT_OK_WITH_ERROR(
         error, AdbcStatementBind(&statement, &export_table, &export_schema, &error));
-    ADBC_ASSERT_OK_WITH_ERROR(error,
-                              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(
+        error, AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementRelease(&statement, &error));
 
     std::memset(&statement, 0, sizeof(statement));
@@ -348,7 +348,7 @@ TEST_F(Sqlite, BulkIngestTable) {
     ADBC_ASSERT_OK_WITH_ERROR(
         error, AdbcStatementBind(&statement, &export_table, &export_schema, &error));
     ASSERT_EQ(ADBC_STATUS_ALREADY_EXISTS,
-              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+              AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementRelease(&statement, &error));
   }
 
@@ -369,7 +369,7 @@ TEST_F(Sqlite, BulkIngestTable) {
     ADBC_ASSERT_OK_WITH_ERROR(
         error, AdbcStatementBind(&statement, &export_table, &export_schema, &error));
     ASSERT_EQ(ADBC_STATUS_NOT_FOUND,
-              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+              AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementRelease(&statement, &error));
   }
 
@@ -392,7 +392,7 @@ TEST_F(Sqlite, BulkIngestTable) {
     ADBC_ASSERT_OK_WITH_ERROR(
         error, AdbcStatementBind(&statement, &export_table, &export_schema, &error));
     ASSERT_EQ(ADBC_STATUS_ALREADY_EXISTS,
-              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+              AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementRelease(&statement, &error));
   }
 }
@@ -418,8 +418,8 @@ TEST_F(Sqlite, BulkIngestStream) {
                                       "bulk_insert", &error));
     ADBC_ASSERT_OK_WITH_ERROR(
         error, AdbcStatementBindStream(&statement, &export_stream, &error));
-    ADBC_ASSERT_OK_WITH_ERROR(error,
-                              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(
+        error, AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementRelease(&statement, &error));
   }
 
@@ -714,13 +714,13 @@ TEST_F(Sqlite, MetadataGetObjectsColumns) {
         error,
         AdbcStatementSetSqlQuery(
             &statement, "CREATE TABLE parent (a, b, c, PRIMARY KEY(c, b))", &error));
-    ADBC_ASSERT_OK_WITH_ERROR(error,
-                              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(
+        error, AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
 
     ADBC_ASSERT_OK_WITH_ERROR(
         error, AdbcStatementSetSqlQuery(&statement, "CREATE TABLE other (a)", &error));
-    ADBC_ASSERT_OK_WITH_ERROR(error,
-                              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(
+        error, AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
 
     ADBC_ASSERT_OK_WITH_ERROR(
         error, AdbcStatementSetSqlQuery(
@@ -728,8 +728,8 @@ TEST_F(Sqlite, MetadataGetObjectsColumns) {
                    "CREATE TABLE child (a, b, c, PRIMARY KEY(a), FOREIGN KEY (c, b) "
                    "REFERENCES parent (c, b), FOREIGN KEY (a) REFERENCES other(a))",
                    &error));
-    ADBC_ASSERT_OK_WITH_ERROR(error,
-                              AdbcStatementExecuteUpdate(&statement, nullptr, &error));
+    ADBC_ASSERT_OK_WITH_ERROR(
+        error, AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error));
 
     ADBC_ASSERT_OK_WITH_ERROR(error, AdbcStatementRelease(&statement, &error));
   }

--- a/c/validation/adbc_validation.c
+++ b/c/validation/adbc_validation.c
@@ -463,7 +463,7 @@ void AdbcValidateStatementSqlIngest(struct AdbcValidateTestContext* adbc_context
                                          "bulk_insert", &error));
   ADBCV_ASSERT_OK(&error,
                   AdbcStatementBind(&statement, &export_array, &export_schema, &error));
-  ADBCV_ASSERT_OK(&error, AdbcStatementExecuteUpdate(&statement, NULL, &error));
+  ADBCV_ASSERT_OK(&error, AdbcStatementExecuteQuery(&statement, NULL, NULL, &error));
   ADBCV_ASSERT_OK(&error, AdbcStatementRelease(&statement, &error));
 
   AdbcValidateBeginCase(adbc_context, "StatementSqlIngest", "read back data");

--- a/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcConnection.java
+++ b/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcConnection.java
@@ -49,14 +49,13 @@ public interface AdbcConnection extends AutoCloseable {
   }
 
   /**
-   * Create a statement from a serialized PartitionDescriptor.
+   * Create a result set from a serialized PartitionDescriptor.
    *
    * @param descriptor The descriptor to load ({@link PartitionDescriptor#getDescriptor()}.
    * @return A statement that can be immediately executed.
    * @see AdbcStatement.PartitionResult
    */
-  default AdbcStatement.QueryResult deserializePartitionDescriptor(ByteBuffer descriptor)
-      throws AdbcException {
+  default ArrowReader readPartition(ByteBuffer descriptor) throws AdbcException {
     throw AdbcException.notImplemented(
         "Connection does not support deserializePartitionDescriptor(ByteBuffer)");
   }

--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
@@ -76,8 +76,7 @@ public class FlightSqlConnection implements AdbcConnection {
   }
 
   @Override
-  public AdbcStatement.QueryResult deserializePartitionDescriptor(ByteBuffer descriptor)
-      throws AdbcException {
+  public ArrowReader readPartition(ByteBuffer descriptor) throws AdbcException {
     final FlightEndpoint endpoint;
     try {
       final Flight.FlightEndpoint protoEndpoint = Flight.FlightEndpoint.parseFrom(descriptor);
@@ -96,9 +95,8 @@ public class FlightSqlConnection implements AdbcConnection {
               "[Flight SQL] Partition descriptor is invalid: " + e.getMessage())
           .withCause(e);
     }
-    return new AdbcStatement.QueryResult(
-        /*affectedRows*/ -1,
-        new FlightInfoReader(allocator, client, clientCache, Collections.singletonList(endpoint)));
+    return new FlightInfoReader(
+        allocator, client, clientCache, Collections.singletonList(endpoint));
   }
 
   @Override

--- a/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/AbstractPartitionDescriptorTest.java
+++ b/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/AbstractPartitionDescriptorTest.java
@@ -33,6 +33,7 @@ import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -106,13 +107,12 @@ public abstract class AbstractPartitionDescriptorTest {
 
       // The serialized partition descriptor should be executable on a separate connection
       try (final AdbcConnection connection2 = database.connect();
-          final AdbcStatement.QueryResult queryResult =
-              connection2.deserializePartitionDescriptor(
+          final ArrowReader reader =
+              connection2.readPartition(
                   partitionResult.getPartitionDescriptors().get(0).getDescriptor())) {
-        assertThat(queryResult.getReader().loadNextBatch()).isTrue();
-        assertThat(queryResult.getReader().getVectorSchemaRoot().getSchema())
-            .isEqualTo(root.getSchema());
-        assertRoot(queryResult.getReader().getVectorSchemaRoot()).isEqualTo(root);
+        assertThat(reader.loadNextBatch()).isTrue();
+        assertThat(reader.getVectorSchemaRoot().getSchema()).isEqualTo(root.getSchema());
+        assertRoot(reader.getVectorSchemaRoot()).isEqualTo(root);
       }
     }
   }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -184,11 +184,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <executions>
@@ -211,4 +206,41 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>jdk9+</id>
+      <activation>
+        <jdk>[9,]</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>
+                --add-opens=java.base/java.nio=ALL-UNNAMED
+              </argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -189,10 +189,6 @@ cdef extern from "adbc.h" nogil:
         CAdbcStatement* statement,
         CArrowArrayStream* out, int64_t* rows_affected,
         CAdbcError* error)
-    CAdbcStatusCode AdbcStatementExecuteUpdate(
-        CAdbcStatement* statement,
-        int64_t* rows_affected,
-        CAdbcError* error)
     CAdbcStatusCode AdbcStatementNew(
         CAdbcConnection* connection,
         CAdbcStatement* statement,
@@ -886,8 +882,9 @@ cdef class AdbcStatement(_AdbcHandle):
         cdef CAdbcError c_error = empty_error()
         cdef int64_t rows_affected = 0
         with nogil:
-            status = AdbcStatementExecuteUpdate(
+            status = AdbcStatementExecuteQuery(
                 &self.statement,
+                NULL,
                 &rows_affected,
                 &c_error)
         check_error(status, &c_error)


### PR DESCRIPTION
In C: combine ExecuteQuery/ExecuteUpdate since they're redundant

In Java: rename some things to be consistent with C. However, do not consolidate ExecuteQuery/ExecuteUpdate since the lack of out parameters means we don't have a way to differentiate the cases.