### PR TITLE
ci: disable Linux packaging builds for RCs for now

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -128,6 +128,8 @@ jobs:
   linux:
     name: Linux ${{ matrix.target }}
     runs-on: ubuntu-latest
+    # TODO(GH-259): disable Linux packaging builds in RC builds for now
+    if: "!startsWith(github.ref, 'refs/tags')"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Workaround for #259.