### PR TITLE
feat(python/adbc_driver_manager): add __del__ for resources

### DIFF
--- a/python/adbc_driver_manager/tests/test_dbapi.py
+++ b/python/adbc_driver_manager/tests/test_dbapi.py
@@ -292,3 +292,20 @@ def test_executemany(sqlite):
         assert next(cur) == (3, 4)
         assert cur.rownumber == 2
         assert next(cur) == (5, 6)
+
+
+@pytest.mark.sqlite
+def test_close_warning(sqlite):
+    with pytest.warns(
+        ResourceWarning,
+        match=r"A adbc_driver_manager.dbapi.Cursor was not explicitly close\(\)d",
+    ):
+        cur = sqlite.cursor()
+        del cur
+
+    with pytest.warns(
+        ResourceWarning,
+        match=r"A adbc_driver_manager.dbapi.Connection was not explicitly close\(\)d",
+    ):
+        conn = dbapi.connect(driver="adbc_driver_sqlite")
+        del conn


### PR DESCRIPTION
This helps ensure we don't leak resources.  A warning will be raised when running under a 'test' environment to help developers catch issues.

Fixes #454.