### PR TITLE
chore: add issues notification of issues opened and closed to issues mailing list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,6 +25,7 @@ github:
 
 notifications:
   commits:      commits@arrow.apache.org
+  issues_status: issues@arrow.apache.org
   issues:       github@arrow.apache.org
   pullrequests: github@arrow.apache.org
   jira_options: link label worklog


### PR DESCRIPTION
As discussed on https://github.com/apache/arrow/pull/14811#issuecomment-1336109840 this will add the opened and closed issues notification emails to issues@apache.org