### PR TITLE
fix(go/adbc/sqldriver): do not swallow array.RecordReader error

### DIFF
--- a/go/adbc/sqldriver/driver.go
+++ b/go/adbc/sqldriver/driver.go
@@ -580,6 +580,9 @@ func (r *rows) Next(dest []driver.Value) error {
 
 	for r.curRecord == nil {
 		if !r.rdr.Next() {
+			if err := r.rdr.Err(); err != nil {
+				return err
+			}
 			return io.EOF
 		}
 		r.curRecord = r.rdr.Record()


### PR DESCRIPTION
In the `database/sql` `Rows.Next()` implementation, errors occurring within `array.RecordReader` were ignored, so that an error result appeared as an empty result.