### PR TITLE
fix(python/adbc_driver_manager): fix fetching queries with empty results

### DIFF
--- a/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
@@ -921,6 +921,8 @@ class _RowIterator(_Closeable):
         if self._current_batch is None or self._next_row >= len(self._current_batch):
             try:
                 self._current_batch = self._reader.read_next_batch()
+                if self._current_batch.num_rows == 0:
+                    raise StopIteration
                 self._next_row = 0
             except StopIteration:
                 self._current_batch = None

--- a/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
@@ -920,9 +920,10 @@ class _RowIterator(_Closeable):
     def fetchone(self):
         if self._current_batch is None or self._next_row >= len(self._current_batch):
             try:
-                self._current_batch = self._reader.read_next_batch()
-                if self._current_batch.num_rows == 0:
-                    raise StopIteration
+                while True:
+                    self._current_batch = self._reader.read_next_batch()
+                    if self._current_batch.num_rows > 0:
+                        break
                 self._next_row = 0
             except StopIteration:
                 self._current_batch = None

--- a/python/adbc_driver_manager/tests/test_dbapi.py
+++ b/python/adbc_driver_manager/tests/test_dbapi.py
@@ -295,6 +295,14 @@ def test_executemany(sqlite):
 
 
 @pytest.mark.sqlite
+def test_fetch_empty(sqlite):
+    with sqlite.cursor() as cur:
+        cur.execute("CREATE TABLE foo (bar)")
+        cur.execute("SELECT * FROM foo")
+        assert cur.fetchall() == []
+
+
+@pytest.mark.sqlite
 def test_prepare(sqlite):
     with sqlite.cursor() as cur:
         schema = cur.adbc_prepare("SELECT 1")


### PR DESCRIPTION
`fetchall` currently fails on queries that return no results.

The issue is `_reader.read_next_batch()` returns a batch with no rows which is not expected by the python code.
I've added a condition similar to the one in the [go driver](https://github.com/apache/arrow-adbc/blob/main/go/adbc/sqldriver/driver.go#L590).