### PR TITLE
fix(c/driver/postgresql): properly handle NULLs

### DIFF
--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -116,7 +116,6 @@ class PostgresStatementTest : public ::testing::Test,
   void TestSqlIngestUInt64() { GTEST_SKIP() << "Not implemented"; }
   void TestSqlIngestFloat32() { GTEST_SKIP() << "Not implemented"; }
   void TestSqlIngestFloat64() { GTEST_SKIP() << "Not implemented"; }
-  void TestSqlIngestString() { GTEST_SKIP() << "TODO(apache/arrow-adbc#557)"; }
   void TestSqlIngestBinary() { GTEST_SKIP() << "Not implemented"; }
 
   void TestSqlPrepareErrorParamCountMismatch() { GTEST_SKIP() << "Not yet implemented"; }
@@ -147,6 +146,8 @@ struct TypeTestCase {
     return info.param.name;
   }
 };
+
+void PrintTo(const TypeTestCase& value, std::ostream* os) { (*os) << value.name; }
 
 class PostgresTypeTest : public ::testing::TestWithParam<TypeTestCase> {
  public:

--- a/c/driver/postgresql/statement.h
+++ b/c/driver/postgresql/statement.h
@@ -46,6 +46,8 @@ class TupleReader final {
 
   int AppendNext(struct ArrowSchemaView* fields, const char* buf, int buf_size,
                  int64_t* row_count, struct ArrowArray* out);
+  int AppendValue(struct ArrowSchemaView* fields, const char* buf, int col,
+                  int64_t row_count, int32_t field_length, struct ArrowArray* out);
   void ExportTo(struct ArrowArrayStream* stream);
 
  private:

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -205,6 +205,7 @@ class StatementTest {
   void TestSqlIngestAppend();
   void TestSqlIngestErrors();
   void TestSqlIngestMultipleConnections();
+  void TestSqlIngestSample();
 
   void TestSqlPartitionedInts();
 
@@ -261,6 +262,7 @@ class StatementTest {
   TEST_F(FIXTURE, SqlIngestAppend) { TestSqlIngestAppend(); }                           \
   TEST_F(FIXTURE, SqlIngestErrors) { TestSqlIngestErrors(); }                           \
   TEST_F(FIXTURE, SqlIngestMultipleConnections) { TestSqlIngestMultipleConnections(); } \
+  TEST_F(FIXTURE, SqlIngestSample) { TestSqlIngestSample(); }                           \
   TEST_F(FIXTURE, SqlPartitionedInts) { TestSqlPartitionedInts(); }                     \
   TEST_F(FIXTURE, SqlPrepareGetParameterSchema) { TestSqlPrepareGetParameterSchema(); } \
   TEST_F(FIXTURE, SqlPrepareSelectNoParams) { TestSqlPrepareSelectNoParams(); }         \


### PR DESCRIPTION
The driver didn't handle NULL values at all! Fix this, and also instead of a homegrown array appender, just use NanoArrow. Simpler and less error prone!

Fixes #557.