### PR TITLE
chore(ci): update bookworm Dockerfile

### DIFF
--- a/ci/linux-packages/apt/debian-bookworm/Dockerfile
+++ b/ci/linux-packages/apt/debian-bookworm/Dockerfile
@@ -26,7 +26,7 @@ RUN \
   echo 'APT::Install-Recommends "false";' > \
     /etc/apt/apt.conf.d/disable-install-recommends
 
-RUN sed -i'' -e 's/main$/main contrib non-free/g' /etc/apt/sources.list
+RUN sed -i'' -e 's/main$/main contrib non-free/g' /etc/apt/sources.list.d/debian.sources
 
 ARG DEBUG
 RUN \

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -64,6 +64,12 @@ case "${TYPE}" in
 esac
 
 case "${distribution}-${code_name}" in
+  debian-bookworm)
+    sed \
+      -i"" \
+      -e "s/ main$/ main contrib non-free/g" \
+      /etc/apt/sources.list.d/debian.sources
+    ;;
   debian-*)
     sed \
       -i"" \


### PR DESCRIPTION
Debian seems to have removed sources.list in favor of sources.list.d.

Fixes #420.