### PR TITLE
ci: 0.4.0 release fixes

### DIFF
--- a/c/driver/postgresql/postgres_copy_reader.h
+++ b/c/driver/postgresql/postgres_copy_reader.h
@@ -32,8 +32,9 @@
 namespace adbcpq {
 
 // "PGCOPY\n\377\r\n\0"
-static int8_t kPgCopyBinarySignature[] = {0x50, 0x47, 0x43, 0x4F, 0x50, 0x59,
-                                          0x0A, 0xFF, 0x0D, 0x0A, 0x00};
+static int8_t kPgCopyBinarySignature[] = {0x50, 0x47, 0x43, 0x4F,
+                                          0x50, 0x59, 0x0A, static_cast<int8_t>(0xFF),
+                                          0x0D, 0x0A, 0x00};
 
 // Read a value from the buffer without checking the buffer size. Advances
 // the cursor of data and reduces its size by sizeof(T).

--- a/c/driver/postgresql/postgres_copy_reader.h
+++ b/c/driver/postgresql/postgres_copy_reader.h
@@ -31,8 +31,9 @@
 
 namespace adbcpq {
 
-static int8_t kPgCopyBinarySignature[] = {'P',  'G',    'C',  'O',  'P', 'Y',
-                                          '\n', '\377', '\r', '\n', '\0'};
+// "PGCOPY\n\377\r\n\0"
+static int8_t kPgCopyBinarySignature[] = {0x50, 0x47, 0x43, 0x4F, 0x50, 0x59,
+                                          0x0A, 0xFF, 0x0D, 0x0A, 0x00};
 
 // Read a value from the buffer without checking the buffer size. Advances
 // the cursor of data and reduces its size by sizeof(T).

--- a/ci/scripts/glib_test.sh
+++ b/ci/scripts/glib_test.sh
@@ -61,6 +61,14 @@ test_subproject() {
                --with-cppflags=-D_LIBCPP_DISABLE_AVAILABILITY
     fi
 
+    # Install consistent version of red-arrow for given arrow-glib
+    local -r arrow_glib_version=$(pkg-config --modversion arrow-glib | sed -e 's/-SNAPSHOT$//g' || :)
+    local red_arrow=""
+    if [ -n "${arrow_glib_version}" ]; then
+        red_arrow="red-arrow:${arrow_glib_version}"
+        export RED_ARROW_VERSION="<= ${arrow_glib_version}"
+    fi
+
     bundle config set --local path 'vendor/bundle'
     bundle install
     bundle exec \
@@ -74,13 +82,6 @@ test_subproject() {
         gem_flags='-- --with-cflags="-D_LIBCPP_DISABLE_AVAILABILITY" --with-cppflags="-D_LIBCPP_DISABLE_AVAILABILITY"'
     fi
 
-    # Install consistent version of red-arrow for given arrow-glib
-    local -r arrow_glib_version=$(pkg-config --modversion arrow-glib | sed -e 's/-SNAPSHOT$//g' || :)
-    local red_arrow=""
-    if [ -n "${arrow_glib_version}" ]; then
-        red_arrow="red-arrow:${arrow_glib_version}"
-        export RED_ARROW_VERSION="<= ${arrow_glib_version}"
-    fi
     gem install \
         --install-dir "${build_dir}/gems" \
         ${red_arrow} \

--- a/ci/scripts/glib_test.sh
+++ b/ci/scripts/glib_test.sh
@@ -79,6 +79,7 @@ test_subproject() {
     local red_arrow=""
     if [ -n "${arrow_glib_version}" ]; then
         red_arrow="red-arrow:${arrow_glib_version}"
+        export RED_ARROW_VERSION="<= ${arrow_glib_version}"
     fi
     gem install \
         --install-dir "${build_dir}/gems" \

--- a/ci/scripts/glib_test.sh
+++ b/ci/scripts/glib_test.sh
@@ -76,14 +76,16 @@ test_subproject() {
 
     # Install consistent version of red-arrow for given arrow-glib
     local -r arrow_glib_version=$(pkg-config --modversion arrow-glib | sed -e 's/-SNAPSHOT$//g' || :)
+    local red_arrow=""
     if [ -n "${arrow_glib_version}" ]; then
-        gem install \
-            --install-dir "${build_dir}/gems" \
-            --version ${arrow_glib_version} \
-            red-arrow \
-            -- ${gem_flags}
+        red_arrow="red-arrow:${arrow_glib_version}"
     fi
-    gem install --install-dir "${build_dir}/gems" pkg/*.gem -- ${gem_flags}
+    gem install \
+        --install-dir "${build_dir}/gems" \
+        ${red_arrow} \
+        pkg/*.gem \
+        -- \
+        ${gem_flags}
     popd
 }
 

--- a/ci/scripts/glib_test.sh
+++ b/ci/scripts/glib_test.sh
@@ -63,9 +63,7 @@ test_subproject() {
 
     # Install consistent version of red-arrow for given arrow-glib
     local -r arrow_glib_version=$(pkg-config --modversion arrow-glib | sed -e 's/-SNAPSHOT$//g' || :)
-    local red_arrow=""
     if [ -n "${arrow_glib_version}" ]; then
-        red_arrow="red-arrow:${arrow_glib_version}"
         export RED_ARROW_VERSION="<= ${arrow_glib_version}"
     fi
 
@@ -84,7 +82,6 @@ test_subproject() {
 
     gem install \
         --install-dir "${build_dir}/gems" \
-        ${red_arrow} \
         pkg/*.gem \
         -- \
         ${gem_flags}

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -146,7 +146,7 @@ function test_packages {
     for component in ${COMPONENTS}; do
         echo "=== Testing $component ==="
 
-        if [[ "$component" = "adbc_driver_snowflake" ]] && [[ "${VCPKG_ARCH}" = "arm64" ]]; then
+        if [[ "$component" = "adbc_driver_snowflake" ]] && [[ "$(uname -m)" = "arm64" ]]; then
             echo "=== Skipping $component on arm64 ==="
             continue
         fi

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -42,6 +42,10 @@ function build_drivers {
         export ADBC_SNOWFLAKE_LIBRARY=${build_dir}/lib/libadbc_driver_snowflake.so
         export VCPKG_DEFAULT_TRIPLET="${VCPKG_ARCH}-linux-static-release"
         export CMAKE_ARGUMENTS=""
+        if [[ "${VCPKG_ARCH}" = "arm64" ]]; then
+            # Can't build Arrow v11 on non-x64 platforms
+            ADBC_DRIVER_SNOWFLAKE=OFF
+        fi
     else # macOS
         export ADBC_FLIGHTSQL_LIBRARY=${build_dir}/lib/libadbc_driver_flightsql.dylib
         export ADBC_POSTGRESQL_LIBRARY=${build_dir}/lib/libadbc_driver_postgresql.dylib

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -146,7 +146,9 @@ function test_packages {
     for component in ${COMPONENTS}; do
         echo "=== Testing $component ==="
 
-        if [[ "$component" = "adbc_driver_snowflake" ]] && [[ "$(uname -m)" = "arm64" ]]; then
+        if [[ "$component" = "adbc_driver_snowflake" ]] &&
+               ([[ "$(uname -m)" = "arm64" ]] ||
+                    [[ "$(uname -m)" = "aarch64" ]]); then
             echo "=== Skipping $component on arm64 ==="
             continue
         fi

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -146,6 +146,11 @@ function test_packages {
     for component in ${COMPONENTS}; do
         echo "=== Testing $component ==="
 
+        if [[ "$component" = "adbc_driver_snowflake" ]] && [[ "${VCPKG_ARCH}" = "arm64" ]]; then
+            echo "=== Skipping $component on arm64 ==="
+            continue
+        fi
+
         python -c "
 import $component
 import $component.dbapi

--- a/ci/scripts/python_wheel_unix_build.sh
+++ b/ci/scripts/python_wheel_unix_build.sh
@@ -89,7 +89,7 @@ check_visibility $ADBC_SNOWFLAKE_LIBRARY
 python -m pip install --upgrade pip auditwheel cibuildwheel delocate setuptools wheel
 
 for component in $COMPONENTS; do
-    if [[ $(uname) = "Darwin" ]] && [[ "${VCPKG_ARCH}" = "arm64" ]]; then
+    if [[ "$component" = "adbc_driver_snowflake" ]] && [[ "${VCPKG_ARCH}" = "arm64" ]]; then
         # XXX: can't build Snowflake driver on non-x64 platforms until upgraded to Arrow 12
         continue
     fi

--- a/ci/scripts/python_wheel_unix_build.sh
+++ b/ci/scripts/python_wheel_unix_build.sh
@@ -94,7 +94,7 @@ python -m pip install --upgrade pip auditwheel cibuildwheel delocate setuptools 
 
 for component in $COMPONENTS; do
     if [[ "$component" = "adbc_driver_snowflake" ]] && [[ "${VCPKG_ARCH}" = "arm64" ]]; then
-        # XXX: can't build Snowflake driver on non-x64 platforms until upgraded to Arrow 12
+        echo "Skipping $component on arm64"
         continue
     fi
 

--- a/ci/scripts/python_wheel_unix_build.sh
+++ b/ci/scripts/python_wheel_unix_build.sh
@@ -82,7 +82,11 @@ build_drivers "${source_dir}" "${build_dir}"
 check_visibility $ADBC_FLIGHTSQL_LIBRARY
 check_visibility $ADBC_POSTGRESQL_LIBRARY
 check_visibility $ADBC_SQLITE_LIBRARY
-check_visibility $ADBC_SNOWFLAKE_LIBRARY
+if [[ -f "$ADBC_SNOWFLAKE_LIBRARY" ]]; then
+    check_visibility $ADBC_SNOWFLAKE_LIBRARY
+else
+    echo "adbc_driver_snowflake not built"
+fi
 
 # https://github.com/pypa/pip/issues/7555
 # Get the latest pip so we have in-tree-build by default

--- a/glib/Gemfile
+++ b/glib/Gemfile
@@ -20,5 +20,6 @@
 source "https://rubygems.org/"
 
 gem "gobject-introspection", ">= 4.0.3"
-gem "red-arrow"
+# 12.0.0 is not yet on conda-forge so this will break CI builds
+gem "red-arrow", "< 12.0.0"
 gem "test-unit"

--- a/glib/Gemfile
+++ b/glib/Gemfile
@@ -20,6 +20,19 @@
 source "https://rubygems.org/"
 
 gem "gobject-introspection", ">= 4.0.3"
-# 12.0.0 is not yet on conda-forge so this will break CI builds
-gem "red-arrow", "< 12.0.0"
+# Use the version of red-arrow based on the available arrow-glib version
+red_arrow_version = ">= 0"
+IO.pipe do |input, output|
+  begin
+    pid = spawn("pkg-config", "--modversion", "arrow-glib",
+                out: output,
+                err: File::NULL)
+    output.close
+    Process.waitpid(pid)
+    arrow_glib_version = input.read.strip.sub(/-SNAPSHOT\z/, "")
+    red_arrow_version = "<= #{arrow_glib_version}"
+  rescue SystemCallError
+  end
+end
+gem "red-arrow", red_arrow_version
 gem "test-unit"

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -23,19 +23,4 @@ gemspec
 
 gem "bundler"
 gem "rake"
-# Use the version of red-arrow based on the available arrow-glib version
-red_arrow_version = ">= 0"
-IO.pipe do |input, output|
-  begin
-    pid = spawn("pkg-config", "--modversion", "arrow-glib",
-                out: output,
-                err: File::NULL)
-    output.close
-    Process.waitpid(pid)
-    arrow_glib_version = input.read.strip.sub(/-SNAPSHOT\z/, "")
-    red_arrow_version = "<= #{arrow_glib_version}"
-  rescue SystemCallError
-  end
-end
-gem "red-arrow", red_arrow_version
 gem "test-unit"

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -23,5 +23,6 @@ gemspec
 
 gem "bundler"
 gem "rake"
-gem "red-arrow"
+# 12.0.0 is not yet on conda-forge so this will break CI builds
+gem "red-arrow", "< 12.0.0"
 gem "test-unit"

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -23,6 +23,19 @@ gemspec
 
 gem "bundler"
 gem "rake"
-# 12.0.0 is not yet on conda-forge so this will break CI builds
-gem "red-arrow", "< 12.0.0"
+# Use the version of red-arrow based on the available arrow-glib version
+red_arrow_version = ">= 0"
+IO.pipe do |input, output|
+  begin
+    pid = spawn("pkg-config", "--modversion", "arrow-glib",
+                out: output,
+                err: File::NULL)
+    output.close
+    Process.waitpid(pid)
+    arrow_glib_version = input.read.strip.sub(/-SNAPSHOT\z/, "")
+    red_arrow_version = "<= #{arrow_glib_version}"
+  rescue SystemCallError
+  end
+end
+gem "red-arrow", red_arrow_version
 gem "test-unit"

--- a/ruby/red-adbc.gemspec
+++ b/ruby/red-adbc.gemspec
@@ -52,7 +52,13 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob("lib/**/*.rb")
   spec.extensions = ["dependency-check/Rakefile"]
 
-  spec.add_runtime_dependency("red-arrow")
+  # For CI: sometimes we can't use the latest red-arrow due to
+  # conda-forge arrow-c-glib lagging behind
+  if ENV["RED_ARROW_VERSION"]
+    spec.add_runtime_dependency("red-arrow", ENV["RED_ARROW_VERSION"])
+  else
+    spec.add_runtime_dependency("red-arrow")
+  end
 
   # spec.metadata["msys2_mingw_dependencies"] = "adbc>=#{spec.version}"
 end


### PR DESCRIPTION
- skip Snowflake wheel on Linux/aarch64 too
- fix how we skip the Snowflake wheel to not skip all wheels
- fix compiler warning in PostgreSQL driver
- pin arrow-c-glib since red-arrow 12 came out but conda-forge does not yet have arrow-c-glib 12

Fixes #660.
Fixes #661.
Fixes #663.