### PR TITLE
chore(dev/release): use "find -exec" instead of "xargs mv -t"

### DIFF
--- a/dev/release/05-linux-upload.sh
+++ b/dev/release/05-linux-upload.sh
@@ -56,7 +56,7 @@ main() {
         tar xf ${tar_gz} -C tmp
         base_dir=${tar_gz%.tar.gz}
         mkdir -p ${base_dir}
-        find tmp -type f -print0 | xargs -0 mv -t ${base_dir}
+        find tmp -type f -exec mv '{}' ${base_dir} ';'
         rm -rf tmp
 	rm -f ${tar_gz}
     done


### PR DESCRIPTION
Fixes #275.

Because "mv -t" isn't portable.