### PR TITLE
feat(ruby): Free an imported reader in Statement#execute explicitly

### DIFF
--- a/ruby/lib/adbc/connection.rb
+++ b/ruby/lib/adbc/connection.rb
@@ -42,14 +42,18 @@ module ADBC
       c_abi_array_stream = get_info(codes)
       begin
         reader = Arrow::RecordBatchReader.import(c_abi_array_stream)
-        table = reader.read_all
-        values = {}
-        table.raw_records.each do |code, value|
-          value = value.values[0] if value.is_a?(Hash)
-          code = ADBC::Info.try_convert(code)
-          values[code.nick.gsub("-", "_").to_sym] = value
+        begin
+          table = reader.read_all
+          values = {}
+          table.raw_records.each do |code, value|
+            value = value.values[0] if value.is_a?(Hash)
+            code = ADBC::Info.try_convert(code)
+            values[code.nick.gsub("-", "_").to_sym] = value
+          end
+          values
+        ensure
+          reader.unref
         end
-        values
       ensure
         GLib.free(c_abi_array_stream)
       end

--- a/ruby/lib/adbc/statement.rb
+++ b/ruby/lib/adbc/statement.rb
@@ -38,10 +38,14 @@ module ADBC
       if need_result
         begin
           reader = Arrow::RecordBatchReader.import(c_abi_array_stream)
-          if block_given?
-            yield(reader, n_rows_affected)
-          else
-            [reader.read_all, n_rows_affected]
+          begin
+            if block_given?
+              yield(reader, n_rows_affected)
+            else
+              [reader.read_all, n_rows_affected]
+            end
+          ensure
+            reader.unref
           end
         ensure
           GLib.free(c_abi_array_stream)


### PR DESCRIPTION
Fixes #664.

The reader is invalid outside of the method. We must free the reader explicitly here to avoid a SEGV.