### PR TITLE
feat(r): Improve error communication

### DIFF
--- a/r/adbcdrivermanager/tests/testthat/_snaps/driver_log.md
+++ b/r/adbcdrivermanager/tests/testthat/_snaps/driver_log.md
@@ -21,7 +21,7 @@
       try(adbc_statement_execute_query(stmt))
     Output
       LogStatementExecuteQuery()
-      Error in stop_for_error(result$status, error) : 
+      Error in adbc_statement_execute_query(stmt) : 
         ADBC_STATUS_NOT_IMPLEMENTED (2)
     Code
       adbc_statement_release(stmt)

--- a/r/adbcdrivermanager/tests/testthat/test-error.R
+++ b/r/adbcdrivermanager/tests/testthat/test-error.R
@@ -27,3 +27,19 @@ test_that("error allocator works", {
   expect_identical(err$vendor_code, 0L)
   expect_identical(err$sqlstate, as.raw(c(0x00, 0x00, 0x00, 0x00, 0x00)))
 })
+
+test_that("stop_for_error() gives a custom error class with extra info", {
+  had_error <- FALSE
+  tryCatch({
+    db <- adbc_database_init(adbc_driver_void())
+    adbc_database_release(db)
+    adbc_database_release(db)
+  }, adbc_status = function(e) {
+    had_error <<- TRUE
+    expect_s3_class(e, "adbc_status")
+    expect_s3_class(e, "adbc_status_invalid_state")
+    expect_identical(e$error$status, 6L)
+  })
+
+  expect_true(had_error)
+})


### PR DESCRIPTION
Before this PR, errors coming from ADBC were rather unhelpfully labelled:

``` r
library(adbcdrivermanager)

db <- adbc_database_init(adbc_driver_void())
adbc_database_release(db)
adbc_database_release(db)
#> Error in stop_for_error(status, error): ADBC_STATUS_INVALID_STATE (6)
```

After this PR, the source of the error is better communicated and errors are given a custom class so they can be caught appropriately:

``` r
library(adbcdrivermanager)

db <- adbc_database_init(adbc_driver_void())
adbc_database_release(db)
adbc_database_release(db)
#> Error in adbc_database_release(db): ADBC_STATUS_INVALID_STATE (6)

tryCatch({
  db <- adbc_database_init(adbc_driver_void())
  adbc_database_release(db)
  adbc_database_release(db)
}, adbc_status_invalid_state = function(e) {
  message(sprintf("Just warning for ADBC status with code %d", e$error$status))
})
#> Just warning for ADBC status with code 6
```

<sup>Created on 2023-05-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>