### PR TITLE
fix(c/driver/sqlite): Fix parameter binding when inferring types and when retrieving

### DIFF
--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -429,7 +429,6 @@ int StatementReaderGetNext(struct ArrowArrayStream* self, struct ArrowArray* out
         break;
       }
     }
-
   }
   if (status == 0) {
     out->length = batch_size;
@@ -862,8 +861,9 @@ AdbcStatusCode AdbcSqliteExportReader(sqlite3* db, sqlite3_stmt* stmt,
           }
 
           for (int col = 0; col < num_columns; col++) {
-            status = StatementReaderInferOneValue(stmt, col, &validity[col], &data[col],
-                                                  &binary[col], &current_type[col], error);
+            status =
+                StatementReaderInferOneValue(stmt, col, &validity[col], &data[col],
+                                             &binary[col], &current_type[col], error);
             if (status != ADBC_STATUS_OK) break;
           }
           if (status != ADBC_STATUS_OK) break;

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -1463,6 +1463,9 @@ void StatementTest::TestSqlPrepareSelectParams() {
     auto start = nrows;
     auto end = nrows + reader.array->length;
 
+    ASSERT_LT(start, expected_int32.size());
+    ASSERT_LE(end, expected_int32.size());
+
     switch (reader.fields[0].type) {
       case NANOARROW_TYPE_INT32:
         ASSERT_NO_FATAL_FAILURE(CompareArray<int32_t>(


### PR DESCRIPTION
Needs tests on the C side and perhaps also on the R side. Please advise.

Closes #734.

``` r
library(adbcdrivermanager)
# pkgload::load_all()

# Use the driver manager to connect to a database
db <- adbc_database_init(adbcsqlite::adbcsqlite(), uri = ":memory:")
con <- adbc_connection_init(db)

# Write a table
flights <- nycflights13::flights
# (timestamp not supported yet)
flights$time_hour <- NULL

stmt <- adbc_statement_init(con, adbc.ingest.target_table = "flights")
adbc_statement_bind(stmt, flights)
adbc_statement_execute_query(stmt)
#> [1] 336776
adbc_statement_release(stmt)

# March flights
stmt <- adbc_statement_init(con)
adbc_statement_set_sql_query(stmt, "SELECT * from flights WHERE month = 3 LIMIT 2")
stream <- nanoarrow::nanoarrow_allocate_array_stream()
adbc_statement_execute_query(stmt, stream)
#> [1] -1


result <- tibble::as_tibble(stream)
adbc_statement_release(stmt)

result
#> # A tibble: 2 × 18
#>    year month   day dep_time sched_dep_time dep_delay arr_time sched_arr_time
#>   <dbl> <dbl> <dbl>    <dbl>          <dbl>     <dbl>    <dbl>          <dbl>
#> 1  2013     3     1        4           2159       125      318             56
#> 2  2013     3     1       50           2358        52      526            438
#> # ℹ 10 more variables: arr_delay <dbl>, carrier <chr>, flight <dbl>,
#> #   tailnum <chr>, origin <chr>, dest <chr>, air_time <dbl>, distance <dbl>,
#> #   hour <dbl>, minute <dbl>


# March flights with a parameter, not passing parameter
stmt <- adbc_statement_init(con)
adbc_statement_set_sql_query(stmt, "SELECT * from flights WHERE month = ? LIMIT 2")
stream <- nanoarrow::nanoarrow_allocate_array_stream()
adbc_statement_execute_query(stmt, stream)
#> [1] -1
result <- tibble::as_tibble(stream)
adbc_statement_release(stmt)

result
#> # A tibble: 0 × 18
#> # ℹ 18 variables: year <dbl>, month <dbl>, day <dbl>, dep_time <dbl>,
#> #   sched_dep_time <dbl>, dep_delay <dbl>, arr_time <dbl>,
#> #   sched_arr_time <dbl>, arr_delay <dbl>, carrier <dbl>, flight <dbl>,
#> #   tailnum <dbl>, origin <dbl>, dest <dbl>, air_time <dbl>, distance <dbl>,
#> #   hour <dbl>, minute <dbl>

# March flights with a parameter
stmt <- adbc_statement_init(con)
adbc_statement_set_sql_query(stmt, "SELECT * from flights WHERE month = ? LIMIT 2")
adbc_statement_bind_stream(stmt, data.frame(a = 3))
stream <- nanoarrow::nanoarrow_allocate_array_stream()
adbc_statement_execute_query(stmt, stream)
#> [1] -1
result <- tibble::as_tibble(stream)
adbc_statement_release(stmt)

result
#> # A tibble: 2 × 18
#>    year month   day dep_time sched_dep_time dep_delay arr_time sched_arr_time
#>   <dbl> <dbl> <dbl>    <dbl>          <dbl>     <dbl>    <dbl>          <dbl>
#> 1  2013     3     1        4           2159       125      318             56
#> 2  2013     3     1       50           2358        52      526            438
#> # ℹ 10 more variables: arr_delay <dbl>, carrier <chr>, flight <dbl>,
#> #   tailnum <chr>, origin <chr>, dest <chr>, air_time <dbl>, distance <dbl>,
#> #   hour <dbl>, minute <dbl>

# Many March flights with multiple parameters
stmt <- adbc_statement_init(con)
adbc_statement_set_sql_query(stmt, "SELECT * from flights WHERE month = ?")
adbc_statement_bind_stream(stmt, data.frame(a = 2:4))
stream <- nanoarrow::nanoarrow_allocate_array_stream()
adbc_statement_execute_query(stmt, stream)
#> [1] -1
result <- tibble::as_tibble(stream)
adbc_statement_release(stmt)

result
#> # A tibble: 24,951 × 18
#>     year month   day dep_time sched_dep_time dep_delay arr_time sched_arr_time
#>    <dbl> <dbl> <dbl>    <dbl>          <dbl>     <dbl>    <dbl>          <dbl>
#>  1  2013     2     1      456            500        -4      652            648
#>  2  2013     2     1      520            525        -5      816            820
#>  3  2013     2     1      527            530        -3      837            829
#>  4  2013     2     1      532            540        -8     1007           1017
#>  5  2013     2     1      540            540         0      859            850
#>  6  2013     2     1      552            600        -8      714            715
#>  7  2013     2     1      552            600        -8      919            910
#>  8  2013     2     1      552            600        -8      655            709
#>  9  2013     2     1      553            600        -7      833            815
#> 10  2013     2     1      553            600        -7      821            825
#> # ℹ 24,941 more rows
#> # ℹ 10 more variables: arr_delay <dbl>, carrier <chr>, flight <dbl>,
#> #   tailnum <chr>, origin <chr>, dest <chr>, air_time <dbl>, distance <dbl>,
#> #   hour <dbl>, minute <dbl>

# Clean up
adbc_connection_release(con)
adbc_database_release(db)
```

<sup>Created on 2023-06-08 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>