### PR TITLE
test(c/driver/postgresql): Remove errant test error message

### DIFF
--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -1822,10 +1822,7 @@ void StatementTest::TestTransactions() {
               })(),
               ::testing::Not(IsOkStatus(&error)));
 
-  if (error.release) {
-    std::cerr << "Failure message: " << error.message << std::endl;
-    error.release(&error);
-  }
+  if (error.release) error.release(&error);
 
   // Rollback
   ASSERT_THAT(AdbcConnectionRollback(&connection, &error), IsOkStatus(&error));


### PR DESCRIPTION
When running the ADBC tests against the postgres driver you currently get output like:

```sh
[ RUN      ] PostgresStatementTest.Transactions
Failure message: [libpq] Failed to execute query: could not infer schema: ERROR:  relation "bulk_ingest" does not exist
LINE 1: SELECT * FROM bulk_ingest
                      ^

[libpq] Query was: SELECT * FROM (SELECT * FROM bulk_ingest) AS ignored LIMIT 0
WARNING:  there is no transaction in progress
[       OK ] PostgresStatementTest.Transactions (47 ms)
```

This was pretty confusing on first glance because the test still passes. On closer inspection, I don't _think_ the stderr write in the test is intentional