### PR TITLE
ci(java): skip RAT check on JAR upload

### DIFF
--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -50,6 +50,14 @@ jobs:
         run: |
           docker-compose run java-jars
 
+      - name: Archive JARs
+        uses: actions/upload-artifact@v3
+        with:
+          name: java
+          retention-days: 7
+          path: |
+            java/**/target/*.jar
+
       - name: Upload JARs to Gemfury
         shell: bash
         if: github.ref == 'refs/heads/main' && (github.event.schedule || github.event.inputs.upload_artifacts == true)

--- a/ci/scripts/java_jar_upload.sh
+++ b/ci/scripts/java_jar_upload.sh
@@ -48,6 +48,7 @@ SETTINGS
 
     mvn \
         -Dmaven.install.skip=true \
+        -Drat.skip=true \
         --settings "${settings_file}" \
         deploy
 


### PR DESCRIPTION
Because the first stage is run in Docker, it creates files we can read but not overwrite.