### PR TITLE
feat(go/sqldriver): implement database/sql/driver.RowsColumnTypeDatabaseTypeName

### DIFF
--- a/go/adbc/sqldriver/driver.go
+++ b/go/adbc/sqldriver/driver.go
@@ -656,6 +656,10 @@ func (r *rows) Next(dest []driver.Value) error {
 	return nil
 }
 
+func (r *rows) ColumnTypeDatabaseTypeName(index int) string {
+	return r.rdr.Schema().Field(index).Type.String()
+}
+
 func (r *rows) ColumnTypeNullable(index int) (nullable, ok bool) {
 	return r.rdr.Schema().Field(index).Nullable, true
 }

--- a/go/adbc/sqldriver/driver_internals_test.go
+++ b/go/adbc/sqldriver/driver_internals_test.go
@@ -225,12 +225,12 @@ func TestNextRowTypes(t *testing.T) {
 				require.NoError(t, err)
 				b.(*array.Time64Builder).Append(time64)
 			},
-			golangValue: time.Date(1970, time.January, 1, testTime.Hour(), testTime.Minute(), testTime.Second(), testTime.Nanosecond(), time.UTC),      
+			golangValue: time.Date(1970, time.January, 1, testTime.Hour(), testTime.Minute(), testTime.Second(), testTime.Nanosecond(), time.UTC),
 		},
 	}
 
 	for i, test := range tests {
-    t.Run(fmt.Sprintf("%d-%s", i, test.arrowType.String()), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d-%s", i, test.arrowType.String()), func(t *testing.T) {
 			schema := arrow.NewSchema([]arrow.Field{{Type: test.arrowType}}, nil)
 			recordBuilder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
 			t.Cleanup(recordBuilder.Release)
@@ -244,6 +244,6 @@ func TestNextRowTypes(t *testing.T) {
 			assert.NoError(t, err)
 			assert.IsType(t, test.golangValue, dest[0])
 			assert.Equal(t, test.golangValue, dest[0])
-    })
+		})
 	}
 }

--- a/go/adbc/sqldriver/driver_internals_test.go
+++ b/go/adbc/sqldriver/driver_internals_test.go
@@ -65,58 +65,58 @@ func TestParseConnectStr(t *testing.T) {
 
 func TestColumnTypeDatabaseTypeName(t *testing.T) {
 	tests := []struct {
-		field  arrow.Field
-		dtName string
+		typ      arrow.DataType
+		typeName string
 	}{
 		{
-			field:  arrow.Field{Type: &arrow.StringType{}},
-			dtName: "utf8",
+			typ:      &arrow.StringType{},
+			typeName: "utf8",
 		},
 		{
-			field:  arrow.Field{Type: &arrow.Date32Type{}},
-			dtName: "date32",
+			typ:      &arrow.Date32Type{},
+			typeName: "date32",
 		},
 		{
-			field:  arrow.Field{Type: &arrow.Date64Type{}},
-			dtName: "date64",
+			typ:      &arrow.Date64Type{},
+			typeName: "date64",
 		},
 		{
-			field:  arrow.Field{Type: &arrow.TimestampType{Unit: arrow.Second, TimeZone: "utc"}},
-			dtName: "timestamp[s, tz=utc]",
+			typ:      &arrow.TimestampType{Unit: arrow.Second, TimeZone: "utc"},
+			typeName: "timestamp[s, tz=utc]",
 		},
 		{
-			field:  arrow.Field{Type: &arrow.TimestampType{Unit: arrow.Millisecond}},
-			dtName: "timestamp[ms]",
+			typ:      &arrow.TimestampType{Unit: arrow.Millisecond},
+			typeName: "timestamp[ms]",
 		},
 		{
-			field:  arrow.Field{Type: &arrow.Time32Type{Unit: arrow.Second}},
-			dtName: "time32[s]",
+			typ:      &arrow.Time32Type{Unit: arrow.Second},
+			typeName: "time32[s]",
 		},
 		{
-			field:  arrow.Field{Type: &arrow.Time32Type{Unit: arrow.Microsecond}},
-			dtName: "time32[us]",
+			typ:      &arrow.Time32Type{Unit: arrow.Microsecond},
+			typeName: "time32[us]",
 		},
 		{
-			field:  arrow.Field{Type: &arrow.Time64Type{Unit: arrow.Second}},
-			dtName: "time64[s]",
+			typ:      &arrow.Time64Type{Unit: arrow.Second},
+			typeName: "time64[s]",
 		},
 		{
-			field:  arrow.Field{Type: &arrow.Time64Type{Unit: arrow.Nanosecond}},
-			dtName: "time64[ns]",
+			typ:      &arrow.Time64Type{Unit: arrow.Nanosecond},
+			typeName: "time64[ns]",
 		},
 		{
-			field:  arrow.Field{Type: &arrow.DurationType{Unit: arrow.Nanosecond}},
-			dtName: "duration[ns]",
+			typ:      &arrow.DurationType{Unit: arrow.Nanosecond},
+			typeName: "duration[ns]",
 		},
 	}
 
 	for i, test := range tests {
-		t.Run(fmt.Sprintf("%d-%s", i, test.dtName), func(t *testing.T) {
-			schema := arrow.NewSchema([]arrow.Field{test.field}, nil)
+		t.Run(fmt.Sprintf("%d-%s", i, test.typeName), func(t *testing.T) {
+			schema := arrow.NewSchema([]arrow.Field{{Type: test.typ}}, nil)
 			reader, err := array.NewRecordReader(schema, nil)
 			require.NoError(t, err)
 			r := &rows{rdr: reader}
-			assert.Equal(t, test.dtName, r.ColumnTypeDatabaseTypeName(0))
+			assert.Equal(t, test.typeName, r.ColumnTypeDatabaseTypeName(0))
 		})
 	}
 }


### PR DESCRIPTION
Helps #391 

Expose the Arrow type names via `database/sql.ColumnType.DatabaseTypeName()` by implementing `database/sql/driver.RowsColumnTypeDatabaseTypeName` with `arrow.DataType.String()`. This method allows the consumer to infer, for example, the time unit of an `arrow.Timestamp` column.