### PR TITLE
[C] Make it easier to build the SQLite driver out of the box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ docker_cache
 *.orig
 .*.swp
 .*.swo
+CMakeUserPresets.json
+build/
 
 site/
 

--- a/c/drivers/sqlite/CMakeLists.txt
+++ b/c/drivers/sqlite/CMakeLists.txt
@@ -21,6 +21,9 @@ list(APPEND CMAKE_MODULE_PATH "${REPOSITORY_ROOT}/c/cmake_modules/")
 include(AdbcDefines)
 include(BuildUtils)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 project(adbc_driver_sqlite
         VERSION "${ADBC_BASE_VERSION}"
         LANGUAGES CXX)


### PR DESCRIPTION
I was curious about the SQLite driver, so I did a quick clone and ran VSCode's default CMake: Configure, CMake: Build, and CMake: Run Tests. It almost worked out of the box, but I got some build errors, I needed a build preset to specify where Arrow was, and I ended up with a lot of untracked build files. This is my take on how to make that a smooth process for a new contributor...feel free to suggest something else!