### PR TITLE
fix(java/driver/jdbc): close allocator on JDBC connection close

### DIFF
--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcConnection.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcConnection.java
@@ -254,6 +254,7 @@ public class JdbcConnection implements AdbcConnection {
   @Override
   public void close() throws Exception {
     connection.close();
+    allocator.close();
   }
 
   private void checkAutoCommit() throws AdbcException, SQLException {


### PR DESCRIPTION
Closes #476 

Call `allocator.close()` when JDBC connection is being closed.

@lidavidm 