### PR TITLE
ci: fix typo in Rakefile

### DIFF
--- a/ci/linux-packages/Rakefile
+++ b/ci/linux-packages/Rakefile
@@ -101,7 +101,7 @@ class ADBCPackageTask < PackageTask
     download(url, @archive_name)
   end
 
-  def download_release_archive
+  def download_released_archive
     base_url = "https://www.apache.org/dyn/closer.lua/arrow"
     archive_name_no_rc = @archive_name.gsub(/-rc\d+(\.tar\.gz)\z/, "\\1")
     url = "#{base_url}/#{@package}-#{@version}/#{archive_name_no_rc}"


### PR DESCRIPTION
Noticed when doing a dry-run of the release: https://github.com/lidavidm/arrow-adbc/actions/runs/3758626322/jobs/6387192369#step:8:33