### PR TITLE
chore(dev/release): reduce parallelism when downloading from GitHub

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -609,10 +609,10 @@ test_binary_distribution() {
     ${PYTHON:-python3} "$ARROW_SOURCE_DIR/dev/release/download_rc_binaries.py" \
                        $VERSION $RC_NUMBER \
                        --dest="${BINARY_DIR}" \
+                       --num_parallel 4 \
                        --package_type=github \
                        --repository="${SOURCE_REPOSITORY}" \
-                       --tag="apache-arrow-adbc-${VERSION}-rc${RC_NUMBER}" \
-                       --num_parallel 4
+                       --tag="apache-arrow-adbc-${VERSION}-rc${RC_NUMBER}"
   fi
 
   if [ ${TEST_BINARY} -gt 0 ]; then

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -611,7 +611,8 @@ test_binary_distribution() {
                        --dest="${BINARY_DIR}" \
                        --package_type=github \
                        --repository="${SOURCE_REPOSITORY}" \
-                       --tag="apache-arrow-adbc-${VERSION}-rc${RC_NUMBER}"
+                       --tag="apache-arrow-adbc-${VERSION}-rc${RC_NUMBER}" \
+                       --num_parallel 4
   fi
 
   if [ ${TEST_BINARY} -gt 0 ]; then


### PR DESCRIPTION
Doesn't need to be in 0.1.0 since I think adding a backoff (apache/arrow#15090) will suffice