### PR TITLE
chore(c): Ignore .clangd file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ dependency-reduced-pom.xml
 MANIFEST
 compile_commands.json
 build.ninja
+.clangd
 
 # Generated Visual Studio files
 *.vcxproj

--- a/.gitignore
+++ b/.gitignore
@@ -53,10 +53,6 @@ perf.data
 perf.data.old
 
 cpp/.idea/
-.clangd/
-cpp/.clangd/
-.cache/clangd/
-cpp/.cache/clangd/
 c/apidoc/html/
 c/apidoc/latex/
 c/apidoc/xml/


### PR DESCRIPTION
Going back to this conversation https://github.com/apache/arrow-adbc/pull/314#issuecomment-1373110668 I think useful to ignore this