### PR TITLE
ci: clean old releases

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -601,3 +601,23 @@ jobs:
           ./ci/scripts/python_wheel_upload.sh upload-staging/adbc_*.tar.gz upload-staging/*.whl
         env:
           GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
+
+  clean-gemfury:
+    name: "Clean old releases"
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.ref, 'refs/tags/')"
+    needs:
+      - upload-gemfury
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Clean old releases
+        shell: bash
+        run: |
+          gem install --user-install gemfury
+          ruby ./ci/scripts/gemfury_clean.rb
+        env:
+          GEMFURY_API_TOKEN: ${{ secrets.GEMFURY_API_TOKEN }}

--- a/ci/scripts/gemfury_clean.rb
+++ b/ci/scripts/gemfury_clean.rb
@@ -22,17 +22,17 @@ require "gemfury"
 
 client = Gemfury::Client.new(user_api_key: ENV["GEMFURY_API_TOKEN"])
 
-for artifact in client.list
+client.list.each do |artifact|
   puts artifact["name"]
   versions = client.versions(artifact["name"])
   versions.sort_by! { |v| v["created_at"] }
 
   # Keep last two versions
-  for version in versions[0...-2]
+  versions[0...-2].each do |version|
     client.yank_version(artifact["name"], version["version"])
     puts "Yanked #{artifact['name']} #{version['version']} (created #{version['created_at']})"
   end
-  for version in versions.last(2)
+  versions.last(2).each do |version|
     puts "Kept #{artifact['name']} #{version['version']} (created #{version['created_at']})"
   end
 end

--- a/ci/scripts/gemfury_clean.rb
+++ b/ci/scripts/gemfury_clean.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Clean old releases from Gemfury.
+
+require "gemfury"
+
+client = Gemfury::Client.new(user_api_key: ENV["GEMFURY_API_TOKEN"])
+
+for artifact in client.list
+  puts artifact["name"]
+  versions = client.versions(artifact["name"])
+  versions.sort_by! { |v| v["created_at"] }
+
+  # Keep last two versions
+  for version in versions[0...-2]
+    client.yank_version(artifact["name"], version["version"])
+    puts "Yanked #{artifact['name']} #{version['version']} (created #{version['created_at']})"
+  end
+  for version in versions.last(2)
+    puts "Kept #{artifact['name']} #{version['version']} (created #{version['created_at']})"
+  end
+end


### PR DESCRIPTION
For this to work, we need to first add the API token. This is a different token than the one used for uploading packages.

Fixes #242.