### PR TITLE
chore(r): Add R library verification to source verification script

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,6 +30,13 @@ on:
         required: false
         type: string
         default: ""
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/verify.yml'
+      - 'dev/release/verify-release-candidate.sh'
+      - 'dev/release/verify-release-candidate.ps1'
 
 permissions:
   contents: read
@@ -37,7 +44,6 @@ permissions:
 jobs:
   binary-unix:
     name: "Verify Binaries/${{ matrix.os }}"
-    if: inputs.version != '' && inputs.rc != ''
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/ci/conda_env_r.txt
+++ b/ci/conda_env_r.txt
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+compilers
+libsqlite
+libpq
+pkg-config
+r-testthat

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -469,6 +469,11 @@ test_python() {
 test_r() {
   show_header "Build and test R libraries"
 
+  maybe_setup_conda --file "${ADBC_SOURCE_DIR}/ci/conda_env_r.txt" || exit 1
+
+  R CMD INSTALL "${ADBC_SOURCE_DIR}/r/adbcdrivermanager"
+  R CMD INSTALL "${ADBC_SOURCE_DIR}/r/adbcsqlite"
+
   echo "Nothing to see here, folks!"
 }
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -470,7 +470,7 @@ test_r() {
   show_header "Build and test R libraries"
 
   maybe_setup_conda --file "${ADBC_SOURCE_DIR}/ci/conda_env_r.txt" || exit 1
-
+  R -e 'install.packages("nanoarrow", repos = "https://cloud.r-project.org/")'
   R CMD INSTALL "${ADBC_SOURCE_DIR}/r/adbcdrivermanager"
   R CMD INSTALL "${ADBC_SOURCE_DIR}/r/adbcsqlite"
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -466,6 +466,12 @@ test_python() {
   "${ADBC_SOURCE_DIR}/ci/scripts/python_test.sh" "${ADBC_SOURCE_DIR}" "${ARROW_TMPDIR}/python-build" "${install_prefix}"
 }
 
+test_r() {
+  show_header "Build and test R libraries"
+
+  echo "Nothing to see here, folks!"
+}
+
 test_glib() {
   show_header "Build and test C GLib libraries"
 
@@ -608,6 +614,9 @@ test_source_distribution() {
   fi
   if [ ${TEST_PYTHON} -gt 0 ]; then
     test_python
+  fi
+  if [ ${TEST_R} -gt 0 ]; then
+    test_r
   fi
 
   popd
@@ -759,9 +768,10 @@ test_jars() {
 : ${TEST_PYTHON:=${TEST_SOURCE}}
 : ${TEST_JS:=${TEST_SOURCE}}
 : ${TEST_GO:=${TEST_SOURCE}}
+: ${TEST_R:=${TEST_SOURCE}}
 
 # Automatically test if its activated by a dependent
-TEST_CPP=$((${TEST_CPP} + ${TEST_GO} + ${TEST_GLIB} + ${TEST_PYTHON}))
+TEST_CPP=$((${TEST_CPP} + ${TEST_GO} + ${TEST_GLIB} + ${TEST_PYTHON} + ${TEST_R}))
 
 # Execute tests in a conda enviroment
 : ${USE_CONDA:=0}

--- a/r/adbcdrivermanager/DESCRIPTION
+++ b/r/adbcdrivermanager/DESCRIPTION
@@ -17,7 +17,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 SystemRequirements: C++11
 Suggests:
-    arrow,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Config/build/bootstrap: TRUE

--- a/r/adbcdrivermanager/configure
+++ b/r/adbcdrivermanager/configure
@@ -22,7 +22,7 @@
 # ADBC repo into this package. If the file doesn't exist, we're installing
 # from a pre-built tarball.
 if [ -f bootstrap.R ]; then
-  $R_HOME/bin/Rscript bootstrap.R
+  $R_HOME/bin/Rscript bootstrap.R --vanilla
 fi
 
 if [ -f "src/adbc.h" ] && [ -f "src/adbc_driver_manager.h" ] && [ -f "src/adbc_driver_manager.cc" ]; then

--- a/r/adbcsqlite/.Rbuildignore
+++ b/r/adbcsqlite/.Rbuildignore
@@ -6,3 +6,4 @@
 ^src/Makevars$
 ^src/sqlite3\.c$
 ^src/sqlite3\.h$
+^\.vscode$

--- a/r/adbcsqlite/configure
+++ b/r/adbcsqlite/configure
@@ -22,7 +22,7 @@
 # ADBC repo into this package. If the file doesn't exist, we're installing
 # from a pre-built tarball.
 if [ -f bootstrap.R ]; then
-  $R_HOME/bin/Rscript bootstrap.R
+  $R_HOME/bin/Rscript bootstrap.R --vanilla
 fi
 
 # Include and library flags


### PR DESCRIPTION
This PR adds the R packages into the bash-based verification script. The general idea is to run `R CMD INSTALL` then `R CMD check` on both packages but the bash is fairly verbose. My shell scripting is rather new and while I tried to follow patterns elsewhere I imagine there are improvements that could be made.

I didn't attempt Windows, mostly just because my PowerShell is non-existent. In theory the same set of commands would work.