### PR TITLE
fix(go/adbc/driver/flightsql): heap-allocate Go handles

### DIFF
--- a/go/adbc/driver/flightsql/flightsql_adbc.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc.go
@@ -487,7 +487,10 @@ func (c *cnxn) GetInfo(ctx context.Context, infoCodes []adbc.InfoCode) (array.Re
 // All non-empty, non-nil strings should be a search pattern (as described
 // earlier).
 func (c *cnxn) GetObjects(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string, tableName *string, columnName *string, tableType []string) (array.RecordReader, error) {
-	panic("not implemented") // TODO: Implement
+	return nil, adbc.Error{
+		Msg:  "Not implemented: GetObjects",
+		Code: adbc.StatusNotImplemented,
+	}
 }
 
 func (c *cnxn) GetTableSchema(ctx context.Context, catalog *string, dbSchema *string, tableName string) (*arrow.Schema, error) {

--- a/go/adbc/pkg/_tmpl/driver.go.tmpl
+++ b/go/adbc/pkg/_tmpl/driver.go.tmpl
@@ -75,11 +75,29 @@ func errToAdbcErr(adbcerr *C.struct_AdbcError, err error) adbc.Status {
 	return adbc.StatusUnknown
 }
 
+// Allocate a new cgo.Handle and store its address in a heap-allocated
+// uintptr_t.  Experimentally, this was found to be necessary, else
+// something (the Go runtime?) would corrupt (garbage-collect?) the
+// handle.
+func createHandle(hndl cgo.Handle) unsafe.Pointer {
+	// uintptr_t* hptr = malloc(sizeof(uintptr_t));
+	hptr := (*C.uintptr_t)(C.malloc(C.sizeof_uintptr_t))
+	// *hptr = (uintptr)hndl;
+	*hptr = C.uintptr_t(uintptr(hndl))
+	return unsafe.Pointer(hptr)
+}
+
 func getFromHandle[T any](ptr unsafe.Pointer) *T {
-	return (*(*cgo.Handle)(ptr)).Value().(*T)
+	// uintptr_t* hptr = (uintptr_t*)ptr;
+	hptr := (*C.uintptr_t)(ptr)
+	return cgo.Handle((uintptr)(*hptr)).Value().(*T)
 }
 
 func checkDBAlloc(db *C.struct_AdbcDatabase, err *C.struct_AdbcError, fname string) bool {
+	if db == nil {
+		setErr(err, "%s: database not allocated", fname)
+		return false
+	}
 	if db.private_data == nil {
 		setErr(err, "%s: database not allocated", fname)
 		return false
@@ -113,7 +131,7 @@ func {{.Prefix}}DatabaseNew(db *C.struct_AdbcDatabase, err *C.struct_AdbcError) 
 	}
 	dbobj := &cDatabase{opts: make(map[string]string)}
 	hndl := cgo.NewHandle(dbobj)
-	db.private_data = unsafe.Pointer(&hndl)
+	db.private_data = createHandle(hndl)
 	return C.ADBC_STATUS_OK
 }
 
@@ -153,7 +171,7 @@ func {{.Prefix}}DatabaseInit(db *C.struct_AdbcDatabase, err *C.struct_AdbcError)
 
 //export {{.Prefix}}DatabaseRelease
 func {{.Prefix}}DatabaseRelease(db *C.struct_AdbcDatabase, err *C.struct_AdbcError) C.AdbcStatusCode {
-	if !checkDBAlloc(db, err, "AdbcDatabaseInit") {
+	if !checkDBAlloc(db, err, "AdbcDatabaseRelease") {
 		return C.ADBC_STATUS_INVALID_STATE
 	}
 	h := (*(*cgo.Handle)(db.private_data))
@@ -165,8 +183,10 @@ func {{.Prefix}}DatabaseRelease(db *C.struct_AdbcDatabase, err *C.struct_AdbcErr
 	}
 	cdb.db = nil
 	cdb.opts = nil
+	C.free(unsafe.Pointer(db.private_data))
 	db.private_data = nil
 	h.Delete()
+
 	return C.ADBC_STATUS_OK
 }
 
@@ -175,6 +195,10 @@ type cConn struct {
 }
 
 func checkConnAlloc(cnxn *C.struct_AdbcConnection, err *C.struct_AdbcError, fname string) bool {
+	if cnxn == nil {
+		setErr(err, "%s: connection not allocated", fname)
+		return false
+	}
 	if cnxn.private_data == nil {
 		setErr(err, "%s: connection not allocated", fname)
 		return false
@@ -203,7 +227,7 @@ func {{.Prefix}}ConnectionNew(cnxn *C.struct_AdbcConnection, err *C.struct_AdbcE
 	}
 
 	hndl := cgo.NewHandle(&cConn{})
-	cnxn.private_data = unsafe.Pointer(&hndl)
+	cnxn.private_data = createHandle(hndl)
 	return C.ADBC_STATUS_OK
 }
 
@@ -256,6 +280,7 @@ func {{.Prefix}}ConnectionRelease(cnxn *C.struct_AdbcConnection, err *C.struct_A
 	}
 	defer func() {
 		conn.cnxn = nil
+		C.free(unsafe.Pointer(cnxn.private_data))
 		cnxn.private_data = nil
 		h.Delete()
 	}()
@@ -432,7 +457,7 @@ func {{.Prefix}}StatementNew(cnxn *C.struct_AdbcConnection, stmt *C.struct_AdbcS
 	}
 
 	h := cgo.NewHandle(st)
-	stmt.private_data = unsafe.Pointer(&h)
+	stmt.private_data = createHandle(h)
 	return C.ADBC_STATUS_OK
 }
 
@@ -450,6 +475,7 @@ func {{.Prefix}}StatementRelease(stmt *C.struct_AdbcStatement, err *C.struct_Adb
 
 	h := (*(*cgo.Handle)(stmt.private_data))
 	st := h.Value().(adbc.Statement)
+	C.free(stmt.private_data)
 	stmt.private_data = nil
 
 	e := st.Close()
@@ -567,6 +593,7 @@ func releasePartitions(partitions *C.struct_AdbcPartitions) {
 	C.free(unsafe.Pointer(partitions.partitions))
 	C.free(unsafe.Pointer(partitions.partition_lengths))
 	h := (*(*cgo.Handle)(partitions.private_data))
+	C.free(partitions.private_data)
 	h.Delete()
 }
 
@@ -607,7 +634,7 @@ func {{.Prefix}}StatementExecutePartitions(stmt *C.struct_AdbcStatement, schema 
 	}
 
 	h := cgo.NewHandle(part)
-	partitions.private_data = unsafe.Pointer(&h)
+	partitions.private_data = createHandle(h)
 	partitions.release = (*[0]byte)(C.releasePartitions)
 	return C.ADBC_STATUS_OK
 }


### PR DESCRIPTION
Experimentally, it was found that at runtime, sometimes Go handles
would be corrupted after crossing the FFI boundary. Heap-allocating
the handles appears to avoid this.