### PR TITLE
fix(go/adbc/driver/snowflake): initialize Params, add DLL build

### DIFF
--- a/go/adbc/driver/snowflake/driver.go
+++ b/go/adbc/driver/snowflake/driver.go
@@ -221,7 +221,9 @@ func (d *database) SetOptions(cnOptions map[string]string) error {
 		d.cfg = cfg
 		delete(cnOptions, adbc.OptionKeyURI)
 	} else {
-		d.cfg = &gosnowflake.Config{}
+		d.cfg = &gosnowflake.Config{
+			Params: make(map[string]*string),
+		}
 	}
 
 	var err error

--- a/go/adbc/pkg/Makefile
+++ b/go/adbc/pkg/Makefile
@@ -17,6 +17,8 @@
 GO_BUILD=go build
 ifeq ($(shell go env GOOS),linux)
 	SUFFIX=so
+else ifeq ($(shell go env GOOS),windows)
+	SUFFIX=dll
 else
 	SUFFIX=dylib
 endif


### PR DESCRIPTION
Fixes https://github.com/apache/arrow-adbc/issues/819

Adds build for Windows DLLs