### PR TITLE
ci: add AArch64 wheels via cross-compilation

### DIFF
--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -260,20 +260,24 @@ jobs:
             python/adbc_driver_sqlite/repaired_wheels/*.whl
 
       - name: Test wheel
+        if: matrix.arch == 'amd64'
         shell: bash
         run: |
-          /Library/Frameworks/Python.framework/Versions/3.9/bin/python3.9 -m venv test-env
-          source test-env/bin/activate
+          /Library/Frameworks/Python.framework/Versions/3.9/bin/python3.9 -m venv test-env-39
+          source test-env-39/bin/activate
+          export PYTHON_VERSION=3.9
           ./ci/scripts/python_wheel_unix_test.sh $(pwd)
           deactivate
 
-          /Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10 -m venv test-env
-          source test-env/bin/activate
+          /Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10 -m venv test-env-310
+          source test-env-310/bin/activate
+          export PYTHON_VERSION=3.10
           ./ci/scripts/python_wheel_unix_test.sh $(pwd)
           deactivate
 
-          /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11 -m venv test-env
-          source test-env/bin/activate
+          /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11 -m venv test-env-311
+          source test-env-311/bin/activate
+          export PYTHON_VERSION=3.11
           ./ci/scripts/python_wheel_unix_test.sh $(pwd)
           deactivate
 

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -129,8 +129,7 @@ jobs:
       matrix:
         arch: ["amd64", "arm64v8"]
         manylinux_version: ["2014"]
-      # Limit parallelism; gemfury appears to return 409 CONFLICT on concurrent uploads
-      max-parallel: 1
+      # Let this one run in parallel because the arm64 build is so much slower
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -176,7 +176,9 @@ jobs:
           ARCH: ${{ matrix.arch }}
           MANYLINUX: ${{ matrix.manylinux_version }}
         run: |
-          docker-compose run python-wheel-manylinux-test
+          env PYTHON=3.9 docker-compose run python-wheel-manylinux-test
+          env PYTHON=3.10 docker-compose run python-wheel-manylinux-test
+          env PYTHON=3.11 docker-compose run python-wheel-manylinux-test
 
       - name: Upload wheels to Gemfury
         shell: bash
@@ -197,7 +199,6 @@ jobs:
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.15"
       PYTHON: "/Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10"
-      PYTHON_VERSION: "3.10"
       # Where to install vcpkg
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
     steps:
@@ -232,9 +233,12 @@ jobs:
         shell: bash
         run: ci/scripts/install_vcpkg.sh $VCPKG_ROOT $VCPKG_VERSION
 
-      - name: Install Python ${{ matrix.python_version }}
+      - name: Install Python
         shell: bash
-        run: sudo ci/scripts/install_python.sh macos ${{ matrix.python_version }}
+        run: |
+          sudo ci/scripts/install_python.sh macos 3.9
+          sudo ci/scripts/install_python.sh macos 3.10
+          sudo ci/scripts/install_python.sh macos 3.11
 
       - name: Build wheel
         shell: bash
@@ -258,9 +262,20 @@ jobs:
       - name: Test wheel
         shell: bash
         run: |
-          $PYTHON -m venv test-env
+          /Library/Frameworks/Python.framework/Versions/3.9/bin/python3.9 -m venv test-env
           source test-env/bin/activate
           ./ci/scripts/python_wheel_unix_test.sh $(pwd)
+          deactivate
+
+          /Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10 -m venv test-env
+          source test-env/bin/activate
+          ./ci/scripts/python_wheel_unix_test.sh $(pwd)
+          deactivate
+
+          /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11 -m venv test-env
+          source test-env/bin/activate
+          ./ci/scripts/python_wheel_unix_test.sh $(pwd)
+          deactivate
 
       - name: Upload wheels to Gemfury
         shell: bash

--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -123,12 +123,12 @@ jobs:
           GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
 
   python-manylinux:
-    name: "Python ${{ matrix.python_version }} manylinux${{ matrix.manylinux_version }}"
+    name: "Python ${{ matrix.arch }} manylinux${{ matrix.manylinux_version }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        arch: ["amd64", "arm64v8"]
         manylinux_version: ["2014"]
-        python_version: ["3.9", "3.10", "3.11"]
       # Limit parallelism; gemfury appears to return 409 CONFLICT on concurrent uploads
       max-parallel: 1
     steps:
@@ -149,17 +149,21 @@ jobs:
           echo "schedule: ${{ github.event.schedule }}"
           echo "ref: ${{ github.ref }}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Build wheel
         shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
+          MANYLINUX: ${{ matrix.manylinux_version }}
         run: |
-          export MANYLINUX=${{ matrix.manylinux_version }}
-          export PYTHON=${{ matrix.python_version }}
           docker-compose run python-wheel-manylinux
 
       - name: Archive wheels
         uses: actions/upload-artifact@v3
         with:
-          name: python${{ matrix.python_version }}-manylinux${{ matrix.manylinux_version }}
+          name: python-${{ matrix.arch }}-manylinux${{ matrix.manylinux_version }}
           retention-days: 7
           path: |
             python/adbc_driver_manager/repaired_wheels/*.whl
@@ -168,9 +172,10 @@ jobs:
 
       - name: Test wheel
         shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
+          MANYLINUX: ${{ matrix.manylinux_version }}
         run: |
-          export MANYLINUX=${{ matrix.manylinux_version }}
-          export PYTHON=${{ matrix.python_version }}
           docker-compose run python-wheel-manylinux-test
 
       - name: Upload wheels to Gemfury
@@ -182,19 +187,17 @@ jobs:
           GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
 
   python-macos:
-    name: "Python ${{ matrix.python_version }} macOS"
+    name: "Python ${{ matrix.arch }} macOS"
     runs-on: macos-latest
     strategy:
       matrix:
-        python_version: ["3.9", "3.10", "3.11"]
+        arch: ["amd64", "arm64v8"]
       # Limit parallelism; gemfury appears to return 409 CONFLICT on concurrent uploads
       max-parallel: 1
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.15"
-      PYTHON: "/Library/Frameworks/Python.framework/Versions/${{ matrix.python_version }}/bin/python${{ matrix.python_version }}"
-      PYTHON_VERSION: "${{ matrix.python_version }}"
-      # Use a custom triplet to only build release packages
-      VCPKG_DEFAULT_TRIPLET: "x64-osx-static-release"
+      PYTHON: "/Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10"
+      PYTHON_VERSION: "3.10"
       # Where to install vcpkg
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
     steps:
@@ -235,15 +238,17 @@ jobs:
 
       - name: Build wheel
         shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           $PYTHON -m venv build-env
           source build-env/bin/activate
-          ./ci/scripts/python_wheel_unix_build.sh x86_64 $(pwd) $(pwd)/build
+          ./ci/scripts/python_wheel_unix_build.sh $ARCH $(pwd) $(pwd)/build
 
       - name: Archive wheels
         uses: actions/upload-artifact@v3
         with:
-          name: python${{ matrix.python_version }}-macOS
+          name: python-${{ matrix.arch }}-macos
           retention-days: 7
           path: |
             python/adbc_driver_manager/repaired_wheels/*.whl
@@ -261,7 +266,7 @@ jobs:
         shell: bash
         if: github.ref == 'refs/heads/main' && (github.event.schedule || github.event.inputs.upload_artifacts == true)
         run: |
-          ./ci/scripts/python_wheel_upload.sh python/adbc_driver_{manager,postgres,sqlite}/dist/*.whl
+          ./ci/scripts/python_wheel_upload.sh python/adbc_driver_{manager,postgres,sqlite}/repaired_wheels/*.whl
         env:
           GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -6,3 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This product includes software from the miniver project (CC0).
 https://github.com/jbweston/miniver
+
+This product includes software from the vcpkg project (MIT).
+Copyright (c) Microsoft Corporation

--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG ARCH
+ARG MANYLINUX
+ARG PYTHON
+ARG REPO
+ARG VCPKG
+
+FROM ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-${MANYLINUX}-vcpkg-${VCPKG}
+
+RUN yum install -y docker

--- a/ci/scripts/python_sdist_build.sh
+++ b/ci/scripts/python_sdist_build.sh
@@ -36,7 +36,7 @@ export _ADBC_IS_SDIST=1
 for component in ${COMPONENTS}; do
     pushd ${source_dir}/python/$component
 
-    echo "=== (${PYTHON_VERSION}) Building $component sdist ==="
+    echo "=== Building $component sdist ==="
     # python -m build copies to a tempdir, so we can't reference other files in the repo
     # https://github.com/pypa/pip/issues/5519
     python setup.py sdist

--- a/ci/scripts/python_sdist_test.sh
+++ b/ci/scripts/python_sdist_test.sh
@@ -21,22 +21,25 @@ set -e
 set -x
 set -o pipefail
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <adbc-src-dir>"
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <arch> <adbc-src-dir>"
   exit 1
 fi
 
-source_dir=${1}
+arch=${1}
+source_dir=${2}
 build_dir="${source_dir}/build"
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "${script_dir}/python_util.sh"
 
-echo "=== (${PYTHON_VERSION}) Building ADBC libpq driver ==="
-# Sets ADBC_POSTGRES_LIBRARY
+echo "=== Set up platform variables ==="
+setup_build_vars "${arch}"
+
+echo "=== Building C/C++ driver components ==="
 build_drivers "${source_dir}" "${build_dir}"
 
-echo "=== (${PYTHON_VERSION}) Installing sdists ==="
+echo "=== Installing sdists ==="
 for component in ${COMPONENTS}; do
     pip install --force-reinstall ${source_dir}/python/${component}/dist/*.tar.gz
 done

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -42,6 +42,9 @@ function build_drivers {
         export VCPKG_DEFAULT_TRIPLET="${VCPKG_ARCH}-osx-static-release"
     fi
 
+    # XXX: patch an odd issue where the path of some file is inconsistent between builds
+    patch -N -p1 < "${source_dir}/ci/vcpkg/0001-Work-around-inconsistent-path.patch" || true
+
     "${VCPKG_ROOT}/vcpkg" install libpq sqlite3 \
           --overlay-triplets "${VCPKG_OVERLAY_TRIPLETS}" \
           --triplet "${VCPKG_DEFAULT_TRIPLET}"

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -42,9 +42,12 @@ function build_drivers {
         export VCPKG_DEFAULT_TRIPLET="${VCPKG_ARCH}-osx-static-release"
     fi
 
-    # XXX: patch an odd issue where the path of some file is inconsistent between builds
     pushd "${VCPKG_ROOT}"
+    # XXX: patch an odd issue where the path of some file is inconsistent between builds
     patch -N -p1 < "${source_dir}/ci/vcpkg/0001-Work-around-inconsistent-path.patch" || true
+
+    # XXX: make vcpkg retry downloads https://github.com/microsoft/vcpkg/discussions/20583
+    patch -N -p1 < "${source_dir}/ci/vcpkg/0002-Retry-downloads.patch" || true
     popd
 
     "${VCPKG_ROOT}/vcpkg" install libpq sqlite3 \

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -43,7 +43,9 @@ function build_drivers {
     fi
 
     # XXX: patch an odd issue where the path of some file is inconsistent between builds
+    pushd "${VCPKG_ROOT}"
     patch -N -p1 < "${source_dir}/ci/vcpkg/0001-Work-around-inconsistent-path.patch" || true
+    popd
 
     "${VCPKG_ROOT}/vcpkg" install libpq sqlite3 \
           --overlay-triplets "${VCPKG_OVERLAY_TRIPLETS}" \

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -35,11 +35,11 @@ function build_drivers {
     if [[ $(uname) == "Linux" ]]; then
         export ADBC_POSTGRES_LIBRARY=${build_dir}/lib/libadbc_driver_postgres.so
         export ADBC_SQLITE_LIBRARY=${build_dir}/lib/libadbc_driver_sqlite.so
-        export VCPKG_DEFAULT_TRIPLET="x64-linux-static-release"
+        export VCPKG_DEFAULT_TRIPLET="${VCPKG_ARCH}-linux-static-release"
     else # macOS
         export ADBC_POSTGRES_LIBRARY=${build_dir}/lib/libadbc_driver_postgres.dylib
         export ADBC_SQLITE_LIBRARY=${build_dir}/lib/libadbc_driver_sqlite.dylib
-        export VCPKG_DEFAULT_TRIPLET="x64-osx-static-release"
+        export VCPKG_DEFAULT_TRIPLET="${VCPKG_ARCH}-osx-static-release"
     fi
 
     "${VCPKG_ROOT}/vcpkg" install libpq sqlite3 \

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -81,6 +81,42 @@ function build_drivers {
     popd
 }
 
+function setup_build_vars {
+    local -r arch="${1}"
+    if [[ "$(uname)" = "Darwin" ]]; then
+        if [[ "${arch}" = "amd64" ]]; then
+            export CIBW_ARCHS="x86_64"
+            export PYTHON_ARCH="x86_64"
+            export VCPKG_ARCH="x64"
+        elif [[ "${arch}" = "arm64v8" ]]; then
+            export CIBW_ARCHS="arm64"
+            export PYTHON_ARCH="arm64"
+            export VCPKG_ARCH="arm64"
+        else
+            echo "Unknown architecture: ${arch}"
+            exit 1
+        fi
+        export CIBW_BUILD='*-macosx_*'
+        export CIBW_PLATFORM="macos"
+    else
+        if [[ "${arch}" = "amd64" ]]; then
+            export CIBW_ARCHS="x86_64"
+            export PYTHON_ARCH="x86_64"
+            export VCPKG_ARCH="x64"
+        elif [[ "${arch}" = "arm64v8" ]]; then
+            export CIBW_ARCHS="aarch64"
+            export PYTHON_ARCH="arm64"
+            export VCPKG_ARCH="arm64"
+        else
+            echo "Unknown architecture: ${arch}"
+            exit 1
+        fi
+        export CIBW_BUILD='*-manylinux_*'
+        export CIBW_PLATFORM="linux"
+    fi
+    export CIBW_SKIP="pp* ${CIBW_SKIP}"
+}
+
 function test_packages {
     for component in ${COMPONENTS}; do
         echo "=== Testing $component ==="

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -21,7 +21,7 @@ COMPONENTS="adbc_driver_manager adbc_driver_postgres adbc_driver_sqlite"
 
 function build_drivers {
     local -r source_dir="$1"
-    local -r build_dir="$2"
+    local -r build_dir="$2/${VCPKG_ARCH}"
 
     : ${CMAKE_BUILD_TYPE:=release}
     : ${CMAKE_UNITY_BUILD:=ON}

--- a/ci/scripts/python_wheel_fix_tag.py
+++ b/ci/scripts/python_wheel_fix_tag.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("wheel")
+    parser.add_argument("wheel", nargs="+")
     args = parser.parse_args()
 
     plat_tag = sysconfig.get_platform()
@@ -38,56 +38,57 @@ def main():
     plat_tag = plat_tag.replace(".", "_")
     print("Using platform tag: ", plat_tag)
 
-    with tempfile.TemporaryDirectory() as dest:
-        dest = Path(dest)
-        subprocess.check_call(
-            [
-                sys.executable,
-                "-m",
-                "wheel",
-                "unpack",
-                "--dest",
-                str(dest),
-                args.wheel,
-            ]
-        )
+    for wheel in args.wheel:
+        with tempfile.TemporaryDirectory() as dest:
+            dest = Path(dest)
+            wheel = Path(wheel).resolve()
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "wheel",
+                    "unpack",
+                    "--dest",
+                    str(dest),
+                    str(wheel),
+                ]
+            )
 
-        (root,) = list(dest.glob("*"))
+            (root,) = list(dest.glob("*"))
 
-        metadata_files = list(root.rglob("*.dist-info/WHEEL"))
-        if len(metadata_files) != 1:
-            raise ValueError(f"Expected one WHEEL file, found: {metadata_files}")
+            metadata_files = list(root.rglob("*.dist-info/WHEEL"))
+            if len(metadata_files) != 1:
+                raise ValueError(f"Expected one WHEEL file, found: {metadata_files}")
 
-        with metadata_files[0].open() as source:
-            contents = source.read()
+            with metadata_files[0].open() as source:
+                contents = source.read()
 
-        new_contents = contents.replace(
-            "Root-Is-Purelib: true", "Root-Is-Purelib: false"
-        )
-        new_contents = new_contents.replace(
-            "Tag: py3-none-any", f"Tag: py3-none-{plat_tag}"
-        )
+            new_contents = contents.replace(
+                "Root-Is-Purelib: true", "Root-Is-Purelib: false"
+            )
+            new_contents = new_contents.replace(
+                "Tag: py3-none-any", f"Tag: py3-none-{plat_tag}"
+            )
 
-        if new_contents == contents:
-            print("No changes made (wheel already properly tagged?)")
-            return
+            if new_contents == contents:
+                print("No changes made (wheel already properly tagged?)")
+                continue
 
-        with metadata_files[0].open("w") as sink:
-            sink.write(new_contents)
+            with metadata_files[0].open("w") as sink:
+                sink.write(new_contents)
 
-        wheel = Path(args.wheel).resolve()
-        subprocess.check_call(
-            [
-                sys.executable,
-                "-m",
-                "wheel",
-                "pack",
-                "--dest-dir",
-                str(wheel.parent),
-                str(root),
-            ]
-        )
-        wheel.unlink()
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "wheel",
+                    "pack",
+                    "--dest-dir",
+                    str(wheel.parent),
+                    str(root),
+                ]
+            )
+            wheel.unlink()
 
 
 if __name__ == "__main__":

--- a/ci/scripts/python_wheel_unix_build.sh
+++ b/ci/scripts/python_wheel_unix_build.sh
@@ -87,7 +87,7 @@ else
     export CIBW_BUILD='*-manylinux_*'
     export CIBW_PLATFORM="linux"
 fi
-export CIBW_SKIP='pp*'
+export CIBW_SKIP="pp* ${CIBW_SKIP}"
 
 echo "=== Building C/C++ driver components ==="
 # Sets ADBC_POSTGRES_LIBRARY, ADBC_SQLITE_LIBRARY

--- a/ci/scripts/python_wheel_unix_build.sh
+++ b/ci/scripts/python_wheel_unix_build.sh
@@ -59,39 +59,7 @@ function check_wheels {
 }
 
 echo "=== Set up platform variables ==="
-
-if [[ "$(uname)" = "Darwin" ]]; then
-    if [[ "${arch}" = "amd64" ]]; then
-        export CIBW_ARCHS="x86_64"
-        export PYTHON_ARCH="x86_64"
-        export VCPKG_ARCH="x64"
-    elif [[ "${arch}" = "arm64v8" ]]; then
-        export CIBW_ARCHS="arm64"
-        export PYTHON_ARCH="arm64"
-        export VCPKG_ARCH="arm64"
-    else
-        echo "Unknown architecture: ${arch}"
-        exit 1
-    fi
-    export CIBW_BUILD='*-macosx_*'
-    export CIBW_PLATFORM="macos"
-else
-    if [[ "${arch}" = "amd64" ]]; then
-        export CIBW_ARCHS="x86_64"
-        export PYTHON_ARCH="x86_64"
-        export VCPKG_ARCH="x64"
-    elif [[ "${arch}" = "arm64v8" ]]; then
-        export CIBW_ARCHS="aarch64"
-        export PYTHON_ARCH="arm64"
-        export VCPKG_ARCH="arm64"
-    else
-        echo "Unknown architecture: ${arch}"
-        exit 1
-    fi
-    export CIBW_BUILD='*-manylinux_*'
-    export CIBW_PLATFORM="linux"
-fi
-export CIBW_SKIP="pp* ${CIBW_SKIP}"
+setup_build_vars "${arch}"
 
 echo "=== Building C/C++ driver components ==="
 # Sets ADBC_POSTGRES_LIBRARY, ADBC_SQLITE_LIBRARY

--- a/ci/scripts/python_wheel_unix_test.sh
+++ b/ci/scripts/python_wheel_unix_test.sh
@@ -33,12 +33,18 @@ source "${script_dir}/python_util.sh"
 
 echo "=== (${PYTHON_VERSION}) Installing wheels ==="
 for component in ${COMPONENTS}; do
+    if [[ "${component}" = "adbc_driver_manager" ]]; then
+        PYTHON_TAG=cp$(python -c "import sysconfig; print(sysconfig.get_python_version().replace('.', ''))")
+    else
+        PYTHON_TAG=py3
+    fi
+
     if [[ -d ${source_dir}/python/${component}/repaired_wheels/ ]]; then
         pip install --force-reinstall \
-            ${source_dir}/python/${component}/repaired_wheels/*.whl
+            ${source_dir}/python/${component}/repaired_wheels/*-${PYTHON_TAG}-*.whl
     else
         pip install --force-reinstall \
-            ${source_dir}/python/${component}/dist/*.whl
+            ${source_dir}/python/${component}/dist/*-${PYTHON_TAG}-*.whl
     fi
 done
 pip install pytest pyarrow pandas

--- a/ci/vcpkg/0001-Work-around-inconsistent-path.patch
+++ b/ci/vcpkg/0001-Work-around-inconsistent-path.patch
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+From a018503281e2738261a76175d722142e62778f72 Mon Sep 17 00:00:00 2001
+From: David Li <li.davidm96@gmail.com>
+Date: Mon, 5 Dec 2022 14:00:05 -0500
+Subject: [PATCH] Work around inconsistent path
+
+---
+ ports/libpq/portfile.cmake | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/ports/libpq/portfile.cmake b/ports/libpq/portfile.cmake
+index 378d41109..19ce64dee 100644
+--- a/ports/libpq/portfile.cmake
++++ b/ports/libpq/portfile.cmake
+@@ -343,8 +343,15 @@ else()
+         set(USE_DL ON)
+     endif()
+
+-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/postgresql/server/pg_config.h" "#define CONFIGURE_ARGS" "// #define CONFIGURE_ARGS")
+-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/pg_config.h" "#define CONFIGURE_ARGS" "// #define CONFIGURE_ARGS")
++    if (EXISTS "${CURRENT_PACKAGES_DIR}/include/postgresql/server/pg_config.h")
++      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/postgresql/server/pg_config.h" "#define CONFIGURE_ARGS" "// #define CONFIGURE_ARGS")
++    endif()
++    if (EXISTS "${CURRENT_PACKAGES_DIR}/include/server/pg_config.h")
++      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/postgresql/server/pg_config.h" "#define CONFIGURE_ARGS" "// #define CONFIGURE_ARGS")
++    endif()
++    if (EXISTS "${CURRENT_PACKAGES_DIR}/include/pg_config.h")
++      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/pg_config.h" "#define CONFIGURE_ARGS" "// #define CONFIGURE_ARGS")
++    endif()
+ endif()
+
+ configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" "${CURRENT_PACKAGES_DIR}/share/postgresql/vcpkg-cmake-wrapper.cmake" @ONLY)
+--
+2.17.1

--- a/ci/vcpkg/0001-Work-around-inconsistent-path.patch
+++ b/ci/vcpkg/0001-Work-around-inconsistent-path.patch
@@ -38,7 +38,7 @@ index 378d41109..19ce64dee 100644
 +      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/postgresql/server/pg_config.h" "#define CONFIGURE_ARGS" "// #define CONFIGURE_ARGS")
 +    endif()
 +    if (EXISTS "${CURRENT_PACKAGES_DIR}/include/server/pg_config.h")
-+      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/postgresql/server/pg_config.h" "#define CONFIGURE_ARGS" "// #define CONFIGURE_ARGS")
++      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/server/pg_config.h" "#define CONFIGURE_ARGS" "// #define CONFIGURE_ARGS")
 +    endif()
 +    if (EXISTS "${CURRENT_PACKAGES_DIR}/include/pg_config.h")
 +      vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/pg_config.h" "#define CONFIGURE_ARGS" "// #define CONFIGURE_ARGS")

--- a/ci/vcpkg/0002-Retry-downloads.patch
+++ b/ci/vcpkg/0002-Retry-downloads.patch
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 From 6bac044938a6c9fd4832ec636a98cb684ea6f609 Mon Sep 17 00:00:00 2001
 From: David Li <li.davidm96@gmail.com>
 Date: Mon, 5 Dec 2022 14:26:42 -0500

--- a/ci/vcpkg/0002-Retry-downloads.patch
+++ b/ci/vcpkg/0002-Retry-downloads.patch
@@ -1,0 +1,24 @@
+From 6bac044938a6c9fd4832ec636a98cb684ea6f609 Mon Sep 17 00:00:00 2001
+From: David Li <li.davidm96@gmail.com>
+Date: Mon, 5 Dec 2022 14:26:42 -0500
+Subject: [PATCH] Retry downloads
+
+---
+ scripts/cmake/vcpkg_download_distfile.cmake | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/scripts/cmake/vcpkg_download_distfile.cmake b/scripts/cmake/vcpkg_download_distfile.cmake
+index 08ca55deb..a1ba00347 100644
+--- a/scripts/cmake/vcpkg_download_distfile.cmake
++++ b/scripts/cmake/vcpkg_download_distfile.cmake
+@@ -73,6 +73,8 @@ function(z_vcpkg_download_distfile_via_aria)
+         debug_message("Download Command: ${ARIA2} ${URL} -o temp/${filename} -l download-${filename}-detailed.log ${headers_param}")
+         vcpkg_execute_in_download_mode(
+             COMMAND ${ARIA2} ${URL}
++	    --max-tries=5
++	    --retry-wait=20
+             -o temp/${arg_FILENAME}
+             -l download-${arg_FILENAME}-detailed.log
+             ${headers_param}
+--
+2.17.1

--- a/ci/vcpkg/triplets/arm64-linux-static-release.cmake
+++ b/ci/vcpkg/triplets/arm64-linux-static-release.cmake
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_BUILD_TYPE release)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)

--- a/ci/vcpkg/triplets/arm64-osx-static-release.cmake
+++ b/ci/vcpkg/triplets/arm64-osx-static-release.cmake
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_BUILD_TYPE release)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     command: "'git config --global --add safe.directory /adbc && git config --global --get safe.directory && /adbc/ci/scripts/python_wheel_unix_build.sh ${ARCH} /adbc /adbc/build'"
 
   python-wheel-manylinux-test:
-    image: ${ARCH}/python:${PYTHON}
+    image: ${ARCH}/python:${PYTHON}-slim
     volumes:
       - .:/adbc:delegated
     command: /adbc/ci/scripts/python_wheel_unix_test.sh /adbc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     image: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-${MANYLINUX}-vcpkg-${VCPKG}
     volumes:
       - .:/adbc:delegated
-    command: "'/adbc/ci/scripts/python_sdist_test.sh /adbc'"
+    command: "'/adbc/ci/scripts/python_sdist_test.sh ${ARCH} /adbc'"
 
   ############################ Python wheels ##################################
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,11 +55,23 @@ services:
   ############################ Python wheels ##################################
 
   python-wheel-manylinux:
-    image: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-${MANYLINUX}-vcpkg-${VCPKG}
+    image: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-${MANYLINUX}-vcpkg-${VCPKG}-adbc
+    build:
+      context: .
+      cache_from:
+        - ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-${MANYLINUX}-vcpkg-${VCPKG}-adbc
+      dockerfile: ci/docker/python-wheel-manylinux.dockerfile
+      args:
+        ARCH: ${ARCH}
+        MANYLINUX: ${MANYLINUX}
+        PYTHON: ${PYTHON}
+        REPO: ${REPO}
+        VCPKG: ${VCPKG}
     volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
       - .:/adbc:delegated
     # Must set safe.directory so miniver won't error when calling git
-    command: "'git config --global --add safe.directory /adbc && git config --global --get safe.directory && /adbc/ci/scripts/python_wheel_unix_build.sh x86_64 /adbc /adbc/build'"
+    command: "'git config --global --add safe.directory /adbc && git config --global --get safe.directory && /adbc/ci/scripts/python_wheel_unix_build.sh ${ARCH} /adbc /adbc/build'"
 
   python-wheel-manylinux-test:
     image: ${ARCH}/python:${PYTHON}

--- a/python/adbc_driver_manager/pyproject.toml
+++ b/python/adbc_driver_manager/pyproject.toml
@@ -39,3 +39,7 @@ build-backend = "setuptools.build_meta"
 markers = [
     "sqlite: tests that require the SQLite driver",
 ]
+
+[tool.setuptools]
+packages = ["adbc_driver_manager"]
+py-modules = ["adbc_driver_manager"]

--- a/python/adbc_driver_postgres/pyproject.toml
+++ b/python/adbc_driver_postgres/pyproject.toml
@@ -37,3 +37,5 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 include-package-data = true
+packages = ["adbc_driver_postgres"]
+py-modules = ["adbc_driver_postgres"]

--- a/python/adbc_driver_postgres/setup.py
+++ b/python/adbc_driver_postgres/setup.py
@@ -30,15 +30,18 @@ repo_root = source_root.joinpath("../../")
 # Resolve Shared Library
 
 library = os.environ.get("ADBC_POSTGRES_LIBRARY")
+target = source_root.joinpath(
+    "./adbc_driver_postgres/libadbc_driver_postgres.so"
+).resolve()
+
 if not library:
     if os.environ.get("_ADBC_IS_SDIST", "").strip().lower() in ("1", "true"):
         print("Building sdist, not requiring ADBC_POSTGRES_LIBRARY")
+    elif target.is_file():
+        print("Driver already exists (but may be stale?), continuing")
     else:
         raise ValueError("Must provide ADBC_POSTGRES_LIBRARY")
 else:
-    target = source_root.joinpath(
-        "./adbc_driver_postgres/libadbc_driver_postgres.so"
-    ).resolve()
     shutil.copy(library, target)
 
 # ------------------------------------------------------------

--- a/python/adbc_driver_sqlite/pyproject.toml
+++ b/python/adbc_driver_sqlite/pyproject.toml
@@ -37,3 +37,5 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 include-package-data = true
+packages = ["adbc_driver_sqlite"]
+py-modules = ["adbc_driver_sqlite"]

--- a/python/adbc_driver_sqlite/setup.py
+++ b/python/adbc_driver_sqlite/setup.py
@@ -30,15 +30,15 @@ repo_root = source_root.joinpath("../../")
 # Resolve Shared Library
 
 library = os.environ.get("ADBC_SQLITE_LIBRARY")
+target = source_root.joinpath("./adbc_driver_sqlite/libadbc_driver_sqlite.so").resolve()
 if not library:
     if os.environ.get("_ADBC_IS_SDIST", "").strip().lower() in ("1", "true"):
         print("Building sdist, not requiring ADBC_SQLITE_LIBRARY")
+    elif target.is_file():
+        print("Driver already exists (but may be stale?), continuing")
     else:
         raise ValueError("Must provide ADBC_SQLITE_LIBRARY")
 else:
-    target = source_root.joinpath(
-        "./adbc_driver_sqlite/libadbc_driver_sqlite.so"
-    ).resolve()
     shutil.copy(library, target)
 
 # ------------------------------------------------------------


### PR DESCRIPTION
- Use cibuildwheel for adbc_driver_manager
- Consolidate the different Python version builds into a single job
- Split the job by architecture instead