### PR TITLE
fix(java)!: require supplying BufferAllocator to create drivers

### DIFF
--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlDriver.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlDriver.java
@@ -26,23 +26,16 @@ import org.apache.arrow.adbc.drivermanager.AdbcDriverManager;
 import org.apache.arrow.adbc.sql.SqlQuirks;
 import org.apache.arrow.flight.Location;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
 
 /** An ADBC driver wrapping Arrow Flight SQL. */
 public class FlightSqlDriver implements AdbcDriver {
-  public static final FlightSqlDriver INSTANCE = new FlightSqlDriver();
-
   static {
     AdbcDriverManager.getInstance()
-        .registerDriver("org.apache.arrow.adbc.driver.flightsql", INSTANCE);
+        .registerDriver("org.apache.arrow.adbc.driver.flightsql", FlightSqlDriver::new);
   }
 
   private final BufferAllocator allocator;
-
-  FlightSqlDriver() {
-    this(new RootAllocator());
-  }
 
   FlightSqlDriver(BufferAllocator allocator) {
     this.allocator = Objects.requireNonNull(allocator);

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriver.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriver.java
@@ -26,11 +26,9 @@ import org.apache.arrow.adbc.core.AdbcException;
 import org.apache.arrow.adbc.drivermanager.AdbcDriverManager;
 import org.apache.arrow.adbc.sql.SqlQuirks;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
 
 /** An ADBC driver wrapping the JDBC API. */
 public class JdbcDriver implements AdbcDriver {
-  public static final JdbcDriver INSTANCE = new JdbcDriver();
   /** A parameter for creating an {@link AdbcDatabase} from a {@link DataSource}. */
   public static final String PARAM_DATASOURCE = "adbc.jdbc.datasource";
   /**
@@ -41,14 +39,11 @@ public class JdbcDriver implements AdbcDriver {
   public static final String PARAM_URI = "uri";
 
   static {
-    AdbcDriverManager.getInstance().registerDriver("org.apache.arrow.adbc.driver.jdbc", INSTANCE);
+    AdbcDriverManager.getInstance()
+        .registerDriver("org.apache.arrow.adbc.driver.jdbc", JdbcDriver::new);
   }
 
   private final BufferAllocator allocator;
-
-  public JdbcDriver() {
-    this(new RootAllocator());
-  }
 
   public JdbcDriver(BufferAllocator allocator) {
     this.allocator = Objects.requireNonNull(allocator);


### PR DESCRIPTION
The old way was prone to memory leaks.

Fixes #563.

BREAKING CHANGE: removes static driver instances.