### PR TITLE
feat(go/adbc/driver/flightsql): change parallelization of DoGet

### DIFF
--- a/docs/source/driver/go/flight_sql.rst
+++ b/docs/source/driver/go/flight_sql.rst
@@ -162,8 +162,16 @@ try the next location.
 
 The driver does not currently cache or pool these secondary
 connections.  It also does not retry connections or requests.
-Requests are made sequentially, one at a time—the driver does not
-parallelize requests or perform readahead.
+
+All partitions are fetched in parallel.  A limited number of batches
+are queued per partition.  Data is returned to the client in the order
+of the partitions.
+
+The queue size can be changed by setting an option on the
+:cpp:class:`AdbcStatement`:
+
+``arrow.flight.sql.rpc.queue_size``
+    The number of batches to queue per partition.  Defaults to 5.
 
 Metadata
 --------

--- a/go/adbc/driver/flightsql/flightsql_adbc.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc.go
@@ -635,6 +635,7 @@ func (c *cnxn) NewStatement() (adbc.Statement, error) {
 		alloc:       c.db.alloc,
 		cl:          c.cl,
 		clientCache: c.clientCache,
+		queueSize:   5,
 	}, nil
 }
 

--- a/go/adbc/driver/flightsql/flightsql_adbc.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc.go
@@ -265,7 +265,7 @@ func (d *database) Open(ctx context.Context) (adbc.Connection, error) {
 		LoaderFunc(func(loc interface{}) (interface{}, error) {
 			uri, ok := loc.(string)
 			if !ok {
-				return nil, adbc.Error{Code: adbc.StatusInternal}
+				return nil, adbc.Error{Msg: fmt.Sprintf("Location must be a string, got %#v", uri), Code: adbc.StatusInternal}
 			}
 
 			cl, err := getFlightClient(context.Background(), uri, d)

--- a/go/adbc/driver/flightsql/flightsql_adbc.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc.go
@@ -602,7 +602,7 @@ func (c *cnxn) GetTableTypes(ctx context.Context) (array.RecordReader, error) {
 		return nil, adbcFromFlightStatus(err)
 	}
 
-	return newRecordReader(ctx, c.db.alloc, c.cl, info, c.clientCache)
+	return newRecordReader(ctx, c.db.alloc, c.cl, info, c.clientCache, 5)
 }
 
 // Commit commits any pending transactions on this connection, it should

--- a/go/adbc/driver/flightsql/flightsql_adbc_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_test.go
@@ -331,3 +331,58 @@ func (suite *PartitionTests) TestIntrospectPartitions() {
 	suite.Require().Equal(1, len(info.Endpoint))
 	suite.Require().Equal(0, len(info.Endpoint[0].Location))
 }
+
+type StatementTests struct {
+	suite.Suite
+
+	Driver adbc.Driver
+	Quirks validation.DriverQuirks
+
+	DB   adbc.Database
+	Cnxn adbc.Connection
+	Stmt adbc.Statement
+	ctx  context.Context
+}
+
+func (suite *StatementTests) SetupTest() {
+	suite.Driver = suite.Quirks.SetupDriver(suite.T())
+	var err error
+	suite.DB, err = suite.Driver.NewDatabase(suite.Quirks.DatabaseOptions())
+	suite.Require().NoError(err)
+	suite.ctx = context.Background()
+	suite.Cnxn, err = suite.DB.Open(suite.ctx)
+	suite.Require().NoError(err)
+	suite.Stmt, err = suite.Cnxn.NewStatement()
+	suite.Require().NoError(err)
+}
+
+func (suite *StatementTests) TearDownTest() {
+	suite.Require().NoError(suite.Stmt.Close())
+	suite.Require().NoError(suite.Cnxn.Close())
+	suite.Quirks.TearDownDriver(suite.T(), suite.Driver)
+	suite.Cnxn = nil
+	suite.DB = nil
+	suite.Driver = nil
+}
+
+func (suite *StatementTests) TestQueueSizeOption() {
+	var err error
+	option := "arrow.flight.sql.rpc.queue_size"
+
+	err = suite.Stmt.SetOption(option, "")
+	suite.Require().ErrorContains(err, "Invalid value for statement option 'arrow.flight.sql.rpc.queue_size': '' is not a positive integer")
+
+	err = suite.Stmt.SetOption(option, "foo")
+	suite.Require().ErrorContains(err, "Invalid value for statement option 'arrow.flight.sql.rpc.queue_size': 'foo' is not a positive integer")
+
+	err = suite.Stmt.SetOption(option, "-1")
+	suite.Require().ErrorContains(err, "Invalid value for statement option 'arrow.flight.sql.rpc.queue_size': '-1' is not a positive integer")
+
+	err = suite.Stmt.SetOption(option, "1")
+	suite.Require().NoError(err)
+}
+
+func (suite *StatementTests) TestUnknownOption() {
+	err := suite.Stmt.SetOption("unknown option", "")
+	suite.Require().ErrorContains(err, "Unknown statement option 'unknown option'")
+}

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -75,9 +75,11 @@ func (s *statement) Close() (err error) {
 
 // SetOption sets a string option on this statement
 func (s *statement) SetOption(key string, val string) error {
-	switch {
-	case key == OptionStatementQueueSize:
-		if size, err := strconv.Atoi(val); err != nil {
+	switch key {
+	case OptionStatementQueueSize:
+		var err error
+		var size int
+		if size, err = strconv.Atoi(val); err != nil {
 			return adbc.Error{
 				Msg:  fmt.Sprintf("Invalid value for statement option '%s': '%s' is not a positive integer", OptionStatementQueueSize, val),
 				Code: adbc.StatusInvalidArgument,
@@ -87,9 +89,8 @@ func (s *statement) SetOption(key string, val string) error {
 				Msg:  fmt.Sprintf("Invalid value for statement option '%s': '%s' is not a positive integer", OptionStatementQueueSize, val),
 				Code: adbc.StatusInvalidArgument,
 			}
-		} else {
-			s.queueSize = size
 		}
+		s.queueSize = size
 		return nil
 	default:
 		return adbc.Error{
@@ -139,11 +140,7 @@ func (s *statement) ExecuteQuery(ctx context.Context) (rdr array.RecordReader, n
 	}
 
 	nrec = info.TotalRecords
-	queueSize := 5
-	if s.queueSize > 0 {
-		queueSize = s.queueSize
-	}
-	rdr, err = newRecordReader(ctx, s.alloc, s.cl, info, s.clientCache, queueSize)
+	rdr, err = newRecordReader(ctx, s.alloc, s.cl, info, s.clientCache, s.queueSize)
 	return
 }
 

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -19,6 +19,8 @@ package flightsql
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow/go/v11/arrow"
@@ -30,13 +32,18 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+const (
+	OptionStatementQueueSize = "arrow.flight.sql.rpc.queue_size"
+)
+
 type statement struct {
 	alloc       memory.Allocator
 	cl          *flightsql.Client
 	clientCache gcache.Cache
 
-	query    string
-	prepared *flightsql.PreparedStatement
+	query     string
+	prepared  *flightsql.PreparedStatement
+	queueSize int
 }
 
 func (s *statement) closePreparedStatement() error {
@@ -68,9 +75,27 @@ func (s *statement) Close() (err error) {
 
 // SetOption sets a string option on this statement
 func (s *statement) SetOption(key string, val string) error {
-	return adbc.Error{
-		Msg:  "[FlightSQL Statement] SetOption not implemented",
-		Code: adbc.StatusNotImplemented,
+	switch {
+	case key == OptionStatementQueueSize:
+		if size, err := strconv.Atoi(val); err != nil {
+			return adbc.Error{
+				Msg:  fmt.Sprintf("Invalid value for statement option '%s': '%s' is not a positive integer", OptionStatementQueueSize, val),
+				Code: adbc.StatusInvalidArgument,
+			}
+		} else if size <= 0 {
+			return adbc.Error{
+				Msg:  fmt.Sprintf("Invalid value for statement option '%s': '%s' is not a positive integer", OptionStatementQueueSize, val),
+				Code: adbc.StatusInvalidArgument,
+			}
+		} else {
+			s.queueSize = size
+		}
+		return nil
+	default:
+		return adbc.Error{
+			Msg:  "[FlightSQL Statement] SetOption not implemented",
+			Code: adbc.StatusNotImplemented,
+		}
 	}
 }
 
@@ -114,7 +139,11 @@ func (s *statement) ExecuteQuery(ctx context.Context) (rdr array.RecordReader, n
 	}
 
 	nrec = info.TotalRecords
-	rdr, err = newRecordReader(ctx, s.alloc, s.cl, info, s.clientCache, 5)
+	queueSize := 5
+	if s.queueSize > 0 {
+		queueSize = s.queueSize
+	}
+	rdr, err = newRecordReader(ctx, s.alloc, s.cl, info, s.clientCache, queueSize)
 	return
 }
 

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -114,7 +114,7 @@ func (s *statement) ExecuteQuery(ctx context.Context) (rdr array.RecordReader, n
 	}
 
 	nrec = info.TotalRecords
-	rdr, err = newRecordReader(ctx, s.alloc, s.cl, info, s.clientCache)
+	rdr, err = newRecordReader(ctx, s.alloc, s.cl, info, s.clientCache, 5)
 	return
 }
 

--- a/go/adbc/driver/flightsql/record_reader.go
+++ b/go/adbc/driver/flightsql/record_reader.go
@@ -46,7 +46,6 @@ type reader struct {
 // gathers all of the records as they come in.
 func newRecordReader(ctx context.Context, alloc memory.Allocator, cl *flightsql.Client, info *flight.FlightInfo, clCache gcache.Cache) (rdr array.RecordReader, err error) {
 	endpoints := info.Endpoint
-	numEndpoints := len(endpoints)
 	var schema *arrow.Schema
 	if len(endpoints) == 0 {
 		if info.Schema == nil {
@@ -68,6 +67,8 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, cl *flightsql.
 	ch := make(chan arrow.Record, 5)
 	group, ctx := errgroup.WithContext(ctx)
 	ctx, cancelFn := context.WithCancel(ctx)
+	// We may mutate endpoints below
+	numEndpoints := len(endpoints)
 
 	if info.Schema != nil {
 		schema, err = flight.DeserializeSchema(info.Schema, alloc)

--- a/go/adbc/driver/flightsql/record_reader_test.go
+++ b/go/adbc/driver/flightsql/record_reader_test.go
@@ -19,7 +19,6 @@ package flightsql
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"testing"
 
@@ -91,7 +90,7 @@ type RecordReaderTests struct {
 	clCache gcache.Cache
 }
 
-func (suite *RecordReaderTests) SetupTest() {
+func (suite *RecordReaderTests) SetupSuite() {
 	suite.alloc = memory.NewCheckedAllocator(memory.DefaultAllocator)
 
 	suite.server = flight.NewServerWithMiddleware(nil)
@@ -100,8 +99,8 @@ func (suite *RecordReaderTests) SetupTest() {
 	suite.server.RegisterFlightService(svc)
 
 	go func() {
-		err := suite.server.Serve()
-		suite.NoError(err)
+		// Explicitly ignore error
+		_ = suite.server.Serve()
 	}()
 
 	var err error
@@ -114,8 +113,6 @@ func (suite *RecordReaderTests) SetupTest() {
 			if !ok {
 				return nil, adbc.Error{Code: adbc.StatusInternal}
 			}
-
-			fmt.Printf("Connecting to %s\n", uri)
 
 			cl, err := getFlightClientTest(context.Background(), uri)
 			if err != nil {
@@ -131,7 +128,7 @@ func (suite *RecordReaderTests) SetupTest() {
 		}).Build()
 }
 
-func (suite *RecordReaderTests) TearDownTest() {
+func (suite *RecordReaderTests) TearDownSuite() {
 	suite.cl.Close()
 	suite.clCache.Purge()
 	suite.server.Shutdown()

--- a/go/adbc/driver/flightsql/record_reader_test.go
+++ b/go/adbc/driver/flightsql/record_reader_test.go
@@ -143,7 +143,7 @@ func (suite *RecordReaderTests) TestNoEndpoints() {
 		Schema: flight.SerializeSchema(orderingSchema(), suite.alloc),
 	}
 
-	reader, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache)
+	reader, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache, 3)
 	suite.NoError(err)
 	defer reader.Release()
 
@@ -155,7 +155,7 @@ func (suite *RecordReaderTests) TestNoEndpoints() {
 func (suite *RecordReaderTests) TestNoEndpointsNoSchema() {
 	info := flight.FlightInfo{}
 
-	_, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache)
+	_, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache, 3)
 	suite.ErrorContains(err, "Server returned FlightInfo with no schema and no endpoints, cannot read stream")
 }
 
@@ -164,7 +164,7 @@ func (suite *RecordReaderTests) TestNoEndpointsInvalidSchema() {
 		Schema: []byte("f"),
 	}
 
-	_, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache)
+	_, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache, 3)
 	suite.ErrorContains(err, "Server returned FlightInfo with invalid schema and no endpoints, cannot read stream")
 }
 
@@ -179,7 +179,7 @@ func (suite *RecordReaderTests) TestNoSchema() {
 		},
 	}
 
-	reader, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache)
+	reader, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache, 3)
 	suite.NoError(err)
 	defer reader.Release()
 
@@ -217,7 +217,7 @@ func (suite *RecordReaderTests) TestOrdering() {
 		},
 	}
 
-	reader, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache)
+	reader, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache, 3)
 	suite.NoError(err)
 	defer reader.Release()
 

--- a/go/adbc/driver/flightsql/record_reader_test.go
+++ b/go/adbc/driver/flightsql/record_reader_test.go
@@ -1,0 +1,247 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package flightsql
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow/go/v11/arrow"
+	"github.com/apache/arrow/go/v11/arrow/array"
+	"github.com/apache/arrow/go/v11/arrow/flight"
+	"github.com/apache/arrow/go/v11/arrow/flight/flightsql"
+	"github.com/apache/arrow/go/v11/arrow/ipc"
+	"github.com/apache/arrow/go/v11/arrow/memory"
+	"github.com/bluele/gcache"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func orderingSchema() *arrow.Schema {
+	return arrow.NewSchema([]arrow.Field{
+		{Name: "epIndex", Type: arrow.PrimitiveTypes.Int8},
+		{Name: "batchIndex", Type: arrow.PrimitiveTypes.Int8},
+	}, nil)
+}
+
+type testFlightService struct {
+	flight.BaseFlightServer
+	alloc memory.Allocator
+}
+
+func (f *testFlightService) DoGet(request *flight.Ticket, stream flight.FlightService_DoGetServer) error {
+	schema := orderingSchema()
+	wr := flight.NewRecordWriter(stream, ipc.WithSchema(schema))
+	defer wr.Close()
+
+	builder := array.NewRecordBuilder(f.alloc, schema)
+	defer builder.Release()
+
+	epIndex := builder.Field(0).(*array.Int8Builder)
+	batchIndex := builder.Field(1).(*array.Int8Builder)
+
+	for idx := int8(0); idx < 4; idx++ {
+		epIndex.Append(int8(request.Ticket[0]))
+		batchIndex.Append(idx)
+
+		rec := builder.NewRecord()
+		defer rec.Release()
+		if err := wr.Write(rec); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getFlightClientTest(ctx context.Context, loc string) (*flightsql.Client, error) {
+	uri, err := url.Parse(loc)
+	if err != nil {
+		return nil, err
+	}
+
+	return flightsql.NewClient(uri.Host, nil, nil, grpc.WithTransportCredentials(insecure.NewCredentials()))
+}
+
+type RecordReaderTests struct {
+	suite.Suite
+
+	alloc   *memory.CheckedAllocator
+	server  flight.Server
+	cl      *flightsql.Client
+	clCache gcache.Cache
+}
+
+func (suite *RecordReaderTests) SetupTest() {
+	suite.alloc = memory.NewCheckedAllocator(memory.DefaultAllocator)
+
+	suite.server = flight.NewServerWithMiddleware(nil)
+	suite.NoError(suite.server.Init("localhost:0"))
+	svc := &testFlightService{alloc: suite.alloc}
+	suite.server.RegisterFlightService(svc)
+
+	go func() {
+		err := suite.server.Serve()
+		suite.NoError(err)
+	}()
+
+	var err error
+	suite.cl, err = flightsql.NewClient(suite.server.Addr().String(), nil, nil, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	suite.NoError(err)
+
+	suite.clCache = gcache.New(20).LRU().
+		LoaderFunc(func(loc interface{}) (interface{}, error) {
+			uri, ok := loc.(string)
+			if !ok {
+				return nil, adbc.Error{Code: adbc.StatusInternal}
+			}
+
+			fmt.Printf("Connecting to %s\n", uri)
+
+			cl, err := getFlightClientTest(context.Background(), uri)
+			if err != nil {
+				return nil, err
+			}
+
+			cl.Alloc = suite.alloc
+			return cl, nil
+		}).
+		EvictedFunc(func(_, client interface{}) {
+			conn := client.(*flightsql.Client)
+			conn.Close()
+		}).Build()
+}
+
+func (suite *RecordReaderTests) TearDownTest() {
+	suite.cl.Close()
+	suite.clCache.Purge()
+	suite.server.Shutdown()
+	suite.alloc.AssertSize(suite.T(), 0)
+}
+
+func (suite *RecordReaderTests) TestNoEndpoints() {
+	info := flight.FlightInfo{
+		Schema: flight.SerializeSchema(orderingSchema(), suite.alloc),
+	}
+
+	reader, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache)
+	suite.NoError(err)
+	defer reader.Release()
+
+	suite.True(reader.Schema().Equal(orderingSchema()))
+	suite.False(reader.Next())
+	suite.NoError(reader.Err())
+}
+
+func (suite *RecordReaderTests) TestNoEndpointsNoSchema() {
+	info := flight.FlightInfo{}
+
+	_, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache)
+	suite.ErrorContains(err, "Server returned FlightInfo with no schema and no endpoints, cannot read stream")
+}
+
+func (suite *RecordReaderTests) TestNoEndpointsInvalidSchema() {
+	info := flight.FlightInfo{
+		Schema: []byte("f"),
+	}
+
+	_, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache)
+	suite.ErrorContains(err, "Server returned FlightInfo with invalid schema and no endpoints, cannot read stream")
+}
+
+func (suite *RecordReaderTests) TestNoSchema() {
+	location := "grpc://" + suite.server.Addr().String()
+	info := flight.FlightInfo{
+		Endpoint: []*flight.FlightEndpoint{
+			{
+				Ticket:   &flight.Ticket{Ticket: []byte{0}},
+				Location: []*flight.Location{{Uri: location}},
+			},
+		},
+	}
+
+	reader, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache)
+	suite.NoError(err)
+	defer reader.Release()
+
+	suite.True(reader.Schema().Equal(orderingSchema()))
+	suite.True(reader.Next())
+	suite.True(reader.Next())
+	suite.True(reader.Next())
+	suite.True(reader.Next())
+	suite.False(reader.Next())
+	suite.NoError(reader.Err())
+}
+
+func (suite *RecordReaderTests) TestOrdering() {
+	// Info with a ton of endpoints; we want to make sure data comes back in order
+	location := "grpc://" + suite.server.Addr().String()
+	info := flight.FlightInfo{
+		Schema: flight.SerializeSchema(orderingSchema(), suite.alloc),
+		Endpoint: []*flight.FlightEndpoint{
+			{
+				Ticket:   &flight.Ticket{Ticket: []byte{0}},
+				Location: []*flight.Location{{Uri: location}},
+			},
+			{
+				Ticket:   &flight.Ticket{Ticket: []byte{1}},
+				Location: []*flight.Location{{Uri: location}},
+			},
+			{
+				Ticket:   &flight.Ticket{Ticket: []byte{2}},
+				Location: []*flight.Location{{Uri: location}},
+			},
+			{
+				Ticket:   &flight.Ticket{Ticket: []byte{3}},
+				Location: []*flight.Location{{Uri: location}},
+			},
+		},
+	}
+
+	reader, err := newRecordReader(context.Background(), suite.alloc, suite.cl, &info, suite.clCache)
+	suite.NoError(err)
+	defer reader.Release()
+
+	for epIdx := int8(0); epIdx < 4; epIdx++ {
+		for batchIdx := int8(0); batchIdx < 4; batchIdx++ {
+			suite.True(reader.Next())
+			rec := reader.Record()
+			defer rec.Release()
+
+			suite.True(rec.Schema().Equal(orderingSchema()))
+			suite.Equal(int64(1), rec.NumRows())
+
+			epIndices := rec.Column(0).(*array.Int8)
+			batchIndices := rec.Column(1).(*array.Int8)
+			suite.True(epIndices.IsValid(0))
+			suite.True(batchIndices.IsValid(0))
+			suite.Equal(epIdx, epIndices.Value(0))
+			suite.Equal(batchIdx, batchIndices.Value(0))
+		}
+	}
+	suite.False(reader.Next())
+	suite.NoError(reader.Err())
+}
+
+func TestRecordReader(t *testing.T) {
+	suite.Run(t, &RecordReaderTests{})
+}


### PR DESCRIPTION
Assume data may be ordered in absence of an explicit server-sent indicator.

Fixes #385.