### PR TITLE
ci(docs): add automatic site rebuild

### DIFF
--- a/.github/workflows/nightly-website.yml
+++ b/.github/workflows/nightly-website.yml
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Automated - Website
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    name: "Build Website"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Build
+        shell: bash
+        run: |
+          docker-compose run docs
+      - name: Archive docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          retention-days: 2
+          path: |
+            docs/build/html
+
+  publish:
+    name: "Publish Website"
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          # NOTE: needed to push at the end
+          persist-credentials: true
+          ref: asf-site
+      - name: Add dev docs
+        uses: actions/download-artifact@v3
+        with:
+          name: docs
+          path: dev
+      - name: Build
+        shell: bash
+        run: |
+          ls -laR
+      - name: Push changes to asf-site branch
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add --all
+          git commit -m "publish documentation"
+          git push origin asf-site:asf-site


### PR DESCRIPTION
This adds the action, but does not actually add the .asf.yaml setup (I'll follow up with that separately).

The idea is to target `arrow.apache.org/adbc/docs` here. Then `dev/` will be a subtree, as demoed here: https://github.com/lidavidm/arrow-adbc/tree/asf-site

We can't use `docs/adbc/` and `docs/dev/adbc/` because we can only target a single directory at a time.

Also,  I'd like to add an `arrow.apache.org/adbc/index.html` at some point to the main arrow-site repo. That can serve as a brief project introduction that links to the various documentation subtrees.