### PR TITLE
fix(format): clarify const-ness of some pointers

### DIFF
--- a/adbc.h
+++ b/adbc.h
@@ -624,7 +624,7 @@ struct ADBC_EXPORT AdbcDriver {
   AdbcStatusCode (*DatabaseRelease)(struct AdbcDatabase*, struct AdbcError*);
 
   AdbcStatusCode (*ConnectionCommit)(struct AdbcConnection*, struct AdbcError*);
-  AdbcStatusCode (*ConnectionGetInfo)(struct AdbcConnection*, uint32_t*, size_t,
+  AdbcStatusCode (*ConnectionGetInfo)(struct AdbcConnection*, const uint32_t*, size_t,
                                       struct ArrowArrayStream*, struct AdbcError*);
   AdbcStatusCode (*ConnectionGetObjects)(struct AdbcConnection*, int, const char*,
                                          const char*, const char*, const char**,
@@ -796,7 +796,7 @@ AdbcStatusCode AdbcConnectionRelease(struct AdbcConnection* connection,
 /// \param[out] error Error details, if an error occurs.
 ADBC_EXPORT
 AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
-                                     uint32_t* info_codes, size_t info_codes_length,
+                                     const uint32_t* info_codes, size_t info_codes_length,
                                      struct ArrowArrayStream* out,
                                      struct AdbcError* error);
 

--- a/c/driver/postgresql/postgresql.cc
+++ b/c/driver/postgresql/postgresql.cc
@@ -123,7 +123,8 @@ AdbcStatusCode PostgresConnectionCommit(struct AdbcConnection* connection,
 }
 
 AdbcStatusCode PostgresConnectionGetInfo(struct AdbcConnection* connection,
-                                         uint32_t* info_codes, size_t info_codes_length,
+                                         const uint32_t* info_codes,
+                                         size_t info_codes_length,
                                          struct ArrowArrayStream* stream,
                                          struct AdbcError* error) {
   return ADBC_STATUS_NOT_IMPLEMENTED;
@@ -211,7 +212,7 @@ AdbcStatusCode AdbcConnectionCommit(struct AdbcConnection* connection,
 }
 
 AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
-                                     uint32_t* info_codes, size_t info_codes_length,
+                                     const uint32_t* info_codes, size_t info_codes_length,
                                      struct ArrowArrayStream* stream,
                                      struct AdbcError* error) {
   return PostgresConnectionGetInfo(connection, info_codes, info_codes_length, stream,

--- a/c/driver/sqlite/sqlite.c
+++ b/c/driver/sqlite/sqlite.c
@@ -348,7 +348,8 @@ AdbcStatusCode SqliteConnectionGetInfoImpl(const uint32_t* info_codes,
 }  // NOLINT(whitespace/indent)
 
 AdbcStatusCode SqliteConnectionGetInfo(struct AdbcConnection* connection,
-                                       uint32_t* info_codes, size_t info_codes_length,
+                                       const uint32_t* info_codes,
+                                       size_t info_codes_length,
                                        struct ArrowArrayStream* out,
                                        struct AdbcError* error) {
   CHECK_CONN_INIT(connection, error);
@@ -1600,7 +1601,7 @@ AdbcStatusCode AdbcConnectionRelease(struct AdbcConnection* connection,
 }
 
 AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
-                                     uint32_t* info_codes, size_t info_codes_length,
+                                     const uint32_t* info_codes, size_t info_codes_length,
                                      struct ArrowArrayStream* out,
                                      struct AdbcError* error) {
   return SqliteConnectionGetInfo(connection, info_codes, info_codes_length, out, error);

--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -138,7 +138,7 @@ AdbcStatusCode ConnectionCommit(struct AdbcConnection*, struct AdbcError* error)
   return ADBC_STATUS_NOT_IMPLEMENTED;
 }
 
-AdbcStatusCode ConnectionGetInfo(struct AdbcConnection* connection, uint32_t* info_codes,
+AdbcStatusCode ConnectionGetInfo(struct AdbcConnection* connection, const uint32_t* info_codes,
                                  size_t info_codes_length, struct ArrowArrayStream* out,
                                  struct AdbcError* error) {
   return ADBC_STATUS_NOT_IMPLEMENTED;
@@ -365,7 +365,7 @@ AdbcStatusCode AdbcConnectionCommit(struct AdbcConnection* connection,
 }
 
 AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
-                                     uint32_t* info_codes, size_t info_codes_length,
+                                     const uint32_t* info_codes, size_t info_codes_length,
                                      struct ArrowArrayStream* out,
                                      struct AdbcError* error) {
   if (!connection->private_driver) {

--- a/go/adbc/pkg/_tmpl/utils.h.tmpl
+++ b/go/adbc/pkg/_tmpl/utils.h.tmpl
@@ -32,7 +32,7 @@ AdbcStatusCode {{.Prefix}}ConnectionNew(struct AdbcConnection* cnxn, struct Adbc
 AdbcStatusCode {{.Prefix}}ConnectionSetOption(struct AdbcConnection* cnxn, const char* key, const char* val, struct AdbcError* err);
 AdbcStatusCode {{.Prefix}}ConnectionInit(struct AdbcConnection* cnxn, struct AdbcDatabase* db, struct AdbcError* err);
 AdbcStatusCode {{.Prefix}}ConnectionRelease(struct AdbcConnection* cnxn, struct AdbcError* err);
-AdbcStatusCode {{.Prefix}}ConnectionGetInfo(struct AdbcConnection* cnxn, uint32_t* codes, size_t len, struct ArrowArrayStream* out, struct AdbcError* err);
+AdbcStatusCode {{.Prefix}}ConnectionGetInfo(struct AdbcConnection* cnxn, const uint32_t* codes, size_t len, struct ArrowArrayStream* out, struct AdbcError* err);
 AdbcStatusCode {{.Prefix}}ConnectionGetObjects(struct AdbcConnection* cnxn, int depth, const char* catalog, const char* dbSchema, const char* tableName, const char** tableType, const char* columnName, struct ArrowArrayStream* out, struct AdbcError* err);
 AdbcStatusCode {{.Prefix}}ConnectionGetTableSchema(struct AdbcConnection* cnxn, const char* catalog, const char* dbSchema, const char* tableName, struct ArrowSchema* schema, struct AdbcError* err);
 AdbcStatusCode {{.Prefix}}ConnectionGetTableTypes(struct AdbcConnection* cnxn, struct ArrowArrayStream* out, struct AdbcError* err);

--- a/go/adbc/pkg/flightsql/utils.c
+++ b/go/adbc/pkg/flightsql/utils.c
@@ -73,7 +73,7 @@ AdbcStatusCode AdbcConnectionRelease(struct AdbcConnection* connection,
 }
 
 AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
-                                     uint32_t* info_codes, size_t info_codes_length,
+                                     const uint32_t* info_codes, size_t info_codes_length,
                                      struct ArrowArrayStream* out,
                                      struct AdbcError* error) {
   return FlightSQLConnectionGetInfo(connection, info_codes, info_codes_length, out,

--- a/go/adbc/pkg/flightsql/utils.h
+++ b/go/adbc/pkg/flightsql/utils.h
@@ -38,7 +38,7 @@ AdbcStatusCode FlightSQLConnectionInit(struct AdbcConnection* cnxn,
                                        struct AdbcDatabase* db, struct AdbcError* err);
 AdbcStatusCode FlightSQLConnectionRelease(struct AdbcConnection* cnxn,
                                           struct AdbcError* err);
-AdbcStatusCode FlightSQLConnectionGetInfo(struct AdbcConnection* cnxn, uint32_t* codes,
+AdbcStatusCode FlightSQLConnectionGetInfo(struct AdbcConnection* cnxn, const uint32_t* codes,
                                           size_t len, struct ArrowArrayStream* out,
                                           struct AdbcError* err);
 AdbcStatusCode FlightSQLConnectionGetObjects(

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -140,7 +140,7 @@ cdef extern from "adbc.h" nogil:
         CAdbcError* error)
     CAdbcStatusCode AdbcConnectionGetInfo(
         CAdbcConnection* connection,
-        uint32_t* info_codes,
+        const uint32_t* info_codes,
         size_t info_codes_length,
         CArrowArrayStream* stream,
         CAdbcError* error)


### PR DESCRIPTION
While working on the Rust bindings I noticed there were some pointers in the ADBC functions parameters that seems like they should have been `const`. The current proposed Rust API includes these changes in the FFI, so wondering if some or all of these changes are welcome, or if I need to do a bit of redesign in the Rust implementation.