### PR TITLE
chore(dev/release): ensure temporary directory writable on cleanup

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -227,6 +227,8 @@ test_yum() {
 setup_tempdir() {
   cleanup() {
     if [ "${TEST_SUCCESS}" = "yes" ]; then
+      # Go modules are installed with 0444.
+      chmod -R u+w "${ARROW_TMPDIR}"
       rm -fr "${ARROW_TMPDIR}"
     else
       echo "Failed to verify release candidate. See ${ARROW_TMPDIR} for details."


### PR DESCRIPTION
I don't know why but Go modules are installed with `0444` permission.

Fixes #295.