### PR TITLE
refactor(python): allow overriding package version

### DIFF
--- a/python/adbc_driver_manager/adbc_driver_manager/_version.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/_version.py
@@ -38,6 +38,9 @@ TAG_RELEASE_FORMAT = re.compile(r"^adbc-([0-9]+\.[0-9]+\.[0-9]+)(?:-rc[0-9]+)?$"
 
 
 def get_version(version_file=STATIC_VERSION_FILE):
+    override = os.environ.get("SETUPTOOLS_SCM_PRETEND_VERSION")
+    if override is not None and override != "":
+        return override
     version_info = get_static_version_info(version_file)
     version = version_info["version"]
     if version == "__use_git__":

--- a/python/adbc_driver_postgres/adbc_driver_postgres/_version.py
+++ b/python/adbc_driver_postgres/adbc_driver_postgres/_version.py
@@ -38,6 +38,9 @@ TAG_RELEASE_FORMAT = re.compile(r"^adbc-([0-9]+\.[0-9]+\.[0-9]+)(?:-rc[0-9]+)?$"
 
 
 def get_version(version_file=STATIC_VERSION_FILE):
+    override = os.environ.get("SETUPTOOLS_SCM_PRETEND_VERSION")
+    if override is not None and override != "":
+        return override
     version_info = get_static_version_info(version_file)
     version = version_info["version"]
     if version == "__use_git__":

--- a/python/adbc_driver_sqlite/adbc_driver_sqlite/_version.py
+++ b/python/adbc_driver_sqlite/adbc_driver_sqlite/_version.py
@@ -38,6 +38,9 @@ TAG_RELEASE_FORMAT = re.compile(r"^adbc-([0-9]+\.[0-9]+\.[0-9]+)(?:-rc[0-9]+)?$"
 
 
 def get_version(version_file=STATIC_VERSION_FILE):
+    override = os.environ.get("SETUPTOOLS_SCM_PRETEND_VERSION")
+    if override is not None and override != "":
+        return override
     version_info = get_static_version_info(version_file)
     version = version_info["version"]
     if version == "__use_git__":


### PR DESCRIPTION
This is needed for Conda packages, which build from Git checkouts and do not know the actual version.

Part of #229.