### PR TITLE
feat(c/driver/postgresql): Add varchar type support

### DIFF
--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -143,6 +143,7 @@ AdbcStatusCode InferSchema(const TypeMapping& type_mapping, PGresult* result,
         field_type = NANOARROW_TYPE_INT64;
         break;
       case PgType::kText:
+      case PgType::kVarChar:
         field_type = NANOARROW_TYPE_STRING;
         break;
       default:


### PR DESCRIPTION
'varchar' and 'text' are really the same type so just need to add it to the supported list. 