### PR TITLE
ci: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,8 +26,8 @@
 adbc.h @lidavidm
 
 ## Implementations
-/c/ @lidavidm @WillAyd
-/csharp/ @CurtHagenlocher @davidhcoe
+/c/ @lidavidm
+# /csharp/
 /glib/ @kou
 /java/ @lidavidm
 /go/ @zeroshade

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@ adbc.h @lidavidm
 
 ## Implementations
 /c/ @lidavidm
-# /csharp/
+/csharp/ @lidavidm
 /glib/ @kou
 /java/ @lidavidm
 /go/ @zeroshade

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,7 @@ adbc.h @lidavidm
 /rust/ @wjones127
 
 ## Docs
-# /docs/
+/docs/ @lidavidm
 # *.md
 # *.rst
 # *.txt

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Any committer can add themselves to any  of the path patterns
+# and will subsequently get requested as a reviewer for any PRs
+# that change matching files.
+#
+# This file uses .gitignore syntax with a few exceptions see the
+# documentation about the syntax: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+## Format
+adbc.h @lidavidm
+
+## Implementations
+/c/ @lidavidm @WillAyd
+/csharp/ @CurtHagenlocher @davidhcoe
+/glib/ @kou
+/java/ @lidavidm
+/go/ @zeroshade
+/python/ @lidavidm
+/r/ @paleolimbot
+/ruby/ @kou
+/rust/ @wjones127
+
+## Docs
+# /docs/
+# *.md
+# *.rst
+# *.txt
+
+## PR CI and repo files
+/.github/ @lidavidm @zeroshade
+.asf.yaml @lidavidm @kou
+.pre-commit-config.yaml @lidavidm
+# .git*
+
+# release scripts
+/ci/ @lidavidm @kou
+/dev/ @lidavidm @kou
+.env @lidavidm


### PR DESCRIPTION
Adding a CODEOWNERS file for auto assigning reviewers on PRs. Feel free to update, add, modify names and assignments here.