### PR TITLE
fix(ci): use conda git in verification

### DIFF
--- a/ci/scripts/go_build.sh
+++ b/ci/scripts/go_build.sh
@@ -28,8 +28,8 @@ main() {
     fi
 
     if [[ "${CGO_ENABLED}" = 1 ]]; then
-        export LD_LIBRARY_PATH="${install_dir}/lib"
-        export DYLD_LIBRARY_PATH="${install_dir}/lib"
+        export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${install_dir}/lib"
+        export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${install_dir}/lib"
     fi
 
     pushd "${source_dir}/go/adbc"

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -522,7 +522,10 @@ test_go() {
   show_header "Build and test Go libraries"
 
   maybe_setup_go || exit 1
-  maybe_setup_conda compilers go=1.18 || exit 1
+  # apache/arrow-adbc#517: `go build` calls git. Don't assume system
+  # has git; even if it's there, go_build.sh sets DYLD_LIBRARY_PATH
+  # which can interfere with system git.
+  maybe_setup_conda compilers git go=1.18 || exit 1
 
   if [ "${USE_CONDA}" -gt 0 ]; then
     # The CMake setup forces RPATH to be the Conda prefix
@@ -530,7 +533,6 @@ test_go() {
   else
     local -r install_prefix="${ARROW_TMPDIR}/local"
   fi
-
 
   export CGO_ENABLED=1
   "${ADBC_SOURCE_DIR}/ci/scripts/go_build.sh" "${ADBC_SOURCE_DIR}" "${ARROW_TMPDIR}/go-build" "${install_prefix}"

--- a/go/adbc/driver/flightsql/flightsql_adbc_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_test.go
@@ -735,7 +735,7 @@ func (ts *TimeoutTestServer) DoGetStatement(ctx context.Context, tkt flightsql.S
 
 	// wait till the context is cancelled
 	<-ctx.Done()
-	return nil, nil, arrow.ErrNotImplemented
+	return nil, nil, ctx.Err()
 }
 
 func (ts *TimeoutTestServer) DoPutCommandStatementUpdate(ctx context.Context, cmd flightsql.StatementUpdate) (int64, error) {
@@ -774,12 +774,12 @@ func (ts *TimeoutTestServer) GetFlightInfoStatement(ctx context.Context, cmd fli
 		}
 		return info, nil
 	}
-	return nil, arrow.ErrNotImplemented
+	return nil, ctx.Err()
 }
 
 func (ts *TimeoutTestServer) CreatePreparedStatement(ctx context.Context, req flightsql.ActionCreatePreparedStatementRequest) (result flightsql.ActionCreatePreparedStatementResult, err error) {
 	<-ctx.Done()
-	return result, arrow.ErrNotImplemented
+	return result, ctx.Err()
 }
 
 type TimeoutTestSuite struct {


### PR DESCRIPTION
Verification on macOS was failing because system git was getting confused by a Conda DYLD_LIBRARY_PATH. Use conda git instead.

Fixes #517.