### PR TITLE
chore(r/adbcdrivermanager): Add link in DESCRIPTION

### DIFF
--- a/r/adbcdrivermanager/DESCRIPTION
+++ b/r/adbcdrivermanager/DESCRIPTION
@@ -10,8 +10,8 @@ Authors@R: c(
 Description: Provides a developer-facing interface to 'Arrow' Database
   Connectivity ('ADBC') for the purposes of driver development, driver
   testing, and building high-level database interfaces for users. 'ADBC'
-  is an API standard for database access libraries that uses 'Arrow' for
-  result sets and query parameters.
+  <https://arrow.apache.org/adbc/> is an API standard for database access
+  libraries that uses 'Arrow' for result sets and query parameters.
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/r/adbcdrivermanager/man/adbcdrivermanager-package.Rd
+++ b/r/adbcdrivermanager/man/adbcdrivermanager-package.Rd
@@ -6,7 +6,7 @@
 \alias{adbcdrivermanager-package}
 \title{adbcdrivermanager: 'Arrow' Database Connectivity ('ADBC') Driver Manager}
 \description{
-Provides a developer-facing interface to 'Arrow' Database Connectivity ('ADBC') for the purposes of driver development, driver testing, and building high-level database interfaces for users. 'ADBC' is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.
+Provides a developer-facing interface to 'Arrow' Database Connectivity ('ADBC') for the purposes of driver development, driver testing, and building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
From the CRAN incoming reviewer:

```
Thanks,

Please add a web reference for the API in the form <https:.....> to the description of the DESCRIPTION file with no space after 'https:' and angle brackets for auto-linking.

Please fix and resubmit.
```