### PR TITLE
docs: fix dir name created by git clone

### DIFF
--- a/docs/source/development/releasing.rst
+++ b/docs/source/development/releasing.rst
@@ -225,7 +225,7 @@ How to Verify Release Candidates
 
 #. Run the verification script::
 
-     $ cd apache-arrow-adbc
+     $ cd arrow-adbc
      # Pass the version and the RC number
      $ ./dev/release/verify-release-candidate.sh 0.1.0 6
 


### PR DESCRIPTION
It seems that the directory name is different when the directory is created with the `git clone https://github.com/apache/arrow-adbc.git` command as per the procedure.