### PR TITLE
feat(c/driver/postgresql): handle non-SELECT statements

### DIFF
--- a/c/vendor/nanoarrow/nanoarrow.hpp
+++ b/c/vendor/nanoarrow/nanoarrow.hpp
@@ -250,6 +250,8 @@ class EmptyArrayStream {
 
   static void release_wrapper(struct ArrowArrayStream* stream) {
     delete reinterpret_cast<EmptyArrayStream*>(stream->private_data);
+    stream->release = nullptr;
+    stream->private_data = nullptr;
   }
 };
 

--- a/python/adbc_driver_postgresql/tests/test_dbapi.py
+++ b/python/adbc_driver_postgresql/tests/test_dbapi.py
@@ -30,3 +30,18 @@ def test_query_trivial(postgres: dbapi.Connection):
     with postgres.cursor() as cur:
         cur.execute("SELECT 1")
         assert cur.fetchone() == (1,)
+
+
+def test_ddl(postgres: dbapi.Connection):
+    with postgres.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS test_ddl")
+        assert cur.fetchone() is None
+
+        cur.execute("CREATE TABLE test_ddl (ints INT)")
+        assert cur.fetchone() is None
+
+        cur.execute("INSERT INTO test_ddl VALUES (1) RETURNING ints")
+        assert cur.fetchone() == (1,)
+
+        cur.execute("SELECT * FROM test_ddl")
+        assert cur.fetchone() == (1,)


### PR DESCRIPTION
Before we tried to infer the query schema before COPY by wrapping it in a "SELECT * FROM (...) LIMIT 0".  This broke if the query was (for example) a CREATE or UPDATE.  Instead, use a prepared statement to infer instead.  If we find that there are no result columns, then execute without the COPY path.

Also, test what happens with "INSERT INTO ... RETURNING" (this works with COPY).

Fixes #701.