### PR TITLE
feat(format): Add more canonical options

### DIFF
--- a/adbc.h
+++ b/adbc.h
@@ -288,6 +288,22 @@ struct ADBC_EXPORT AdbcError {
 /// For use as the value in SetOption calls.
 #define ADBC_OPTION_VALUE_DISABLED "false"
 
+/// \brief Canonical option name for URIs.
+///
+/// Should be used as the expected option name to specify
+/// a URI for any ADBC driver.
+#define ADBC_OPTION_URI "uri"
+/// \brief Canonical option name for usernames.
+///
+/// Should be used as the expected option name to specify
+/// a username to a driver for authentication.
+#define ADBC_OPTION_USERNAME "username"
+/// \brief Canonical option name for passwords.
+///
+/// Should be used as the expected option name to specify
+/// a password for authentication to a driver.
+#define ADBC_OPTION_PASSWORD "password"
+
 /// \brief The database vendor/product name (e.g. the server name).
 ///   (type: utf8).
 ///

--- a/docs/source/format/specification.rst
+++ b/docs/source/format/specification.rst
@@ -45,7 +45,7 @@ the implementations via helpers:
 
 - C/C++: :c:macro:`ADBC_OPTION_URI`
 - Go: ``OptionKeyURI``
-- Java: ``org.apache.arrow.adbc.core.AdbcDriver#PARAM_URL
+- Java: ``org.apache.arrow.adbc.core.AdbcDriver#PARAM_URL``
 
 Authentication
 --------------

--- a/docs/source/format/specification.rst
+++ b/docs/source/format/specification.rst
@@ -36,6 +36,30 @@ provides a place to hold ownership of the in-memory database.
 - Go: ``Driver``
 - Java: ``org.apache.arrow.adbc.core.AdbcDatabase``
 
+URIs
+----
+
+When specifying the URI of the database, there is a standard option
+name to pass to drivers. This is the string `uri`, available in
+the implementations via helpers:
+
+- C/C++: :c:macro:`ADBC_OPTION_URI`
+- Go: ``OptionKeyURI``
+- Java: ``org.apache.arrow.adbc.core.AdbcDriver#PARAM_URL
+
+Authentication
+--------------
+
+Standard options are defined for specifying the username and password
+for authentication to a driver. Further authentication options would
+be driver specific, such as a particular driver supporting the use
+of kerberos auth or plain auth, etc.
+
+- C/C++: :c:macro:`ADBC_OPTION_USERNAME` and :c:macro:`ADBC_OPTION_PASSWORD`
+- Go: ``OptionKeyUsername`` and ``OptionKeyPassword``
+- Java: ``org.apache.arrow.adbc.core.AdbcDriver#PARAM_USER`` and ``org.apache.arrow.adbc.core.AdbcDriver#PARAM_PASS``
+
+
 Connections
 ===========
 

--- a/docs/source/format/specification.rst
+++ b/docs/source/format/specification.rst
@@ -33,7 +33,7 @@ means common configuration and caches.  For in-memory databases, it
 provides a place to hold ownership of the in-memory database.
 
 - C/C++: :cpp:class:`AdbcDatabase`
-- Go: ``Driver``
+- Go: ``Database``
 - Java: ``org.apache.arrow.adbc.core.AdbcDatabase``
 
 URIs
@@ -45,7 +45,7 @@ the implementations via helpers:
 
 - C/C++: :c:macro:`ADBC_OPTION_URI`
 - Go: ``OptionKeyURI``
-- Java: ``org.apache.arrow.adbc.core.AdbcDriver#PARAM_URL``
+- Java: ``org.apache.arrow.adbc.core.AdbcDriver#PARAM_URI``
 
 Authentication
 --------------
@@ -57,7 +57,7 @@ of kerberos auth or plain auth, etc.
 
 - C/C++: :c:macro:`ADBC_OPTION_USERNAME` and :c:macro:`ADBC_OPTION_PASSWORD`
 - Go: ``OptionKeyUsername`` and ``OptionKeyPassword``
-- Java: ``org.apache.arrow.adbc.core.AdbcDriver#PARAM_USER`` and ``org.apache.arrow.adbc.core.AdbcDriver#PARAM_PASS``
+- Java: ``org.apache.arrow.adbc.core.AdbcDriver#PARAM_USERNAME`` and ``org.apache.arrow.adbc.core.AdbcDriver#PARAM_PASSWORD``
 
 
 Connections

--- a/go/adbc/adbc.go
+++ b/go/adbc/adbc.go
@@ -152,6 +152,9 @@ const (
 	OptionKeyReadOnly           = "adbc.connection.readonly"
 	OptionValueIngestModeCreate = "adbc.ingest.mode.create"
 	OptionValueIngestModeAppend = "adbc.ingest.mode.append"
+	OptionKeyURI                = "uri"
+	OptionKeyUsername           = "username"
+	OptionKeyPassword           = "password"
 )
 
 type OptionIsolationLevel string

--- a/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcDriver.java
+++ b/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcDriver.java
@@ -22,13 +22,16 @@ import java.util.Map;
 /** A handle to an ADBC database driver. */
 public interface AdbcDriver {
   /** The standard parameter name for a connection URL (type String). */
-  String PARAM_URL = "uri";
+  @Deprecated
+  String PARAM_URL = "url";
+  /** The standard parameter name for a connection URI (type String). */
+  String PARAM_URI = "uri";
   /** The standard parameter name for SQL quirks configuration (type SqlQuirks). */
   String PARAM_SQL_QUIRKS = "adbc.sql.quirks";
   /** The standard parameter name for an auth username (type String). */
-  String PARAM_USER = "username";
+  String PARAM_USERNAME = "username";
   /** The standard parameter name for an auth password (type String). */
-  String PARAM_PASS = "password";
+  String PARAM_PASSWORD = "password";
 
   /**
    * Open a database via this driver.

--- a/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcDriver.java
+++ b/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcDriver.java
@@ -22,8 +22,7 @@ import java.util.Map;
 /** A handle to an ADBC database driver. */
 public interface AdbcDriver {
   /** The standard parameter name for a connection URL (type String). */
-  @Deprecated
-  String PARAM_URL = "url";
+  @Deprecated String PARAM_URL = "url";
   /** The standard parameter name for a connection URI (type String). */
   String PARAM_URI = "uri";
   /** The standard parameter name for SQL quirks configuration (type SqlQuirks). */

--- a/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcDriver.java
+++ b/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcDriver.java
@@ -22,7 +22,7 @@ import java.util.Map;
 /** A handle to an ADBC database driver. */
 public interface AdbcDriver {
   /** The standard parameter name for a connection URL (type String). */
-  @Deprecated String PARAM_URL = "url";
+  @Deprecated String PARAM_URL = "adbc.url";
   /** The standard parameter name for a connection URI (type String). */
   String PARAM_URI = "uri";
   /** The standard parameter name for SQL quirks configuration (type SqlQuirks). */

--- a/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcDriver.java
+++ b/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcDriver.java
@@ -22,9 +22,13 @@ import java.util.Map;
 /** A handle to an ADBC database driver. */
 public interface AdbcDriver {
   /** The standard parameter name for a connection URL (type String). */
-  String PARAM_URL = "adbc.url";
+  String PARAM_URL = "uri";
   /** The standard parameter name for SQL quirks configuration (type SqlQuirks). */
   String PARAM_SQL_QUIRKS = "adbc.sql.quirks";
+  /** The standard parameter name for an auth username (type String). */
+  String PARAM_USER = "username";
+  /** The standard parameter name for an auth password (type String). */
+  String PARAM_PASS = "password";
 
   /**
    * Open a database via this driver.


### PR DESCRIPTION
Adding canonical option names for URI, Username and Password. 

This also adds these definitions to the Go and Java implementations along with the spec docs.