### PR TITLE
feat(go/adbc/driver/flightsql,go/adbc/sqldriver): small improvements

### DIFF
--- a/go/adbc/driver/flightsql/flightsql_adbc.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc.go
@@ -237,7 +237,7 @@ func getFlightClient(ctx context.Context, loc string, d *database) (*flightsql.C
 	}
 
 	cl.Alloc = d.alloc
-	if d.user != "" {
+	if d.user != "" || d.pass != "" {
 		ctx, err = cl.Client.AuthenticateBasicToken(ctx, d.user, d.pass)
 		if err != nil {
 			return nil, adbc.Error{


### PR DESCRIPTION
Two small changes:
- flightsql: allow basic authentication with username or password or both
    - InfluxDB/IOx has a token authentication which ignores username
- sqldriver: allow queries without prepared statements
    - InfluxDB/IOx does not support prepared statements (yet)
