### PR TITLE
refactor(c/driver_manager): remove unnecessary libarrow dependency

### DIFF
--- a/c/driver_manager/CMakeLists.txt
+++ b/c/driver_manager/CMakeLists.txt
@@ -47,11 +47,10 @@ endforeach()
 install(FILES "${REPOSITORY_ROOT}/adbc.h" adbc_driver_manager.h DESTINATION include)
 
 if(ADBC_BUILD_TESTS)
-  find_package(Arrow REQUIRED)
   if(ADBC_TEST_LINKAGE STREQUAL "shared")
-    set(TEST_LINK_LIBS adbc_driver_manager_shared arrow_shared)
+    set(TEST_LINK_LIBS adbc_driver_manager_shared)
   else()
-    set(TEST_LINK_LIBS adbc_driver_manager_static arrow_static)
+    set(TEST_LINK_LIBS adbc_driver_manager_static)
   endif()
 
   add_test_case(driver_manager_test

--- a/c/driver_manager/adbc_driver_manager_test.cc
+++ b/c/driver_manager/adbc_driver_manager_test.cc
@@ -18,11 +18,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <arrow/c/bridge.h>
-#include <arrow/record_batch.h>
-#include <arrow/table.h>
-#include <arrow/testing/matchers.h>
-
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
After this, we just need to port the SQLite driver.