### PR TITLE
fix(ci): don't make jobs depend on each other

### DIFF
--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -27,6 +27,6 @@ ARG ARCH
 
 RUN yum install -y docker
 # arm64v8 -> arm64
-RUN wget https://go.dev/dl/go1.19.5.linux-${ARCH/v8/}.tar.gz
+RUN wget --no-verbose https://go.dev/dl/go1.19.5.linux-${ARCH/v8/}.tar.gz
 RUN tar -C /usr/local -xzf go1.19.5.linux-${ARCH/v8/}.tar.gz
 ENV PATH="${PATH}:/usr/local/go/bin"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,11 +48,20 @@ services:
 
   python-sdist-test:
     image: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-${MANYLINUX}-vcpkg-${VCPKG}-adbc
-    depends_on:
-      - python-wheel-manylinux  # shared image
+    build:
+      context: .
+      cache_from:
+        - ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-${MANYLINUX}-vcpkg-${VCPKG}-adbc
+      dockerfile: ci/docker/python-wheel-manylinux.dockerfile
+      args:
+        ARCH: ${ARCH}
+        MANYLINUX: ${MANYLINUX}
+        PYTHON: ${PYTHON}
+        REPO: ${REPO}
+        VCPKG: ${VCPKG}
     volumes:
       - .:/adbc:delegated
-    command: "'git config --global --add safe.directory /adbc && source /adbc/ci/scripts/python_sdist_test.sh ${ARCH} /adbc /adbcbuild'"
+    command: "'git config --global --add safe.directory /adbc && source /adbc/ci/scripts/python_sdist_test.sh ${ARCH} /adbc'"
 
   ############################ Python wheels ##################################
 


### PR DESCRIPTION
This was making python-sdist-test flaky since we were accidentally starting up two docker-compose services which then trampled each other. Instead of trying to share image definitions, just copy-paste and let Docker figure out deduplication.