### PR TITLE
feat(c/driver/postgresql): Implement GetObjects for tables

### DIFF
--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -311,6 +311,16 @@ class PqGetObjectsHelper {
       return ADBC_STATUS_INTERNAL;
     }
 
+    // TODO: we should replace this with a parametrized query
+    // Currently liable for SQL injection
+    if (table_name_ != NULL) {
+      int res = StringBuilderAppend(&query, "%s%s%s", " AND c.relname LIKE '",
+                                    table_name_, "'");
+      if (res) {
+        return ADBC_STATUS_INTERNAL;
+      }
+    }
+
     // We assume schema_name does not need to be escaped as this method
     // is private to the class and called from other private methods that have
     // already escaped

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -346,6 +346,7 @@ class PqGetObjectsHelper {
     }
 
     auto result_helper = PqResultHelper{conn_, query.buffer, params, error_};
+    StringBuilderReset(&query);
 
     RAISE_ADBC(result_helper.Prepare());
     RAISE_ADBC(result_helper.Execute());

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -322,7 +322,7 @@ class PqGetObjectsHelper {
         const char* table_name = row[0].data;
         const char* table_type = row[1].data;
 
-        if (depth_ >= ADBC_OBJECT_DEPTH_COLUMNS) {
+        if (depth_ > ADBC_OBJECT_DEPTH_TABLES) {
           return ADBC_STATUS_NOT_IMPLEMENTED;
         } else {
           CHECK_NA(INTERNAL,
@@ -334,11 +334,13 @@ class PqGetObjectsHelper {
           CHECK_NA(INTERNAL, ArrowArrayAppendNull(table_columns_col_, 1), error_);
           CHECK_NA(INTERNAL, ArrowArrayAppendNull(table_constraints_col_, 1), error_);
         }
+        CHECK_NA(INTERNAL, ArrowArrayFinishElement(schema_table_items_), error_);
       }
     } else {
       return ADBC_STATUS_INTERNAL;
     }
 
+    CHECK_NA(INTERNAL, ArrowArrayFinishElement(db_schema_tables_col_), error_);
     return ADBC_STATUS_OK;
   }
 

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -86,7 +86,6 @@ class PostgresConnectionTest : public ::testing::Test,
   void SetUp() override { ASSERT_NO_FATAL_FAILURE(SetUpTest()); }
   void TearDown() override { ASSERT_NO_FATAL_FAILURE(TearDownTest()); }
 
-  void TestMetadataGetObjectsTables() { GTEST_SKIP() << "Not yet implemented"; }
   void TestMetadataGetObjectsTablesTypes() { GTEST_SKIP() << "Not yet implemented"; }
   void TestMetadataGetObjectsColumns() { GTEST_SKIP() << "Not yet implemented"; }
 


### PR DESCRIPTION
You've mentioned a few other times that we need to start using a prepared statement instead of string appends for handling queries. Think we've hit that point with this PR.

Current plan is to make that prepared statement usage part of the `PqResultHelper` in a pre-cursor to this, but I think the overall structure of this is still reviewable