### PR TITLE
fix(java/driver/jdbc): clean up buffer leaks

### DIFF
--- a/java/driver/flight-sql-validation/src/test/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlQuirks.java
+++ b/java/driver/flight-sql-validation/src/test/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlQuirks.java
@@ -43,7 +43,7 @@ public class FlightSqlQuirks extends SqlValidationQuirks {
   }
 
   @Override
-  public AdbcDatabase initDatabase() throws AdbcException {
+  public AdbcDatabase initDatabase(BufferAllocator allocator) throws AdbcException {
     String url = getFlightLocation();
 
     final Map<String, Object> parameters = new HashMap<>();

--- a/java/driver/jdbc-validation-derby/src/test/java/org/apache/arrow/adbc/driver/jdbc/derby/DerbyQuirks.java
+++ b/java/driver/jdbc-validation-derby/src/test/java/org/apache/arrow/adbc/driver/jdbc/derby/DerbyQuirks.java
@@ -29,6 +29,7 @@ import org.apache.arrow.adbc.core.AdbcDriver;
 import org.apache.arrow.adbc.core.AdbcException;
 import org.apache.arrow.adbc.driver.jdbc.JdbcDriver;
 import org.apache.arrow.adbc.driver.testsuite.SqlValidationQuirks;
+import org.apache.arrow.memory.BufferAllocator;
 
 public class DerbyQuirks extends SqlValidationQuirks {
   private final String jdbcUrl;
@@ -38,10 +39,10 @@ public class DerbyQuirks extends SqlValidationQuirks {
   }
 
   @Override
-  public AdbcDatabase initDatabase() throws AdbcException {
+  public AdbcDatabase initDatabase(BufferAllocator allocator) throws AdbcException {
     final Map<String, Object> parameters = new HashMap<>();
     parameters.put(AdbcDriver.PARAM_URL, jdbcUrl);
-    return JdbcDriver.INSTANCE.open(parameters);
+    return new JdbcDriver(allocator).open(parameters);
   }
 
   @Override

--- a/java/driver/jdbc-validation-postgresql/src/test/java/org/apache/arrow/adbc/driver/jdbc/postgresql/PostgresqlQuirks.java
+++ b/java/driver/jdbc-validation-postgresql/src/test/java/org/apache/arrow/adbc/driver/jdbc/postgresql/PostgresqlQuirks.java
@@ -29,6 +29,7 @@ import org.apache.arrow.adbc.core.AdbcException;
 import org.apache.arrow.adbc.driver.jdbc.JdbcDriver;
 import org.apache.arrow.adbc.driver.testsuite.SqlValidationQuirks;
 import org.apache.arrow.adbc.sql.SqlQuirks;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.junit.jupiter.api.Assumptions;
 
@@ -49,7 +50,7 @@ public class PostgresqlQuirks extends SqlValidationQuirks {
   }
 
   @Override
-  public AdbcDatabase initDatabase() throws AdbcException {
+  public AdbcDatabase initDatabase(BufferAllocator allocator) throws AdbcException {
     String url = makeJdbcUrl();
 
     final Map<String, Object> parameters = new HashMap<>();
@@ -65,7 +66,7 @@ public class PostgresqlQuirks extends SqlValidationQuirks {
                   return SqlQuirks.DEFAULT_ARROW_TYPE_TO_SQL_TYPE_NAME_MAPPING.apply(arrowType);
                 }))
             .build());
-    return JdbcDriver.INSTANCE.open(parameters);
+    return new JdbcDriver(allocator).open(parameters);
   }
 
   @Override

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcArrowReader.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcArrowReader.java
@@ -78,11 +78,13 @@ public class JdbcArrowReader extends ArrowReader {
   @Override
   public boolean loadNextBatch() {
     if (!delegate.hasNext()) return false;
-    final VectorSchemaRoot root = delegate.next();
-    final VectorUnloader unloader = new VectorUnloader(root);
-    final ArrowRecordBatch recordBatch = unloader.getRecordBatch();
-    bytesRead += recordBatch.computeBodyLength();
-    loadRecordBatch(recordBatch);
+    try (final VectorSchemaRoot root = delegate.next()) {
+      final VectorUnloader unloader = new VectorUnloader(root);
+      try (final ArrowRecordBatch recordBatch = unloader.getRecordBatch()) {
+        bytesRead += recordBatch.computeBodyLength();
+        loadRecordBatch(recordBatch);
+      }
+    }
     return true;
   }
 

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcBindReader.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcBindReader.java
@@ -54,9 +54,10 @@ final class JdbcBindReader extends ArrowReader {
       }
     }
 
-    final VectorSchemaRoot root = currentSource.next();
-    try (final ArrowRecordBatch batch = new VectorUnloader(root).getRecordBatch()) {
-      loadRecordBatch(batch);
+    try (final VectorSchemaRoot root = currentSource.next()) {
+      try (final ArrowRecordBatch batch = new VectorUnloader(root).getRecordBatch()) {
+        loadRecordBatch(batch);
+      }
     }
     return true;
   }
@@ -68,11 +69,13 @@ final class JdbcBindReader extends ArrowReader {
 
   @Override
   protected void closeReadSource() throws IOException {
-    try {
-      // Do not close PreparedStatement so we can reuse it
-      currentResultSet.close();
-    } catch (SQLException e) {
-      throw new IOException(e);
+    if (currentResultSet != null) {
+      try {
+        // Do not close PreparedStatement so we can reuse it
+        currentResultSet.close();
+      } catch (SQLException e) {
+        throw new IOException(e);
+      }
     }
   }
 

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcConnection.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcConnection.java
@@ -32,6 +32,7 @@ import org.apache.arrow.adbc.core.IsolationLevel;
 import org.apache.arrow.adbc.core.StandardSchemas;
 import org.apache.arrow.adbc.sql.SqlQuirks;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -44,6 +45,13 @@ public class JdbcConnection implements AdbcConnection {
   private final Connection connection;
   private final SqlQuirks quirks;
 
+  /**
+   * Create a new connection.
+   *
+   * @param allocator The allocator to use. The connection will close the allocator when done.
+   * @param connection The JDBC connection.
+   * @param quirks Backend-specific quirks to account for.
+   */
   JdbcConnection(BufferAllocator allocator, Connection connection, SqlQuirks quirks) {
     this.allocator = allocator;
     this.connection = connection;
@@ -253,7 +261,7 @@ public class JdbcConnection implements AdbcConnection {
 
   @Override
   public void close() throws Exception {
-    connection.close();
+    AutoCloseables.close(connection, allocator);
   }
 
   private void checkAutoCommit() throws AdbcException, SQLException {

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriver.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriver.java
@@ -17,6 +17,7 @@
 package org.apache.arrow.adbc.driver.jdbc;
 
 import java.util.Map;
+import java.util.Objects;
 import org.apache.arrow.adbc.core.AdbcDatabase;
 import org.apache.arrow.adbc.core.AdbcDriver;
 import org.apache.arrow.adbc.core.AdbcException;
@@ -27,14 +28,21 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
 
 /** An ADBC driver wrapping the JDBC API. */
-public enum JdbcDriver implements AdbcDriver {
-  INSTANCE;
+public class JdbcDriver implements AdbcDriver {
+  public static final JdbcDriver INSTANCE = new JdbcDriver();
+
+  static {
+    AdbcDriverManager.getInstance().registerDriver("org.apache.arrow.adbc.driver.jdbc", INSTANCE);
+  }
 
   private final BufferAllocator allocator;
 
-  JdbcDriver() {
-    allocator = new RootAllocator();
-    AdbcDriverManager.getInstance().registerDriver("org.apache.arrow.adbc.driver.jdbc", this);
+  public JdbcDriver() {
+    this(new RootAllocator());
+  }
+
+  public JdbcDriver(BufferAllocator allocator) {
+    this.allocator = Objects.requireNonNull(allocator);
   }
 
   @Override

--- a/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/AbstractConnectionMetadataTest.java
+++ b/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/AbstractConnectionMetadataTest.java
@@ -68,9 +68,9 @@ public abstract class AbstractConnectionMetadataTest {
   @BeforeEach
   public void beforeEach() throws Exception {
     Preconditions.checkNotNull(quirks, "Must initialize quirks in subclass with @BeforeAll");
-    database = quirks.initDatabase();
-    connection = database.connect();
     allocator = new RootAllocator();
+    database = quirks.initDatabase(allocator);
+    connection = database.connect();
     util = new SqlTestUtil(quirks);
     tableName = quirks.caseFoldTableName("foo");
     mainTable = quirks.caseFoldTableName("product");

--- a/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/AbstractConnectionTest.java
+++ b/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/AbstractConnectionTest.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.arrow.adbc.core.AdbcConnection;
 import org.apache.arrow.adbc.core.AdbcDatabase;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.AutoCloseables;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,18 +32,20 @@ public abstract class AbstractConnectionTest {
   /** Must be initialized by the subclass. */
   protected static SqlValidationQuirks quirks;
 
+  protected BufferAllocator allocator;
   protected AdbcDatabase database;
   protected AdbcConnection connection;
 
   @BeforeEach
   public void beforeEach() throws Exception {
-    database = quirks.initDatabase();
+    allocator = new RootAllocator();
+    database = quirks.initDatabase(allocator);
     connection = database.connect();
   }
 
   @AfterEach
   public void afterEach() throws Exception {
-    AutoCloseables.close(connection, database);
+    AutoCloseables.close(connection, database, allocator);
   }
 
   @Test

--- a/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/AbstractPartitionDescriptorTest.java
+++ b/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/AbstractPartitionDescriptorTest.java
@@ -55,9 +55,9 @@ public abstract class AbstractPartitionDescriptorTest {
   @BeforeEach
   public void beforeEach() throws Exception {
     Preconditions.checkNotNull(quirks, "Must initialize quirks in subclass with @BeforeAll");
-    database = quirks.initDatabase();
-    connection = database.connect();
     allocator = new RootAllocator();
+    database = quirks.initDatabase(allocator);
+    connection = database.connect();
     util = new SqlTestUtil(quirks);
     tableName = quirks.caseFoldTableName("bulktable");
     schema =

--- a/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/AbstractTransactionTest.java
+++ b/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/AbstractTransactionTest.java
@@ -52,9 +52,9 @@ public abstract class AbstractTransactionTest {
   @BeforeEach
   public void beforeEach() throws Exception {
     Preconditions.checkNotNull(quirks, "Must initialize quirks in subclass with @BeforeAll");
-    database = quirks.initDatabase();
-    connection = database.connect();
     allocator = new RootAllocator();
+    database = quirks.initDatabase(allocator);
+    connection = database.connect();
   }
 
   @AfterEach

--- a/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/SqlValidationQuirks.java
+++ b/java/driver/validation/src/main/java/org/apache/arrow/adbc/driver/testsuite/SqlValidationQuirks.java
@@ -21,10 +21,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.arrow.adbc.core.AdbcDatabase;
 import org.apache.arrow.adbc.core.AdbcException;
+import org.apache.arrow.memory.BufferAllocator;
 
 /** Account for driver/vendor-specific quirks in implementing validation tests. */
 public abstract class SqlValidationQuirks {
-  public abstract AdbcDatabase initDatabase() throws AdbcException;
+  public abstract AdbcDatabase initDatabase(BufferAllocator allocator) throws AdbcException;
 
   public void cleanupTable(String name) throws Exception {}
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,7 +28,7 @@
   <url>https://arrow.apache.org/</url>
 
   <properties>
-    <dep.arrow.version>10.0.0</dep.arrow.version>
+    <dep.arrow.version>11.0.0</dep.arrow.version>
     <adbc.version>0.4.0-SNAPSHOT</adbc.version>
   </properties>
 


### PR DESCRIPTION
* Close the allocator in JdbcConnection.
* Allow supplying an allocator to JdbcDriver.
* Fix miscellaneous memory leaks discovered from those changes.

Fixes #476.
Fixes #477.