### PR TITLE
fix(c/driver/sqlite,c/validation): Ensure float/double values are not truncated on bind or select

### DIFF
--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -182,8 +182,8 @@ AdbcStatusCode AdbcSqliteBinderBindNext(struct AdbcSqliteBinder* binder, sqlite3
         }
         case NANOARROW_TYPE_FLOAT:
         case NANOARROW_TYPE_DOUBLE: {
-          int64_t value = ArrowArrayViewGetDoubleUnsafe(binder->batch.children[col],
-                                                        binder->next_row);
+          double value = ArrowArrayViewGetDoubleUnsafe(binder->batch.children[col],
+                                                       binder->next_row);
           status = sqlite3_bind_double(stmt, col + 1, value);
           break;
         }

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -1678,7 +1678,7 @@ void StatementTest::TestSqlQueryInts() {
 
 void StatementTest::TestSqlQueryFloats() {
   ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
-  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT CAST(1.0 AS FLOAT)", &error),
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT CAST(1.5 AS FLOAT)", &error),
               IsOkStatus(&error));
 
   {
@@ -1702,11 +1702,11 @@ void StatementTest::TestSqlQueryFloats() {
     switch (reader.fields[0].type) {
       case NANOARROW_TYPE_FLOAT:
         ASSERT_NO_FATAL_FAILURE(
-            CompareArray<float>(reader.array_view->children[0], {1.0f}));
+            CompareArray<float>(reader.array_view->children[0], {1.5f}));
         break;
       case NANOARROW_TYPE_DOUBLE:
         ASSERT_NO_FATAL_FAILURE(
-            CompareArray<double>(reader.array_view->children[0], {1.0}));
+            CompareArray<double>(reader.array_view->children[0], {1.5}));
         break;
       default:
         FAIL() << "Unexpected data type: " << reader.fields[0].type;

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -937,8 +937,8 @@ void StatementTest::TestSqlIngestNumericType(ArrowType type) {
   if constexpr (std::is_floating_point_v<CType>) {
     // XXX: sqlite and others seem to have trouble with extreme
     // values. Likely a bug on our side, but for now, avoid them.
-    values.push_back(-1.0);
-    values.push_back(1.0);
+    values.push_back(-1.5);
+    values.push_back(1.5);
   } else {
     values.push_back(std::numeric_limits<CType>::lowest());
     values.push_back(std::numeric_limits<CType>::max());


### PR DESCRIPTION
Closes #578 and modifies the validation suite so that it will catch this type of accidental cast should it happen again.