### PR TITLE
fix(go/adbc/sqldriver): allow equals signs in DSN values

### DIFF
--- a/go/adbc/sqldriver/driver.go
+++ b/go/adbc/sqldriver/driver.go
@@ -70,7 +70,7 @@ func getIsolationlevel(lvl sql.IsolationLevel) adbc.OptionIsolationLevel {
 	return ""
 }
 
-func ParseConnectStr(str string) (ret map[string]string, err error) {
+func parseConnectStr(str string) (ret map[string]string, err error) {
 	ret = make(map[string]string)
 	for _, kv := range strings.Split(str, ";") {
 		parsed := strings.SplitN(kv, "=", 2)
@@ -139,7 +139,7 @@ func (d Driver) Open(name string) (driver.Conn, error) {
 
 // OpenConnector expects the same format as driver.Open
 func (d Driver) OpenConnector(name string) (driver.Connector, error) {
-	opts, err := ParseConnectStr(name)
+	opts, err := parseConnectStr(name)
 	if err != nil {
 		return nil, err
 	}

--- a/go/adbc/sqldriver/driver.go
+++ b/go/adbc/sqldriver/driver.go
@@ -70,10 +70,10 @@ func getIsolationlevel(lvl sql.IsolationLevel) adbc.OptionIsolationLevel {
 	return ""
 }
 
-func parseConnectStr(str string) (ret map[string]string, err error) {
+func ParseConnectStr(str string) (ret map[string]string, err error) {
 	ret = make(map[string]string)
 	for _, kv := range strings.Split(str, ";") {
-		parsed := strings.Split(kv, "=")
+		parsed := strings.SplitN(kv, "=", 2)
 		if len(parsed) != 2 {
 			return nil, &adbc.Error{
 				Msg:  "invalid format for connection string",
@@ -139,7 +139,7 @@ func (d Driver) Open(name string) (driver.Conn, error) {
 
 // OpenConnector expects the same format as driver.Open
 func (d Driver) OpenConnector(name string) (driver.Connector, error) {
-	opts, err := parseConnectStr(name)
+	opts, err := ParseConnectStr(name)
 	if err != nil {
 		return nil, err
 	}

--- a/go/adbc/sqldriver/driver_internals_test.go
+++ b/go/adbc/sqldriver/driver_internals_test.go
@@ -1,0 +1,44 @@
+package sqldriver
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseConnectStr(t *testing.T) {
+	const (
+		scheme   = "grpc+tcp"
+		host     = "host"
+		port     = 443
+		dbname   = "dbname"
+		username = "username"
+		password = "token=="
+	)
+
+	var (
+		uri = fmt.Sprintf("%s://%s:%d/%s", scheme, host, port, dbname)
+	)
+
+	dsn := strings.Join([]string{
+		fmt.Sprintf("%s=%s", adbc.OptionKeyURI, uri),
+		fmt.Sprintf("%s=%s", adbc.OptionKeyUsername, username),
+		fmt.Sprintf("%s=%s", adbc.OptionKeyPassword, password),
+		fmt.Sprintf("%s=%s", adbc.OptionKeyReadOnly, adbc.OptionValueEnabled),
+	}, " ; ")
+
+	expectOpts := map[string]string{
+		adbc.OptionKeyURI:      uri,
+		adbc.OptionKeyUsername: username,
+		adbc.OptionKeyPassword: password,
+		adbc.OptionKeyReadOnly: adbc.OptionValueEnabled,
+	}
+
+	gotOpts, err := parseConnectStr(dsn)
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectOpts, gotOpts)
+	}
+}

--- a/go/adbc/sqldriver/driver_internals_test.go
+++ b/go/adbc/sqldriver/driver_internals_test.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package sqldriver
 
 import (

--- a/go/adbc/sqldriver/driver_test.go
+++ b/go/adbc/sqldriver/driver_test.go
@@ -22,7 +22,10 @@ package sqldriver_test
 import (
 	"database/sql"
 	"fmt"
+	"strings"
+	"testing"
 
+	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-adbc/go/adbc/drivermgr"
 	"github.com/apache/arrow-adbc/go/adbc/sqldriver"
 )
@@ -70,4 +73,38 @@ func Example() {
 	// 1
 	// true true
 	// 1
+}
+
+func TestParseConnectStr(t *testing.T) {
+	const (
+		scheme   = "grpc+tcp"
+		host     = "host"
+		port     = 443
+		dbname   = "dbname"
+		username = "username"
+		password = "token=="
+	)
+
+	var (
+		uri = fmt.Sprintf("%s://%s:%d/%s", scheme, host, port, dbname)
+	)
+
+	dsn := strings.Join([]string{
+		fmt.Sprintf("%s=%s", adbc.OptionKeyURI, uri),
+		fmt.Sprintf("%s=%s", adbc.OptionKeyUsername, username),
+		fmt.Sprintf("%s=%s", adbc.OptionKeyPassword, password),
+		fmt.Sprintf("%s=%s", adbc.OptionKeyReadOnly, adbc.OptionValueEnabled),
+	}, " ; ")
+
+	expectOpts := map[string]string{
+		adbc.OptionKeyURI:      uri,
+		adbc.OptionKeyUsername: username,
+		adbc.OptionKeyPassword: password,
+		adbc.OptionKeyReadOnly: adbc.OptionValueEnabled,
+	}
+
+	gotOpts, err := sqldriver.ParseConnectStr(dsn)
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectOpts, gotOpts)
+	}
 }

--- a/go/adbc/sqldriver/driver_test.go
+++ b/go/adbc/sqldriver/driver_test.go
@@ -22,10 +22,7 @@ package sqldriver_test
 import (
 	"database/sql"
 	"fmt"
-	"strings"
-	"testing"
 
-	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-adbc/go/adbc/drivermgr"
 	"github.com/apache/arrow-adbc/go/adbc/sqldriver"
 )
@@ -73,38 +70,4 @@ func Example() {
 	// 1
 	// true true
 	// 1
-}
-
-func TestParseConnectStr(t *testing.T) {
-	const (
-		scheme   = "grpc+tcp"
-		host     = "host"
-		port     = 443
-		dbname   = "dbname"
-		username = "username"
-		password = "token=="
-	)
-
-	var (
-		uri = fmt.Sprintf("%s://%s:%d/%s", scheme, host, port, dbname)
-	)
-
-	dsn := strings.Join([]string{
-		fmt.Sprintf("%s=%s", adbc.OptionKeyURI, uri),
-		fmt.Sprintf("%s=%s", adbc.OptionKeyUsername, username),
-		fmt.Sprintf("%s=%s", adbc.OptionKeyPassword, password),
-		fmt.Sprintf("%s=%s", adbc.OptionKeyReadOnly, adbc.OptionValueEnabled),
-	}, " ; ")
-
-	expectOpts := map[string]string{
-		adbc.OptionKeyURI:      uri,
-		adbc.OptionKeyUsername: username,
-		adbc.OptionKeyPassword: password,
-		adbc.OptionKeyReadOnly: adbc.OptionValueEnabled,
-	}
-
-	gotOpts, err := sqldriver.ParseConnectStr(dsn)
-	if assert.NoError(t, err) {
-		assert.Equal(t, expectOpts, gotOpts)
-	}
 }


### PR DESCRIPTION
Fix a small nit. My "passwords" are tokens, which are base64-encoded values, so they often have an equals sign `=` suffix.

FYI the added test does not pass on my local development environment, due to a cgo issue:
```# github.com/apache/arrow-adbc/go/adbc/drivermgr
adbc_driver_manager.cc:224:26: warning: default member initializer for non-static data member is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:225:32: warning: default member initializer for non-static data member is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:316:14: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:316:27: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:322:12: error: no member named 'ignore' in namespace 'std'
adbc_driver_manager.cc:349:3: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:428:3: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:432:14: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:432:27: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:473:3: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:558:3: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:576:3: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:648:3: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:784:3: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
adbc_driver_manager.cc:790:5: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
FAIL    github.com/apache/arrow-adbc/go/adbc/sqldriver [build failed]
```