### PR TITLE
feat(glib): add transaction related connection bindings

### DIFF
--- a/glib/adbc-glib/connection.c
+++ b/glib/adbc-glib/connection.c
@@ -32,6 +32,9 @@
  * #GADBCConnection is a class for connection.
  */
 
+#define BOOLEAN_TO_OPTION_VALUE(boolean) \
+  ((boolean) ? ADBC_OPTION_VALUE_ENABLED : ADBC_OPTION_VALUE_DISABLED)
+
 typedef struct {
   gboolean initialized;
   struct AdbcConnection adbc_connection;
@@ -145,6 +148,22 @@ gboolean gadbc_connection_set_option(GADBCConnection* connection, const gchar* k
   AdbcStatusCode status_code =
       AdbcConnectionSetOption(adbc_connection, key, value, &adbc_error);
   return gadbc_error_check(error, status_code, &adbc_error, context);
+}
+
+/**
+ * gadbc_connection_set_auto_commit:
+ * @connection: A #GADBCConnection.
+ * @auto_commit: Whether auto commit is enabled or not.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE if this is set successfully, %FALSE otherwise.
+ *
+ * Since: 0.4.0
+ */
+gboolean gadbc_connection_set_auto_commit(GADBCConnection* connection,
+                                          gboolean auto_commit, GError** error) {
+  return gadbc_connection_set_option(connection, ADBC_CONNECTION_OPTION_AUTOCOMMIT,
+                                     BOOLEAN_TO_OPTION_VALUE(auto_commit), error);
 }
 
 /**
@@ -315,6 +334,56 @@ gpointer gadbc_connection_get_table_types(GADBCConnection* connection, GError** 
     g_free(array_stream);
     return NULL;
   }
+}
+
+/**
+ * gadbc_connection_commit:
+ * @connection: A #GADBCConnection.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Commit any pending transactions. Only used if auto commit is
+ * disabled.
+ *
+ * Behavior is undefined if this is mixed with SQL transaction
+ * statements.
+ *
+ * Returns: %TRUE if the commit is done successfully, %FALSE
+ *   otherwise.
+ *
+ * Since: 0.4.0
+ */
+gboolean gadbc_connection_commit(GADBCConnection* connection, GError** error) {
+  const gchar* context = "[adbc][connection][commit]";
+  struct AdbcConnection* adbc_connection =
+      gadbc_connection_get_raw(connection, context, error);
+  struct AdbcError adbc_error = {};
+  return gadbc_error_check(error, AdbcConnectionCommit(adbc_connection, &adbc_error),
+                           &adbc_error, context);
+}
+
+/**
+ * gadbc_connection_rollback:
+ * @connection: A #GADBCConnection.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Rollback any pending transactions. Only used if auto commit is
+ * disabled.
+ *
+ * Behavior is undefined if this is mixed with SQL transaction
+ * statements.
+ *
+ * Returns: %TRUE if the rollback is done successfully, %FALSE
+ *   otherwise.
+ *
+ * Since: 0.4.0
+ */
+gboolean gadbc_connection_rollback(GADBCConnection* connection, GError** error) {
+  const gchar* context = "[adbc][connection][rollback]";
+  struct AdbcConnection* adbc_connection =
+      gadbc_connection_get_raw(connection, context, error);
+  struct AdbcError adbc_error = {};
+  return gadbc_error_check(error, AdbcConnectionRollback(adbc_connection, &adbc_error),
+                           &adbc_error, context);
 }
 
 /**

--- a/glib/adbc-glib/connection.h
+++ b/glib/adbc-glib/connection.h
@@ -64,6 +64,9 @@ gboolean gadbc_connection_release(GADBCConnection* connection, GError** error);
 GADBC_AVAILABLE_IN_0_1
 gboolean gadbc_connection_set_option(GADBCConnection* connection, const gchar* key,
                                      const gchar* value, GError** error);
+GADBC_AVAILABLE_IN_0_4
+gboolean gadbc_connection_set_auto_commit(GADBCConnection* connection,
+                                          gboolean auto_commit, GError** error);
 GADBC_AVAILABLE_IN_0_1
 gboolean gadbc_connection_init(GADBCConnection* connection, GADBCDatabase* database,
                                GError** error);
@@ -77,5 +80,9 @@ gpointer gadbc_connection_get_table_schema(GADBCConnection* connection,
                                            const gchar* table_name, GError** error);
 GADBC_AVAILABLE_IN_0_4
 gpointer gadbc_connection_get_table_types(GADBCConnection* connection, GError** error);
+GADBC_AVAILABLE_IN_0_4
+gboolean gadbc_connection_commit(GADBCConnection* connection, GError** error);
+GADBC_AVAILABLE_IN_0_4
+gboolean gadbc_connection_rollback(GADBCConnection* connection, GError** error);
 
 G_END_DECLS

--- a/glib/test/helper.rb
+++ b/glib/test/helper.rb
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require "tmpdir"
+
 require "arrow"
 
 module Helper


### PR DESCRIPTION
Fixes #551.

New APIs:

* `gadbc_connection_set_auto_commit()`
* `gadbc_connection_commit()`
* `gadbc_connection_rollback()`