### PR TITLE
chore(r): Drop references to nanoarrow R package on GitHub

### DIFF
--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -621,14 +621,14 @@ jobs:
       - name: Prepare sources (driver manager)
         if: matrix.config.pkg == 'adbcdrivermanager'
         run: |
-          R -e 'install.packages("remotes", repos = "https://cloud.r-project.org"); remotes::install_github("apache/arrow-nanoarrow/r", build = FALSE)'
+          R -e 'install.packages("nanoarrow", repos = "https://cloud.r-project.org")'
           R CMD INSTALL r/${{ matrix.config.pkg }}
         shell: bash
 
       - name: Prepare sources
         if: matrix.config.pkg != 'adbcdrivermanager'
         run: |
-          R -e 'install.packages("remotes", repos = "https://cloud.r-project.org"); remotes::install_github("apache/arrow-nanoarrow/r", build = FALSE)'
+          R -e 'install.packages("nanoarrow", repos = "https://cloud.r-project.org")'
           R CMD INSTALL r/adbcdrivermanager
           R CMD INSTALL r/${{ matrix.config.pkg }}
         shell: bash

--- a/r/adbcdrivermanager/DESCRIPTION
+++ b/r/adbcdrivermanager/DESCRIPTION
@@ -25,4 +25,3 @@ URL: https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports:
     nanoarrow
-Remotes: nanoarrow=apache/arrow-nanoarrow/r


### PR DESCRIPTION
Now that nanoarrow is on CRAN, we can use it like a regular dependency!