### PR TITLE
feat(java/driver/flight-sql): add basic auth

### DIFF
--- a/java/driver/flight-sql-validation/src/test/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlQuirks.java
+++ b/java/driver/flight-sql-validation/src/test/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlQuirks.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.Assumptions;
 
 public class FlightSqlQuirks extends SqlValidationQuirks {
   static final String FLIGHT_SQL_LOCATION_ENV_VAR = "ADBC_FLIGHT_SQL_LOCATION";
+  static final String FLIGHT_SQL_USER_ENV_VAR = "ADBC_FLIGHT_SQL_USER";
+  static final String FLIGHT_SQL_PASSWORD_ENV_VAR = "ADBC_FLIGHT_SQL_PASSWORD";
 
   static String getFlightLocation() {
     final String location = System.getenv(FLIGHT_SQL_LOCATION_ENV_VAR);
@@ -48,6 +50,8 @@ public class FlightSqlQuirks extends SqlValidationQuirks {
 
     final Map<String, Object> parameters = new HashMap<>();
     parameters.put(AdbcDriver.PARAM_URL, url);
+    parameters.put("adbc.username", System.getenv(FLIGHT_SQL_USER_ENV_VAR));
+    parameters.put("adbc.password", System.getenv(FLIGHT_SQL_PASSWORD_ENV_VAR));
     return FlightSqlDriver.INSTANCE.open(parameters);
   }
 

--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
@@ -23,16 +23,24 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.apache.arrow.adbc.core.AdbcConnection;
 import org.apache.arrow.adbc.core.AdbcException;
 import org.apache.arrow.adbc.core.AdbcStatement;
 import org.apache.arrow.adbc.core.BulkIngestMode;
 import org.apache.arrow.adbc.sql.SqlQuirks;
+import org.apache.arrow.flight.CallHeaders;
+import org.apache.arrow.flight.CallInfo;
+import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.flight.FlightClientMiddleware;
 import org.apache.arrow.flight.FlightEndpoint;
 import org.apache.arrow.flight.Location;
 import org.apache.arrow.flight.Ticket;
+import org.apache.arrow.flight.auth2.Auth2Constants;
+import org.apache.arrow.flight.auth2.BasicAuthCredentialWriter;
+import org.apache.arrow.flight.grpc.CredentialCallOption;
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.flight.sql.FlightSqlClient;
 import org.apache.arrow.memory.BufferAllocator;
@@ -45,9 +53,13 @@ public class FlightSqlConnection implements AdbcConnection {
   private final SqlQuirks quirks;
   private final LoadingCache<Location, FlightClient> clientCache;
 
-  FlightSqlConnection(BufferAllocator allocator, FlightClient client, SqlQuirks quirks) {
+  FlightSqlConnection(
+      BufferAllocator allocator,
+      SqlQuirks quirks,
+      Location location,
+      String username,
+      String password) {
     this.allocator = allocator;
-    this.client = new FlightSqlClient(client);
     this.quirks = quirks;
     this.clientCache =
         Caffeine.newBuilder()
@@ -62,7 +74,51 @@ public class FlightSqlConnection implements AdbcConnection {
                     throw new RuntimeException(e);
                   }
                 })
-            .build(location -> FlightClient.builder(allocator, location).build());
+            .build(
+                loc -> {
+                  FlightClient flightClient =
+                      FlightClient.builder(allocator, loc)
+                          .intercept(
+                              new FlightClientMiddleware.Factory() {
+                                final String[] bearerValue = {null};
+
+                                @Override
+                                public FlightClientMiddleware onCallStarted(CallInfo info) {
+                                  return new FlightClientMiddleware() {
+                                    @Override
+                                    public void onBeforeSendingHeaders(
+                                        CallHeaders outgoingHeaders) {
+                                      if (bearerValue[0] != null) {
+                                        outgoingHeaders.insert(
+                                            Auth2Constants.AUTHORIZATION_HEADER, bearerValue[0]);
+                                      }
+                                    }
+
+                                    @Override
+                                    public void onHeadersReceived(CallHeaders incomingHeaders) {
+                                      if (bearerValue[0] == null) {
+                                        bearerValue[0] =
+                                            incomingHeaders.get(
+                                                Auth2Constants.AUTHORIZATION_HEADER);
+                                      }
+                                    }
+
+                                    @Override
+                                    public void onCallCompleted(CallStatus status) {}
+                                  };
+                                }
+                              })
+                          .build();
+
+                  if (username != null) {
+                    flightClient.handshake(
+                        new CredentialCallOption(
+                            new BasicAuthCredentialWriter(username, password)));
+                  }
+                  return flightClient;
+                });
+
+    this.client = new FlightSqlClient(Objects.requireNonNull(clientCache.get(location)));
   }
 
   @Override

--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlDriver.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlDriver.java
@@ -64,6 +64,11 @@ public enum FlightSqlDriver implements AdbcDriver {
     } else {
       quirks = new SqlQuirks();
     }
-    return new FlightSqlDatabase(allocator, location, (SqlQuirks) quirks);
+    return new FlightSqlDatabase(
+        allocator,
+        location,
+        (SqlQuirks) quirks,
+        (String) parameters.get("adbc.username"),
+        (String) parameters.get("adbc.password"));
   }
 }


### PR DESCRIPTION
@lidavidm I want a quick feedback on some of the changes.

- Removed unused FlightClient from `FlightSqlDatabase`
- FlightClient creation moved from `FlightSqlDatabase` to `FlightSqlConnection`. In the existing version after connect() is called a new client object is created, but all of them shared the same allocator. That was probably a bug, right?
- username/password passed as parameters named `adbc.username` and `adbc.password` (to be added in `AdbcDriver`). Are there any plans to have some sort of connection string syntax like JDBC?
- As there can be more than one FlightClients, I wanted to avoid keeping track of auth token, so added a middleware that does both: extract an auth token and pass it on future calls. It's functionally similar to the go example, but I couldn't use `authenticateBasicToken` because I couldn't find a way to extract bearer value from CredenialCallOption. Maybe there's a simpler way to accomplish this???
- I'd like to keep FlightClient creation logic contained in `clientCache`. Right now the main FlightClient is created independently and only Endpoint clients are obtained from cache. If changed, main client will always have to be obtained from cache before usage, otherwise it might have expired.