### PR TITLE
build(go/adbc/driver/flightsql): explicitly set -std=c++11

### DIFF
--- a/go/adbc/pkg/_tmpl/driver.go.tmpl
+++ b/go/adbc/pkg/_tmpl/driver.go.tmpl
@@ -19,6 +19,7 @@
 
 package main
 
+// #cgo CXXFLAGS: -std=c++11
 // #include "../../drivermgr/adbc.h"
 // #include "utils.h"
 // #include <stdint.h>

--- a/go/adbc/pkg/flightsql/driver.go
+++ b/go/adbc/pkg/flightsql/driver.go
@@ -21,6 +21,7 @@
 
 package main
 
+// #cgo CXXFLAGS: -std=c++11
 // #include "../../drivermgr/adbc.h"
 // #include "utils.h"
 // #include <stdint.h>


### PR DESCRIPTION
Fixes #455.