### PR TITLE
feat(golang/sqldriver): add simple FlightSQL database/sql driver wrapper

### DIFF
--- a/go/adbc/sqldriver/doc.go
+++ b/go/adbc/sqldriver/doc.go
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package sqldriver is a wrapper around the ADBC (Arrow Database
+// Connectivity) interfaces to support the standard golang database/sql
+// package, described here: https://go.dev/src/database/sql/doc.txt
+//
+// This allows any ADBC driver implementation to also be used as-is
+// with the database/sql package of the standard library rather than
+// having to implement drivers for both separately.
+//
+// Registering the driver can be done by importing this and then running
+//
+//	sql.Register("drivername", sqldriver.Driver{adbcdriver})
+//
+// Additionally, the sqldriver/flightsql package simplifies registration
+// of the FlightSQL ADBC driver implementation, so that only a single
+// import statement is needed. See the example in that package.
+//
+// EXPERIMENTAL. The ADBC interfaces are subject to change and as such
+// this wrapper is also subject to change based on that.
+package sqldriver

--- a/go/adbc/sqldriver/driver.go
+++ b/go/adbc/sqldriver/driver.go
@@ -15,20 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Package sqldriver is a wrapper around the ADBC (Arrow Database
-// Connectivity) interfaces to support the standard golang database/sql
-// package.
-//
-// This allows any ADBC driver implementation to also be used as-is
-// with the database/sql package of the standard library rather than
-// having to implement drivers for both separately.
-//
-// Registering the driver can be done by importing this and then running
-//
-// 		sql.Register("drivername", sqldriver.Driver{adbcdriver})
-//
-// EXPERIMENTAL. The ADBC interfaces are subject to change and as such
-// this wrapper is also subject to change based on that.
 package sqldriver
 
 import (

--- a/go/adbc/sqldriver/driver.go
+++ b/go/adbc/sqldriver/driver.go
@@ -253,6 +253,11 @@ func (c *conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, e
 		return nil, err
 	}
 
+	if err := s.Prepare(ctx); err != nil {
+		s.Close()
+		return nil, err
+	}
+
 	paramSchema, err := s.GetParameterSchema()
 	var adbcErr adbc.Error
 	if errors.As(err, &adbcErr) {

--- a/go/adbc/sqldriver/flightsql/README.md
+++ b/go/adbc/sqldriver/flightsql/README.md
@@ -1,3 +1,22 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
 # flightsql - A FlightSQL driver for the database/sql package
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/apache/arrow-adbc/go/adbc/sqldriver/flightsql.svg)](https://pkg.go.dev/github.com/apache/arrow-adbc/go/adbc/sqldriver/flightsql)

--- a/go/adbc/sqldriver/flightsql/README.md
+++ b/go/adbc/sqldriver/flightsql/README.md
@@ -1,0 +1,42 @@
+# flightsql - A FlightSQL driver for the database/sql package
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/apache/arrow-adbc/go/adbc/sqldriver/flightsql.svg)](https://pkg.go.dev/github.com/apache/arrow-adbc/go/adbc/sqldriver/flightsql)
+
+Golang database/sql driver for [FlightSQL](https://arrow.apache.org/docs/format/FlightSql.html).
+
+> Arrow Flight SQL is a protocol for interacting with SQL databases using
+> the Arrow in-memory format and the Flight RPC framework.
+
+## Technical Details
+
+This package is a thin wrapper over the
+[ADBC database/sql driver wrapper](https://pkg.go.dev/github.com/apache/arrow-adbc/go/adbc/sqldriver),
+which is itself database/sql wrapper driver for any
+[ADBC](https://arrow.apache.org/docs/format/ADBC.html) driver.
+
+This package simply registers the
+[FlightSQL ADBC driver](https://pkg.go.dev/github.com/apache/arrow-adbc/go/adbc/driver/flightsql)
+with the database/sql package.
+Understanding ADBC is not necessary to use this driver.
+
+## Example
+
+```golang
+package main
+
+import (
+	"database/sql"
+	_ "github.com/apache/arrow-adbc/go/adbc/sqldriver/flightsql"
+)
+
+func main() {
+	db, err := sql.Open("flightsql", "uri=grpc://localhost:12345")
+	if err != nil {
+		panic(err)
+	}
+
+	if err = db.Ping(); err != nil {
+		panic(err)
+	}
+}
+```

--- a/go/adbc/sqldriver/flightsql/flightsql.go
+++ b/go/adbc/sqldriver/flightsql/flightsql.go
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package flightsql
+
+import (
+	"database/sql"
+	"github.com/apache/arrow-adbc/go/adbc/driver/flightsql"
+	"github.com/apache/arrow-adbc/go/adbc/sqldriver"
+)
+
+func init() {
+	sql.Register("flightsql", sqldriver.Driver{
+		Driver: flightsql.Driver{},
+	})
+}

--- a/go/adbc/sqldriver/flightsql/flightsql_test.go
+++ b/go/adbc/sqldriver/flightsql/flightsql_test.go
@@ -18,8 +18,19 @@
 package flightsql_test
 
 import (
+	"context"
 	"database/sql"
 	_ "github.com/apache/arrow-adbc/go/adbc/sqldriver/flightsql"
+	"github.com/apache/arrow/go/v12/arrow/flight"
+	"github.com/apache/arrow/go/v12/arrow/flight/flightsql"
+	"github.com/apache/arrow/go/v12/arrow/flight/flightsql/example"
+	"github.com/apache/arrow/go/v12/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+	"os"
+	"testing"
 )
 
 func Example() {
@@ -31,5 +42,100 @@ func Example() {
 		panic(err)
 	}
 
-	_ = db.Ping()
+	if err = db.Ping(); err != nil {
+		panic(err)
+	}
+}
+
+type SQLDriverFlightSQLSuite struct {
+	suite.Suite
+
+	srv      *example.SQLiteFlightSQLServer
+	s        flight.Server
+	opts     []grpc.ServerOption
+	sqliteDB *sql.DB
+
+	done chan bool
+	mem  *memory.CheckedAllocator
+}
+
+func (suite *SQLDriverFlightSQLSuite) SetupTest() {
+	var err error
+
+	suite.sqliteDB, err = example.CreateDB()
+	require.NoError(suite.T(), err)
+
+	suite.mem = memory.NewCheckedAllocator(memory.DefaultAllocator)
+	suite.s = flight.NewServerWithMiddleware(nil, suite.opts...)
+	require.NoError(suite.T(), err)
+	suite.srv, err = example.NewSQLiteFlightSQLServer(suite.sqliteDB)
+	require.NoError(suite.T(), err)
+	suite.srv.Alloc = suite.mem
+
+	suite.s.RegisterFlightService(flightsql.NewFlightServer(suite.srv))
+	require.NoError(suite.T(), suite.s.Init("localhost:0"))
+	suite.s.SetShutdownOnSignals(os.Interrupt, os.Kill)
+	suite.done = make(chan bool)
+	go func() {
+		defer close(suite.done)
+		_ = suite.s.Serve()
+	}()
+}
+
+func (suite *SQLDriverFlightSQLSuite) TearDownTest() {
+	if suite.done == nil {
+		return
+	}
+
+	suite.s.Shutdown()
+	<-suite.done
+	suite.srv = nil
+	suite.mem.AssertSize(suite.T(), 0)
+	_ = suite.sqliteDB.Close()
+	suite.done = nil
+}
+
+func (suite *SQLDriverFlightSQLSuite) dsn() string {
+	return "uri=grpc+tcp://" + suite.s.Addr().String()
+}
+
+type srvQuery string
+
+func (s srvQuery) GetQuery() string { return string(s) }
+
+func (s srvQuery) GetTransactionId() []byte { return nil }
+
+func (suite *SQLDriverFlightSQLSuite) TestQuery() {
+	db, err := sql.Open("flightsql", suite.dsn())
+	require.NoError(suite.T(), err)
+	defer db.Close()
+
+	_, err = suite.srv.DoPutCommandStatementUpdate(
+		context.Background(), srvQuery("CREATE TABLE t (k, v)"))
+	require.NoError(suite.T(), err)
+	_, err = suite.srv.DoPutCommandStatementUpdate(
+		context.Background(), srvQuery("INSERT INTO t (k, v) VALUES ('one', 'alpha'), ('two', 'bravo')"))
+	require.NoError(suite.T(), err)
+
+	// TODO db.Exec() fails:
+	// Received unexpected error:
+	// Invalid State: SqlState: , msg: [Flight SQL Statement] must call Prepare before GetParameterSchema
+	//
+	//_, err = db.Exec("CREATE TABLE t (k, v)")
+	//require.NoError(suite.T(), err)
+	//defer db.Exec("DROP TABLE IF EXISTS t")
+	//_, err = db.Exec("INSERT INTO t (k, v) VALUES ('one', 'alpha'), ('two', 'bravo')")
+	//require.NoError(suite.T(), err)
+
+	var expected int = 2
+	var actual int
+	row := db.QueryRow("SELECT count(*) FROM t")
+	err = row.Scan(&actual)
+	if assert.NoError(suite.T(), err) {
+		assert.Equal(suite.T(), expected, actual)
+	}
+}
+
+func TestSQLDriverFlightSQL(t *testing.T) {
+	suite.Run(t, new(SQLDriverFlightSQLSuite))
 }

--- a/go/adbc/sqldriver/flightsql/flightsql_test.go
+++ b/go/adbc/sqldriver/flightsql/flightsql_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/apache/arrow/go/v12/arrow/flight/flightsql"
 	"github.com/apache/arrow/go/v12/arrow/flight/flightsql/example"
 	"github.com/apache/arrow/go/v12/arrow/memory"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 )
@@ -62,17 +61,17 @@ func (suite *SQLDriverFlightSQLSuite) SetupTest() {
 	var err error
 
 	suite.sqliteDB, err = example.CreateDB()
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 
 	suite.mem = memory.NewCheckedAllocator(memory.DefaultAllocator)
 	suite.s = flight.NewServerWithMiddleware(nil, suite.opts...)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	suite.srv, err = example.NewSQLiteFlightSQLServer(suite.sqliteDB)
-	require.NoError(suite.T(), err)
+	suite.Require().NoError(err)
 	suite.srv.Alloc = suite.mem
 
 	suite.s.RegisterFlightService(flightsql.NewFlightServer(suite.srv))
-	require.NoError(suite.T(), suite.s.Init("localhost:0"))
+	suite.Require().NoError(suite.s.Init("localhost:0"))
 	suite.s.SetShutdownOnSignals(os.Interrupt, os.Kill)
 	suite.done = make(chan bool)
 	go func() {
@@ -105,7 +104,6 @@ func (suite *SQLDriverFlightSQLSuite) TestQuery() {
 
 	_, err = db.Exec("CREATE TABLE t (k, v)")
 	suite.Require().NoError(err)
-	defer db.Exec("DROP TABLE IF EXISTS t")
 	result, err := db.Exec("INSERT INTO t (k, v) VALUES ('one', 'alpha'), ('two', 'bravo')")
 	suite.Require().NoError(err)
 

--- a/go/adbc/sqldriver/flightsql/flightsql_test.go
+++ b/go/adbc/sqldriver/flightsql/flightsql_test.go
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package flightsql_test
+
+import (
+	"database/sql"
+	_ "github.com/apache/arrow-adbc/go/adbc/sqldriver/flightsql"
+)
+
+func Example() {
+	// Be sure to import the driver first:
+	// import _ "github.com/apache/arrow-adbc/go/adbc/sqldriver/flightsql"
+
+	db, err := sql.Open("flightsql", "uri=grpc://localhost:12345")
+	if err != nil {
+		panic(err)
+	}
+
+	_ = db.Ping()
+}


### PR DESCRIPTION
Helps https://github.com/apache/arrow/issues/34332

Golang/FlightSQL docs should be updated to point here for the canonical `database/sql` wrapper.