### PR TITLE
ci: fix versioning of wheels in CI

### DIFF
--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -34,6 +34,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     name: "Documentation"
@@ -42,7 +46,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
+
+      - name: Update tags
+        shell: bash
+        run: |
+          git fetch --tags --force origin
 
       - name: Show inputs
         shell: bash
@@ -76,7 +85,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
+
+      - name: Update tags
+        shell: bash
+        run: |
+          git fetch --tags --force origin
 
       - name: Show inputs
         shell: bash
@@ -121,7 +135,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
+
+      - name: Update tags
+        shell: bash
+        run: |
+          git fetch --tags --force origin
 
       - name: Show inputs
         shell: bash
@@ -182,7 +201,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
+
+      - name: Update tags
+        shell: bash
+        run: |
+          git fetch --tags --force origin
 
       - name: Show inputs
         shell: bash
@@ -263,7 +287,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
+
+      - name: Update tags
+        shell: bash
+        run: |
+          git fetch --tags --force origin
 
       - name: Show inputs
         shell: pwsh
@@ -340,7 +369,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
+
+      - name: Update tags
+        shell: bash
+        run: |
+          git fetch --tags --force origin
 
       - name: Show inputs
         shell: bash

--- a/ci/scripts/python_wheel_unix_build.sh
+++ b/ci/scripts/python_wheel_unix_build.sh
@@ -76,8 +76,13 @@ PLAT_NAME=$(python -c "import sysconfig; print(sysconfig.get_platform())")
 for component in $COMPONENTS; do
     pushd ${source_dir}/python/$component
 
-    echo "=== (${PYTHON_VERSION}) Clean build artifacts==="
+    echo "=== (${PYTHON_VERSION}) Clean build artifacts ==="
     rm -rf ./build ./dist ./repaired_wheels ./$component/*.so ./$component/*.so.*
+
+    echo "=== (${PYTHON_VERSION}) Check $component version ==="
+    python $component/_version.py
+    git describe --long --always --first-parent
+    git describe --long --always
 
     echo "=== (${PYTHON_VERSION}) Building $component wheel ==="
     # python -m build copies to a tempdir, so we can't reference other files in the repo

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -79,6 +79,9 @@ FOR /F %%i IN ('python -c "import sysconfig; print(sysconfig.get_platform())"') 
 FOR %%c IN (adbc_driver_manager adbc_driver_postgres adbc_driver_sqlite) DO (
     pushd %source_dir%\python\%%c
 
+    echo "=== (%PYTHON_VERSION%) Checking %%c version ==="
+    python %%c\_version.py
+
     echo "=== (%PYTHON_VERSION%) Building %%c wheel ==="
     python -m pip wheel -w dist -vvv . || exit /B 1
 


### PR DESCRIPTION
It turns out even with `fetch-depth: 0`, the checkout action doesn't seem to properly fetch tags.