### PR TITLE
chore: Fix CI failures reported for R driver packages

### DIFF
--- a/r/adbcpostgresql/.Rbuildignore
+++ b/r/adbcpostgresql/.Rbuildignore
@@ -9,3 +9,4 @@
 ^docker-compose\.yml$
 ^configure\.win$
 ^windows$
+^\.vscode$

--- a/r/adbcpostgresql/R/adbcpostgresql-package.R
+++ b/r/adbcpostgresql/R/adbcpostgresql-package.R
@@ -52,7 +52,7 @@ adbcpostgresql <- function() {
 #' @rdname adbcpostgresql
 #' @importFrom adbcdrivermanager adbc_database_init
 #' @export
-adbc_database_init.adbcpostgresql_driver_postgresql <- function(driver, uri) {
+adbc_database_init.adbcpostgresql_driver_postgresql <- function(driver, ..., uri) {
   adbcdrivermanager::adbc_database_init_default(
     driver,
     list(uri = uri),
@@ -63,8 +63,8 @@ adbc_database_init.adbcpostgresql_driver_postgresql <- function(driver, uri) {
 #' @rdname adbcpostgresql
 #' @importFrom adbcdrivermanager adbc_connection_init
 #' @export
-adbc_connection_init.adbcpostgresql_database <- function(database,
-                                                     adbc.connection.autocommit = NULL) {
+adbc_connection_init.adbcpostgresql_database <- function(database, ...,
+                                                         adbc.connection.autocommit = NULL) {
   options <- list(adbc.connection.autocommit = adbc.connection.autocommit)
   adbcdrivermanager::adbc_connection_init_default(
     database,
@@ -76,7 +76,7 @@ adbc_connection_init.adbcpostgresql_database <- function(database,
 #' @rdname adbcpostgresql
 #' @importFrom adbcdrivermanager adbc_statement_init
 #' @export
-adbc_statement_init.adbcpostgresql_connection <- function(connection,
+adbc_statement_init.adbcpostgresql_connection <- function(connection, ...,
                                                       adbc.ingest.target_table = NULL,
                                                       adbc.ingest.mode = NULL) {
   options <- list(

--- a/r/adbcpostgresql/man/adbcpostgresql.Rd
+++ b/r/adbcpostgresql/man/adbcpostgresql.Rd
@@ -9,18 +9,22 @@
 \usage{
 adbcpostgresql()
 
-\method{adbc_database_init}{adbcpostgresql_driver_postgresql}(driver, uri)
+\method{adbc_database_init}{adbcpostgresql_driver_postgresql}(driver, ..., uri)
 
-\method{adbc_connection_init}{adbcpostgresql_database}(database, adbc.connection.autocommit = NULL)
+\method{adbc_connection_init}{adbcpostgresql_database}(database, ..., adbc.connection.autocommit = NULL)
 
 \method{adbc_statement_init}{adbcpostgresql_connection}(
   connection,
+  ...,
   adbc.ingest.target_table = NULL,
   adbc.ingest.mode = NULL
 )
 }
 \arguments{
 \item{driver}{An \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}.}
+
+\item{...}{Driver-specific options. For the default method, these are
+named values that are converted to strings.}
 
 \item{uri}{A URI to a database path (e.g.,
 \verb{postgresql://localhost:1234/postgres?user=user&password=password})}

--- a/r/adbcsqlite/R/adbcsqlite-package.R
+++ b/r/adbcsqlite/R/adbcsqlite-package.R
@@ -52,7 +52,7 @@ adbcsqlite <- function() {
 #' @rdname adbcsqlite
 #' @importFrom adbcdrivermanager adbc_database_init
 #' @export
-adbc_database_init.adbcsqlite_driver_sqlite <- function(driver, uri = ":memory:") {
+adbc_database_init.adbcsqlite_driver_sqlite <- function(driver, ..., uri = ":memory:") {
   adbcdrivermanager::adbc_database_init_default(
     driver,
     list(uri = uri),
@@ -63,7 +63,7 @@ adbc_database_init.adbcsqlite_driver_sqlite <- function(driver, uri = ":memory:"
 #' @rdname adbcsqlite
 #' @importFrom adbcdrivermanager adbc_connection_init
 #' @export
-adbc_connection_init.adbcsqlite_database <- function(database,
+adbc_connection_init.adbcsqlite_database <- function(database, ...,
                                                      adbc.connection.autocommit = NULL) {
   options <- list(adbc.connection.autocommit = adbc.connection.autocommit)
   adbcdrivermanager::adbc_connection_init_default(
@@ -76,7 +76,7 @@ adbc_connection_init.adbcsqlite_database <- function(database,
 #' @rdname adbcsqlite
 #' @importFrom adbcdrivermanager adbc_statement_init
 #' @export
-adbc_statement_init.adbcsqlite_connection <- function(connection,
+adbc_statement_init.adbcsqlite_connection <- function(connection, ...,
                                                       adbc.ingest.target_table = NULL,
                                                       adbc.ingest.mode = NULL,
                                                       adbc.sqlite.query.batch_rows = NULL) {

--- a/r/adbcsqlite/man/adbcsqlite.Rd
+++ b/r/adbcsqlite/man/adbcsqlite.Rd
@@ -9,12 +9,13 @@
 \usage{
 adbcsqlite()
 
-\method{adbc_database_init}{adbcsqlite_driver_sqlite}(driver, uri = ":memory:")
+\method{adbc_database_init}{adbcsqlite_driver_sqlite}(driver, ..., uri = ":memory:")
 
-\method{adbc_connection_init}{adbcsqlite_database}(database, adbc.connection.autocommit = NULL)
+\method{adbc_connection_init}{adbcsqlite_database}(database, ..., adbc.connection.autocommit = NULL)
 
 \method{adbc_statement_init}{adbcsqlite_connection}(
   connection,
+  ...,
   adbc.ingest.target_table = NULL,
   adbc.ingest.mode = NULL,
   adbc.sqlite.query.batch_rows = NULL
@@ -22,6 +23,9 @@ adbcsqlite()
 }
 \arguments{
 \item{driver}{An \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}.}
+
+\item{...}{Driver-specific options. For the default method, these are
+named values that are converted to strings.}
 
 \item{uri}{A URI to a database path or ":memory:" for an in-memory database.}
 


### PR DESCRIPTION
I believe the root of this is that the new R release contains a slightly modified check for S3 generic method implementations.