### PR TITLE
fix(r): Don't save database/connection/statement options at the R level

### DIFF
--- a/r/adbcdrivermanager/R/adbc.R
+++ b/r/adbcdrivermanager/R/adbc.R
@@ -82,7 +82,6 @@ adbc_database_set_options <- function(database, options) {
       error
     )
     stop_for_error(status, error)
-    xptr_add_option(database, key, value)
   }
   invisible(database)
 }
@@ -152,7 +151,6 @@ adbc_connection_set_options <- function(connection, options) {
       error
     )
     stop_for_error(status, error)
-    xptr_add_option(connection, key, value)
   }
   invisible(connection)
 }
@@ -346,7 +344,6 @@ adbc_statement_set_options <- function(statement, options) {
       error
     )
     stop_for_error(status, error)
-    xptr_add_option(statement, key, value)
   }
   invisible(statement)
 }

--- a/r/adbcdrivermanager/R/utils.R
+++ b/r/adbcdrivermanager/R/utils.R
@@ -32,14 +32,6 @@ key_value_options <- function(options) {
   options
 }
 
-xptr_add_option <- function(xptr, key, value) {
-  if (is.null(xptr$options)) {
-    xptr$options <- new.env(parent = emptyenv())
-  }
-
-  xptr$options[[key]] <- unname(value)
-}
-
 new_env <- function() {
   new.env(parent = emptyenv())
 }

--- a/r/adbcdrivermanager/tests/testthat/test-radbc.R
+++ b/r/adbcdrivermanager/tests/testthat/test-radbc.R
@@ -18,7 +18,6 @@
 test_that("can initialize and release a database", {
   db <- adbc_database_init(adbc_driver_void(), some_key = "some_value")
   expect_s3_class(db, "adbc_database")
-  expect_identical(db$options$some_key, "some_value")
   adbc_database_release(db)
   expect_error(adbc_database_release(db), "ADBC_STATUS_INVALID_STATE")
 })
@@ -26,7 +25,6 @@ test_that("can initialize and release a database", {
 test_that("can initialize and release a connection", {
   db <- adbc_database_init(adbc_driver_void())
   con <- adbc_connection_init(db, some_key = "some_value")
-  expect_identical(con$options$some_key, "some_value")
   expect_s3_class(con, "adbc_connection")
   adbc_connection_release(con)
   expect_error(adbc_connection_release(con), "ADBC_STATUS_INVALID_STATE")
@@ -84,7 +82,6 @@ test_that("can initialize and release a statement", {
   con <- adbc_connection_init(db)
   stmt <- adbc_statement_init(con, some_key = "some_value")
   expect_s3_class(stmt, "adbc_statement")
-  expect_identical(stmt$options$some_key, "some_value")
   adbc_statement_release(stmt)
   expect_error(adbc_statement_release(stmt), "ADBC_STATUS_INVALID_STATE")
 })


### PR DESCRIPTION
I think initially I thought this would be useful for printing, but it turns out it's distressingly easy to print out/leak/expose secret credentials with the default print method:

``` r
library(adbcdrivermanager)

uri <- Sys.getenv("ADBC_SNOWFLAKE_TEST_URI")
adbc_database_init(adbcsnowflake::adbcsnowflake(), uri = uri)
#> <adbcsnowflake_database> <pointer: 0x14f65c350> List of 2
#>  $ driver :<adbcsnowflake_driver_snowflake> List of 1
#>   ..$ driver_init_func:Class 'adbc_driver_init_func' <externalptr> 
#>  $ options:List of 1
#>   ..$ uri: chr "paleolimbot:ADBC44test@wt78143.ca-central-1.aws/SNOWFLAKE_SAMPLE_DATA/TPCH_SF1?role=ACCOUNTADMIN"
```

This PR nixes that whole system: if it's helpful to expose something it can be exposed by individual drivers. After this PR:

``` r
library(adbcdrivermanager)

uri <- Sys.getenv("ADBC_SNOWFLAKE_TEST_URI")
adbc_database_init(adbcsnowflake::adbcsnowflake(), uri = uri)
#> <adbcsnowflake_database> <pointer: 0x15365d570> List of 1
#>  $ driver:<adbcsnowflake_driver_snowflake> List of 1
#>   ..$ driver_init_func:Class 'adbc_driver_init_func' <externalptr>
```

<sup>Created on 2023-05-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>