### PR TITLE
[Build] Refactor CMake to Have Top Level C Build

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -86,28 +86,14 @@ jobs:
             --file ci/conda_env_glib.txt \
             --file ci/conda_env_python.txt
 
-      - name: Build SQLite3 Driver
+      - name: Build Drivers
         shell: bash -l {0}
         run: |
-          env BUILD_ALL=0 BUILD_DRIVER_SQLITE=1 ./ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
-      - name: Test SQLite3 Driver
+          env BUILD_ALL=0 ADBC_BUILD_DRIVER_SQLITE=1 ADBC_BUILD_DRIVER_POSTGRESQL ADBC_BUILD_DRIVER_MANAGER ./ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
+      - name: Test Drivers
         shell: bash -l {0}
         run: |
-          env BUILD_ALL=0 BUILD_DRIVER_SQLITE=1 ./ci/scripts/cpp_test.sh "$(pwd)" "$(pwd)/build"
-      - name: Build PostgreSQL Driver
-        shell: bash -l {0}
-        # No test for now, since we need to spin up PostgreSQL itself
-        run: |
-          env BUILD_ALL=0 BUILD_DRIVER_POSTGRESQL=1 ./ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
-      - name: Build Driver Manager
-        shell: bash -l {0}
-        run: |
-          env BUILD_ALL=0 BUILD_DRIVER_MANAGER=1 ./ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
-      - name: Test Driver Manager
-        shell: bash -l {0}
-        run: |
-          env BUILD_ALL=0 BUILD_DRIVER_MANAGER=1 ./ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
-          env BUILD_ALL=0 BUILD_DRIVER_MANAGER=1 ./ci/scripts/cpp_test.sh "$(pwd)" "$(pwd)/build"
+          make test
 
       - name: Build and Install (No ASan)
         shell: bash -l {0}

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cmake_minimum_required(VERSION 3.18)
+get_filename_component(REPOSITORY_ROOT ".." ABSOLUTE)
+message(STATUS "${REPOSITORY_ROOT}")
+list(APPEND CMAKE_MODULE_PATH "${REPOSITORY_ROOT}/c/cmake_modules/")
+include(AdbcDefines)
+include(BuildUtils)
+
+project(adbc_driver_manager
+        VERSION "${ADBC_BASE_VERSION}"
+        LANGUAGES CXX)
+include(CTest)
+
+add_subdirectory(driver_manager)
+
+if(ADBC_BUILD_SQLITE)
+  add_subdirectory(driver/sqlite)
+endif()
+
+if(ADBC_BUILD_POSTGRES)
+  add_subdirectory(driver/postgresql)
+endif()

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -27,12 +27,14 @@ project(adbc_driver_manager
         LANGUAGES CXX)
 include(CTest)
 
-add_subdirectory(driver_manager)
+if(ADBC_BUILD_DRIVER_MANAGER)
+  add_subdirectory(driver_manager)
+endif()
 
-if(ADBC_BUILD_SQLITE)
+if(ADBC_BUILD_DRIVER_SQLITE)
   add_subdirectory(driver/sqlite)
 endif()
 
-if(ADBC_BUILD_POSTGRES)
+if(ADBC_BUILD_DRIVER_POSTGRESQL)
   add_subdirectory(driver/postgresql)
 endif()

--- a/c/driver/postgresql/CMakeLists.txt
+++ b/c/driver/postgresql/CMakeLists.txt
@@ -15,16 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.18)
-get_filename_component(REPOSITORY_ROOT "../../../" ABSOLUTE)
-list(APPEND CMAKE_MODULE_PATH "${REPOSITORY_ROOT}/c/cmake_modules/")
-include(AdbcDefines)
-include(BuildUtils)
-
-project(adbc_driver_postgresql
-        VERSION "${ADBC_BASE_VERSION}"
-        LANGUAGES CXX)
-include(CTest)
 
 if(WIN32)
   # XXX: for now, assume vcpkg

--- a/c/driver/sqlite/CMakeLists.txt
+++ b/c/driver/sqlite/CMakeLists.txt
@@ -15,16 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.18)
-get_filename_component(REPOSITORY_ROOT "../../../" ABSOLUTE)
-list(APPEND CMAKE_MODULE_PATH "${REPOSITORY_ROOT}/c/cmake_modules/")
-include(AdbcDefines)
-include(BuildUtils)
-
-project(adbc_driver_sqlite
-        VERSION "${ADBC_BASE_VERSION}"
-        LANGUAGES CXX)
-include(CTest)
 
 find_package(SQLite3)
 if(SQLite3_FOUND)

--- a/c/driver_manager/CMakeLists.txt
+++ b/c/driver_manager/CMakeLists.txt
@@ -15,18 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.18)
-get_filename_component(REPOSITORY_ROOT "../.." ABSOLUTE)
-message(STATUS "${REPOSITORY_ROOT}")
-list(APPEND CMAKE_MODULE_PATH "${REPOSITORY_ROOT}/c/cmake_modules/")
-include(AdbcDefines)
-include(BuildUtils)
-
-project(adbc_driver_manager
-        VERSION "${ADBC_BASE_VERSION}"
-        LANGUAGES CXX)
-include(CTest)
-
 add_arrow_lib(adbc_driver_manager
               SOURCES
               adbc_driver_manager.cc

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -32,11 +32,14 @@ set -e
 : ${ADBC_CMAKE_ARGS:=""}
 : ${CMAKE_BUILD_TYPE:=Debug}
 
-build_subproject() {
+main() {
     local -r source_dir="${1}"
     local -r build_dir="${2}"
-    local -r install_dir="${3}"
-    local -r subproject="${4}"
+    local install_dir="${3}"
+
+    if [[ -z "${install_dir}" ]]; then
+        install_dir="${build_dir}/local"
+    fi
 
     if [[ -z "${CMAKE_INSTALL_PREFIX}" ]]; then
         CMAKE_INSTALL_PREFIX="${install_dir}"
@@ -56,33 +59,12 @@ build_subproject() {
           -DADBC_USE_UBSAN="${ADBC_USE_UBSAN}" \
           -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
           -DCMAKE_INSTALL_LIBDIR=lib \
-          -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}"
+          -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}" \
+          -DADBC_BUILD_DRIVER_MANAGER="${ADBC_BUILD_DRIVER_MANAGER}" \
+          -DADBC_BUILD_DRIVER_POSTGRESQL="${ADBC_BUILD_DRIVER_POSTGRESQL}" \
+          -DADBC_BUILD_DRIVER_SQLITE="${ADBC_BUILD_DRIVER_SQLITE}" \
     set +x
     cmake --build . --target install -j
-
-    popd
-}
-
-main() {
-    local -r source_dir="${1}"
-    local -r build_dir="${2}"
-    local install_dir="${3}"
-
-    if [[ -z "${install_dir}" ]]; then
-        install_dir="${build_dir}/local"
-    fi
-
-    if [[ "${BUILD_DRIVER_MANAGER}" -gt 0 ]]; then
-        build_subproject "${source_dir}" "${build_dir}" "${install_dir}" driver_manager
-    fi
-
-    if [[ "${BUILD_DRIVER_POSTGRESQL}" -gt 0 ]]; then
-        build_subproject "${source_dir}" "${build_dir}" "${install_dir}" driver/postgresql
-    fi
-
-    if [[ "${BUILD_DRIVER_SQLITE}" -gt 0 ]]; then
-        build_subproject "${source_dir}" "${build_dir}" "${install_dir}" driver/sqlite
-    fi
 }
 
 main "$@"


### PR DESCRIPTION
Hope I'm not overlooking something simple, but seems like the build system could be simplified if we used a top level CMakeLists.txt and triggered build of particular drivers / managers via arguments.

Intermediate state right now - just want to make sure this isn't crazy before going too deep