### PR TITLE
feat(format): remove unnecessary padding

### DIFF
--- a/adbc.h
+++ b/adbc.h
@@ -799,7 +799,7 @@ struct ADBC_EXPORT AdbcDriver {
   /// and attempt to have the driver initialize it with
   /// ADBC_VERSION_1_1_0.  This must return an error, after which the
   /// driver will try again with ADBC_VERSION_1_0_0.  The driver must
-  /// not access the new fields.
+  /// not access the new fields, which will carry undefined values.
   ///
   /// For a 1.1.0 driver being loaded by a 1.0.0 driver manager: the
   /// 1.0.0 manager will allocate the old AdbcDriver struct and
@@ -844,9 +844,6 @@ struct ADBC_EXPORT AdbcDriver {
                                           struct AdbcError*);
   AdbcStatusCode (*StatementSetOptionDouble)(struct AdbcStatement*, const char*, double,
                                              struct AdbcError*);
-
-  /// Pad the struct to have 96 pointers.  Space reserved for future growth.
-  void* reserved[50];
 
   /// @}
 };

--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -870,9 +870,6 @@ AdbcStatusCode AdbcLoadDriverFromInitFunc(AdbcDriverInitFunc init_func, int vers
   if (version >= ADBC_VERSION_1_1_0) {
     auto* driver = reinterpret_cast<struct AdbcDriver*>(raw_driver);
     FILL_DEFAULT(driver, StatementExecuteSchema);
-
-    // Zero out the padding
-    std::memset(driver->reserved, 0, sizeof(driver->reserved));
   }
 
   return ADBC_STATUS_OK;

--- a/c/driver_manager/adbc_driver_manager_test.cc
+++ b/c/driver_manager/adbc_driver_manager_test.cc
@@ -34,8 +34,6 @@ namespace adbc {
 using adbc_validation::IsOkStatus;
 using adbc_validation::IsStatus;
 
-TEST(Adbc, AdbcDriverSize) { ASSERT_EQ(sizeof(AdbcDriver), 96 * sizeof(void*)); }
-
 class DriverManager : public ::testing::Test {
  public:
   void SetUp() override {


### PR DESCRIPTION
- Clarify one of the docstrings
- Remove the 'future growth' padding since we have a different compatibility strategy