### PR TITLE
perf(go/adbc/driver/flightsql): filter by schema in getObjectsTables

### DIFF
--- a/go/adbc/driver/flightsql/flightsql_adbc.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc.go
@@ -1110,6 +1110,7 @@ func (c *cnxn) getObjectsTables(ctx context.Context, depth adbc.ObjectDepth, cat
 	// Pre-populate the map of which schemas are in which catalogs
 	includeSchema := depth == adbc.ObjectDepthAll || depth == adbc.ObjectDepthColumns
 	info, err := c.cl.GetTables(ctx, &flightsql.GetTablesOpts{
+		DbSchemaFilterPattern:  dbSchema,
 		TableNameFilterPattern: tableName,
 		TableTypes:             tableType,
 		IncludeSchema:          includeSchema,


### PR DESCRIPTION
GetObjects uses this function, for example to list the tables in a specific schema.
The issue is getObjectsTables does not use the requested schema as a filter when making the API call, and only later the results are filtered on the client side.
This fix prevents the server from having to process a lot of unnecessary data in DBs with many schemas.