### PR TITLE
fix(r/adbcdrivermanager): Check that bootstrap.R exists before trying to run it

### DIFF
--- a/r/adbcdrivermanager/configure
+++ b/r/adbcdrivermanager/configure
@@ -19,8 +19,11 @@
 # package built with pkgbuild::build() with pkgbuild >1.4.0; however, we
 # run it again in case this is R CMD INSTALL on a directory or
 # devtools::load_all(). This will vendor files from elsewhere in the
-# ADBC repo into this package.
-$R_HOME/bin/Rscript bootstrap.R
+# ADBC repo into this package. If the file doesn't exist, we're installing
+# from a pre-built tarball.
+if [ -f bootstrap.R ]; then
+  $R_HOME/bin/Rscript bootstrap.R
+fi
 
 if [ -f "src/adbc.h" ] && [ -f "src/adbc_driver_manager.h" ] && [ -f "src/adbc_driver_manager.cc" ]; then
   echo "Found vendored ADBC"


### PR DESCRIPTION
After trying the install instructions for the R driver manager added in #365, we get rather scary message (although the install works just fine):

```
* installing *source* package ‘adbcdrivermanager’ ...
** using staged installation
Fatal error: cannot open file 'bootstrap.R': No such file or directory
Fetched ADBC from https://github.com/apache/arrow-adbc
** libs
```

This happens because bootstrap.R is in `.Rbuildignore`, so it doesn't end up in the built tarball. It's referenced from `configure` though (for when somebody is installing from the source directory, not a built tarball). This PR just adds a check for the file before attempting to run it.