### PR TITLE
fix(ci/ruby): revert GEM_HOME for RubyGems install test

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -24,6 +24,7 @@ on:
     paths:
       - "adbc.h"
       - "c/**"
+      - "ci/**"
       - "glib/**"
       - "python/**"
       - ".github/workflows/cpp.yml"
@@ -31,6 +32,7 @@ on:
     paths:
       - "adbc.h"
       - "c/**"
+      - "ci/**"
       - "glib/**"
       - "python/**"
       - ".github/workflows/cpp.yml"

--- a/ci/scripts/glib_test.sh
+++ b/ci/scripts/glib_test.sh
@@ -40,8 +40,8 @@ test_subproject() {
 
     if [[ "$(uname)" = "Darwin" ]]; then
         bundle config build.red-arrow -- \
-               --with-cflags=\"-D_LIBCPP_DISABLE_AVAILABILITY\" \
-               --with-cppflags=\"-D_LIBCPP_DISABLE_AVAILABILITY\"
+               --with-cflags=-D_LIBCPP_DISABLE_AVAILABILITY \
+               --with-cppflags=-D_LIBCPP_DISABLE_AVAILABILITY
     fi
 
     bundle config set --local path 'vendor/bundle'
@@ -57,8 +57,8 @@ test_subproject() {
 
     if [[ "$(uname)" = "Darwin" ]]; then
         bundle config build.red-arrow -- \
-               --with-cflags=\"-D_LIBCPP_DISABLE_AVAILABILITY\" \
-               --with-cppflags=\"-D_LIBCPP_DISABLE_AVAILABILITY\"
+               --with-cflags=-D_LIBCPP_DISABLE_AVAILABILITY \
+               --with-cppflags=-D_LIBCPP_DISABLE_AVAILABILITY
     fi
 
     bundle config set --local path 'vendor/bundle'
@@ -74,9 +74,7 @@ test_subproject() {
         gem_flags='-- --with-cflags="-D_LIBCPP_DISABLE_AVAILABILITY" --with-cppflags="-D_LIBCPP_DISABLE_AVAILABILITY"'
     fi
 
-    export GEM_HOME="${build_dir}/gems"
-    export PATH="${GEM_HOME}/bin:${PATH}"
-    gem install pkg/*.gem -- ${gem_flags}
+    gem install --install-dir "${build_dir}/gems" pkg/*.gem -- ${gem_flags}
     popd
 }
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -484,6 +484,7 @@ test_glib() {
 
   # Install bundler if doesn't exist
   if ! bundle --version; then
+    # This is for old Ruby. Recent Ruby bundles Bundler.
     export GEM_HOME="${ARROW_TMPDIR}/glib-build/gems"
     export PATH="${GEM_HOME}/bin:${PATH}"
     gem install --no-document bundler


### PR DESCRIPTION
Fixes #350.

We don't need to set GEM_HOME for RubyGems install test. Because we don't use installed gems. We just want to test installation.

We can't use GEM_HOME environment variable on conda environment. Because conda's Ruby sets gemhome in etc/gemrc. We can't overwrite it by GEM_HOME environment variable.

So "--install-dir" is portable than GEM_HOME.