### PR TITLE
fix(go/adbc/driver/flightsql): guard against inconsistent schemas

### DIFF
--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -392,7 +392,7 @@ jobs:
           cache: true
           cache-dependency-path: go/adbc/go.sum
       - name: Install staticcheck
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
       - name: Go Build
         run: |
           ./ci/scripts/go_build.sh "$(pwd)" "$(pwd)/build" "$HOME/local"
@@ -450,7 +450,7 @@ jobs:
       - name: Install staticcheck
         shell: bash -l {0}
         if: ${{ !contains('macos-latest', matrix.os) }}
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+        run: go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
 
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
In case the FlightInfo schema doesn't match the DoGet schema, return an error instead of allowing the client to misinterpret the result.