### PR TITLE
ci: fix wrongly tagged wheels being uploaded

### DIFF
--- a/.github/workflows/packaging-wheels.yml
+++ b/.github/workflows/packaging-wheels.yml
@@ -363,9 +363,9 @@ jobs:
           name: python${{ matrix.python_version }}-windows
           retention-days: 7
           path: |
-            python/adbc_driver_manager/dist/*.whl
-            python/adbc_driver_postgres/dist/*.whl
-            python/adbc_driver_sqlite/dist/*.whl
+            python/adbc_driver_manager/repaired_wheels/*.whl
+            python/adbc_driver_postgres/repaired_wheels/*.whl
+            python/adbc_driver_sqlite/repaired_wheels/*.whl
 
       - name: Test wheel
         shell: cmd
@@ -379,7 +379,7 @@ jobs:
         shell: pwsh
         if: github.ref == 'refs/heads/main' && (github.event.schedule || inputs.upload_artifacts)
         run: |
-          foreach ($wheel in Get-ChildItem python\adbc_driver_*\dist\*.whl) {
+          foreach ($wheel in Get-ChildItem python\adbc_driver_*\repaired_wheels\*.whl) {
               .\ci\scripts\python_wheel_upload.ps1 $wheel.FullName
           }
         env:

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -17,6 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+set -ex
+
 COMPONENTS="adbc_driver_manager adbc_driver_postgres adbc_driver_sqlite"
 
 function build_drivers {

--- a/ci/scripts/python_wheel_unix_build.sh
+++ b/ci/scripts/python_wheel_unix_build.sh
@@ -61,6 +61,15 @@ function check_wheels {
 echo "=== Set up platform variables ==="
 setup_build_vars "${arch}"
 
+echo "${PYTHON_ARCH}"
+
+# XXX: when we manually retag the wheel, we have to use the right arch
+# tag accounting for cross-compiling, hence the replacements
+PLAT_NAME=$(python -c "import sysconfig; print(sysconfig.get_platform()\
+    .replace('-x86_64', '-${PYTHON_ARCH}')\
+    .replace('-arm64', '-${PYTHON_ARCH}')\
+    .replace('-universal2', '-${PYTHON_ARCH}'))")
+
 echo "=== Building C/C++ driver components ==="
 # Sets ADBC_POSTGRES_LIBRARY, ADBC_SQLITE_LIBRARY
 build_drivers "${source_dir}" "${build_dir}"
@@ -72,10 +81,6 @@ check_visibility $ADBC_SQLITE_LIBRARY
 # https://github.com/pypa/pip/issues/7555
 # Get the latest pip so we have in-tree-build by default
 python -m pip install --upgrade pip auditwheel cibuildwheel delocate setuptools wheel
-
-# XXX: when we manually retag the wheel, we have to use the right arch
-# tag, hence the replacements
-PLAT_NAME=$(python -c "import sysconfig; print(sysconfig.get_platform().replace('-x86_64', '${PYTHON_ARCH}').replace('-arm64', '${PYTHON_ARCH}'))")
 
 for component in $COMPONENTS; do
     pushd ${source_dir}/python/$component

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -91,10 +91,8 @@ FOR %%c IN (adbc_driver_manager adbc_driver_postgres adbc_driver_sqlite) DO (
     )
 
     echo "=== (%PYTHON_VERSION%) Repair %%c wheel ==="
-    python -m pip wheel -w dist -vvv . || exit /B 1
-
     FOR %%w IN (dist\*.whl) DO (
-        delvewheel repair -w dist\ %%w
+        delvewheel repair -w repaired_wheels\ %%w
     )
 
     popd


### PR DESCRIPTION
- The Windows wheels were accidentally being built twice, leading to a `py3-none-any` wheel being uploaded
- The macOS wheels were retagging to `universal2` instead of the arch-specific tag