### PR TITLE
fix(go/adbc): Update snowflake dep

### DIFF
--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -104,6 +104,4 @@ require (
 	modernc.org/token v1.1.0 // indirect
 )
 
-replace github.com/snowflakedb/gosnowflake v1.6.21 => github.com/snowflakedb/gosnowflake v1.6.21-0.20230510151847-61ad7b87c8f9
-
 replace github.com/apache/arrow/go/v12 v12.0.0 => github.com/apache/arrow/go/v12 v12.0.0-20230428025921-06d49ee63e26

--- a/go/adbc/go.sum
+++ b/go/adbc/go.sum
@@ -134,8 +134,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qq
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/snowflakedb/gosnowflake v1.6.21-0.20230510151847-61ad7b87c8f9 h1:W9iAxKNtLYhuVIB2Tj1D/A4IThORgevOTUeWNTQNxFg=
-github.com/snowflakedb/gosnowflake v1.6.21-0.20230510151847-61ad7b87c8f9/go.mod h1:P2fE/xiD2kQXpr48OdgnazkzPsKD6aVtnHD3WP8yD9c=
+github.com/snowflakedb/gosnowflake v1.6.21 h1:OEn5/P+voj3P/STW+R/gGktJlEpfP127GzrxvtAJ5II=
+github.com/snowflakedb/gosnowflake v1.6.21/go.mod h1:P2fE/xiD2kQXpr48OdgnazkzPsKD6aVtnHD3WP8yD9c=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=


### PR DESCRIPTION
Snowflake finally released a new version of their lib as v1.6.21, so we can remove the `replace` directive and point at the version proper without needing to specify a specific commit.