### PR TITLE
fix(java/driver/jdbc): return timestamps as MICROSECOND always

### DIFF
--- a/java/driver/jdbc-validation-postgresql/src/test/java/org/apache/arrow/adbc/driver/jdbc/postgresql/PostgreSqlTypeTest.java
+++ b/java/driver/jdbc-validation-postgresql/src/test/java/org/apache/arrow/adbc/driver/jdbc/postgresql/PostgreSqlTypeTest.java
@@ -76,27 +76,27 @@ class PostgreSqlTypeTest extends AbstractSqlTypeTest {
   protected void timestamp3WithoutTimeZoneType() throws Exception {
     final Schema schema = connection.getTableSchema(null, null, "adbc_alltypes");
     assertThat(schema.findField("timestamp_without_time_zone_p3_t").getType())
-        .isEqualTo(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null));
+        .isEqualTo(new ArrowType.Timestamp(TimeUnit.MICROSECOND, null));
   }
 
   @Test
   protected void timestamp2WithoutTimeZoneType() throws Exception {
     final Schema schema = connection.getTableSchema(null, null, "adbc_alltypes");
     assertThat(schema.findField("timestamp_without_time_zone_p2_t").getType())
-        .isEqualTo(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null));
+        .isEqualTo(new ArrowType.Timestamp(TimeUnit.MICROSECOND, null));
   }
 
   @Test
   protected void timestamp1WithoutTimeZoneType() throws Exception {
     final Schema schema = connection.getTableSchema(null, null, "adbc_alltypes");
     assertThat(schema.findField("timestamp_without_time_zone_p1_t").getType())
-        .isEqualTo(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null));
+        .isEqualTo(new ArrowType.Timestamp(TimeUnit.MICROSECOND, null));
   }
 
   @Test
   protected void timestamp0WithoutTimeZoneType() throws Exception {
     final Schema schema = connection.getTableSchema(null, null, "adbc_alltypes");
     assertThat(schema.findField("timestamp_without_time_zone_p0_t").getType())
-        .isEqualTo(new ArrowType.Timestamp(TimeUnit.SECOND, null));
+        .isEqualTo(new ArrowType.Timestamp(TimeUnit.MICROSECOND, null));
   }
 }

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/StandardJdbcQuirks.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/StandardJdbcQuirks.java
@@ -60,29 +60,13 @@ public final class StandardJdbcQuirks {
   private static ArrowType postgresql(JdbcFieldInfoExtra field) {
     switch (field.getJdbcType()) {
       case Types.TIMESTAMP:
-        {
-          int decimalDigits = field.getScale();
-          final TimeUnit unit;
-          if (decimalDigits == 0) {
-            unit = TimeUnit.SECOND;
-          } else if (decimalDigits > 0 && decimalDigits <= 3) {
-            unit = TimeUnit.MILLISECOND;
-          } else if (decimalDigits > 0 && decimalDigits <= 6) {
-            unit = TimeUnit.MICROSECOND;
-          } else if (decimalDigits > 6) {
-            unit = TimeUnit.NANOSECOND;
-          } else {
-            // Negative precision?
-            return null;
-          }
-          if ("timestamptz".equals(field.getTypeName())) {
-            return new ArrowType.Timestamp(unit, "UTC");
-          } else if ("timestamp".equals(field.getTypeName())) {
-            return new ArrowType.Timestamp(unit, /*timezone*/ null);
-          }
-          // Unknown type
-          return null;
+        if ("timestamptz".equals(field.getTypeName())) {
+          return new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC");
+        } else if ("timestamp".equals(field.getTypeName())) {
+          return new ArrowType.Timestamp(TimeUnit.MICROSECOND, /*timezone*/ null);
         }
+        // Unknown type
+        return null;
       default:
         return JdbcToArrowUtils.getArrowTypeFromJdbcType(field.getFieldInfo(), /*calendar*/ null);
     }


### PR DESCRIPTION
Fixes #770.