### PR TITLE
[C] Fix MacOS CI

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -94,10 +94,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=$HOME/local \
             -DCMAKE_PREFIX_PATH=$CONDA_PREFIX
           cmake --build . --target install
-          export DYLD_LIBRARY_PATH=$HOME/local/lib
-          # MacOS doesn't allow DYLD_LIBRARY_PATH to propagate through
-          # CTest, so call the test directly
-          ./adbc-driver-sqlite-test
+          ctest --output-on-failure --no-tests=error
           popd
       - name: Build/Test Driver Manager
         shell: bash -l {0}


### PR DESCRIPTION
Turns out we suddenly don't need the DYLD_LIBRARY_PATH workaround anymore and it in fact is harmful instead