### PR TITLE
fix(ci): don't fail Anaconda upload when packages already exist

### DIFF
--- a/ci/scripts/python_conda_upload.sh
+++ b/ci/scripts/python_conda_upload.sh
@@ -26,6 +26,7 @@ set -x
 main() {
     anaconda -t "${ANACONDA_API_TOKEN}" \
              upload \
+             --skip-existing \
              --user "${CHANNEL}" \
              "$@"
 }


### PR DESCRIPTION
Fixes #397.