### PR TITLE
chore: Update + unify R driver packages after adbcdrivermanager CRAN release

### DIFF
--- a/docs/source/driver/flight_sql.rst
+++ b/docs/source/driver/flight_sql.rst
@@ -70,6 +70,14 @@ Installation
          # For pip
          pip install adbc_driver_flightsql
 
+   .. tab-item:: R
+      :sync: r
+
+      .. code-block:: r
+
+         # install.packages("remotes")
+         remotes::install_github("apache/arrow-adbc/r/adbcflightsql", build = FALSE)
+
 Usage
 =====
 

--- a/docs/source/driver/postgresql.rst
+++ b/docs/source/driver/postgresql.rst
@@ -76,7 +76,7 @@ Installation
       .. code-block:: r
 
          # install.packages("remotes")
-         remotes::install_github("apache/arrow-adbc/r/adbcpostgresql")
+         remotes::install_github("apache/arrow-adbc/r/adbcpostgresql", build = FALSE)
 
 Usage
 =====

--- a/docs/source/driver/snowflake.rst
+++ b/docs/source/driver/snowflake.rst
@@ -61,7 +61,6 @@ Installation
       .. code-block:: shell
 
          # install.packages("remotes")
-         remotes::install_github("apache/arrow-adbc/r/adbcdrivermanager", build = FALSE)
          remotes::install_github("apache/arrow-adbc/r/adbcsnowflake", build = FALSE)
 
 Usage

--- a/docs/source/driver/sqlite.rst
+++ b/docs/source/driver/sqlite.rst
@@ -58,7 +58,6 @@ Installation
       .. code-block:: shell
 
          # install.packages("remotes")
-         remotes::install_github("apache/arrow-adbc/r/adbcdrivermanager", build = FALSE)
          remotes::install_github("apache/arrow-adbc/r/adbcsqlite", build = FALSE)
 
    .. tab-item:: Go

--- a/r/adbcdrivermanager/README.Rmd
+++ b/r/adbcdrivermanager/README.Rmd
@@ -50,8 +50,8 @@ install.packages("adbcdrivermanager")
 You can install the development version of adbcdrivermanager from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("pak")
-pak::pkg_install("apache/arrow-adbc/r/adbcdrivermanager")
+# install.packages("remotes")
+remotes::install_github("apache/arrow-adbc/r/adbcdrivermanager", build = FALSE)
 ```
 
 ## Example

--- a/r/adbcdrivermanager/README.Rmd
+++ b/r/adbcdrivermanager/README.Rmd
@@ -50,8 +50,8 @@ install.packages("adbcdrivermanager")
 You can install the development version of adbcdrivermanager from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcdrivermanager")
+# install.packages("pak")
+pak::pkg_install("apache/arrow-adbc/r/adbcdrivermanager")
 ```
 
 ## Example

--- a/r/adbcdrivermanager/README.md
+++ b/r/adbcdrivermanager/README.md
@@ -40,8 +40,8 @@ You can install the development version of adbcdrivermanager from
 [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcdrivermanager")
+# install.packages("pak")
+pak::pkg_install("apache/arrow-adbc/r/adbcdrivermanager")
 ```
 
 ## Example

--- a/r/adbcdrivermanager/README.md
+++ b/r/adbcdrivermanager/README.md
@@ -40,8 +40,8 @@ You can install the development version of adbcdrivermanager from
 [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("pak")
-pak::pkg_install("apache/arrow-adbc/r/adbcdrivermanager")
+# install.packages("remotes")
+remotes::install_github("apache/arrow-adbc/r/adbcdrivermanager", build = FALSE)
 ```
 
 ## Example

--- a/r/adbcflightsql/DESCRIPTION
+++ b/r/adbcflightsql/DESCRIPTION
@@ -1,13 +1,17 @@
 Package: adbcflightsql
-Title: Arrow Database Connectivity (ADBC) FlightSQL Driver
+Title: 'Arrow' Database Connectivity ('ADBC') 'FlightSQL' Driver
 Version: 0.5.0.9000
 Authors@R: c(
       person("Dewey", "Dunnington", , "dewey@dunnington.ca", role = c("aut", "cre"),
              comment = c(ORCID = "0000-0002-9415-4582")),
-      person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph"))
+      person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph")),
+      person("Apache Software Foundation", email = "dev@arrow.apache.org", role = c("cph"))
     )
-Description: Provides a developer-facing interface to the Arrow Database
-  Connectivity (ADBC) FlightSQL driver.
+Description: Provides a developer-facing interface to the 'Arrow' Database
+  Connectivity ('ADBC') 'FlightSQL' driver  for the purposes of building high-level
+  database interfaces for users. 'ADBC' <https://arrow.apache.org/adbc/> is
+  an API standard for database access libraries that uses 'Arrow' for result
+  sets and query parameters.
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
@@ -19,7 +23,4 @@ Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
 URL: https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
-Imports:
-    adbcdrivermanager
-Remotes:
-    adbcdrivermanager=apache/arrow-adbc/r/adbcdrivermanager
+Imports: adbcdrivermanager

--- a/r/adbcflightsql/R/adbcflightsql-package.R
+++ b/r/adbcflightsql/R/adbcflightsql-package.R
@@ -57,7 +57,7 @@ adbc_database_init.adbcflightsql_driver_flightsql <- function(driver, ..., uri =
   options <- list(..., uri = uri)
   adbcdrivermanager::adbc_database_init_default(
     driver,
-    options[!vapply(options, is.null, logical(1))],
+    options,
     subclass = "adbcflightsql_database"
   )
 }
@@ -70,7 +70,7 @@ adbc_connection_init.adbcflightsql_database <- function(database, ...,
   options <- list(..., adbc.connection.autocommit = adbc.connection.autocommit)
   adbcdrivermanager::adbc_connection_init_default(
     database,
-    options[!vapply(options, is.null, logical(1))],
+    options,
     subclass = "adbcflightsql_connection"
   )
 }
@@ -89,7 +89,7 @@ adbc_statement_init.adbcflightsql_connection <- function(connection, ...,
 
   adbcdrivermanager::adbc_statement_init_default(
     connection,
-    options[!vapply(options, is.null, logical(1))],
+    options,
     subclass = "adbcflightsql_statement"
   )
 }

--- a/r/adbcflightsql/README.Rmd
+++ b/r/adbcflightsql/README.Rmd
@@ -44,14 +44,12 @@ You can install the development version of adbcflightsql from [GitHub](https://g
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcdrivermanager", build = FALSE)
 remotes::install_github("apache/arrow-adbc/r/adbcflightsql", build = FALSE)
 ```
 
 ## Example
 
 This is a basic example which shows you how to solve a common problem.
-
 
 ```{r example}
 library(adbcdrivermanager)
@@ -63,47 +61,26 @@ db <- adbc_database_init(adbcflightsql::adbcflightsql(), uri = uri)
 con <- adbc_connection_init(db)
 
 # Write a table
-stmt <- adbc_statement_init(con)
-adbc_statement_set_sql_query(
-  stmt,
-  "CREATE TABLE crossfit (exercise TEXT, difficulty_level INTEGER)"
-)
-adbc_statement_execute_query(stmt)
-adbc_statement_release(stmt)
-
-stmt <- adbc_statement_init(con)
-adbc_statement_set_sql_query(
-  stmt,
-  "INSERT INTO crossfit values
-    ('Push Ups', 3),
-    ('Pull Ups', 5),
-    ('Push Jerk', 7),
-    ('Bar Muscle Up', 10);"
-)
-adbc_statement_execute_query(stmt)
-adbc_statement_release(stmt)
+con |>
+  execute_adbc("CREATE TABLE crossfit (exercise TEXT, difficulty_level INTEGER)") |>
+  execute_adbc(
+    "INSERT INTO crossfit values
+      ('Push Ups', 3),
+      ('Pull Ups', 5),
+      ('Push Jerk', 7),
+      ('Bar Muscle Up', 10);"
+  )
 
 # Query it
-stmt <- adbc_statement_init(con)
-stream <- nanoarrow::nanoarrow_allocate_array_stream()
-
-adbc_statement_set_sql_query(stmt, "SELECT * from crossfit")
-adbc_statement_execute_query(stmt, stream)
-result <- tibble::as_tibble(stream)
-adbc_statement_release(stmt)
-
-result
+con |>
+  read_adbc("SELECT * from crossfit") |>
+  tibble::as_tibble()
 ```
 
-```{r example-clean-up, include=FALSE}
-stmt <- adbc_statement_init(con)
-adbc_statement_set_sql_query(stmt, "DROP TABLE crossfit")
-adbc_statement_execute_query(stmt)
-adbc_statement_release(stmt)
-```
-
-```{r example-clean-up2, include=FALSE}
+```{r example-clean-up}
 # Clean up
+con |>
+  execute_adbc("DROP TABLE crossfit")
 adbc_connection_release(con)
 adbc_database_release(db)
 ```

--- a/r/adbcflightsql/man/adbcflightsql-package.Rd
+++ b/r/adbcflightsql/man/adbcflightsql-package.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/adbcflightsql-package.R
 \docType{package}
 \name{adbcflightsql-package}
-\title{adbcflightsql: Arrow Database Connectivity (ADBC) FlightSQL Driver}
+\title{adbcflightsql: 'Arrow' Database Connectivity ('ADBC') 'FlightSQL' Driver}
 \description{
-Provides a developer-facing interface to the Arrow Database Connectivity (ADBC) FlightSQL driver.
+Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADBC') 'FlightSQL' driver for the purposes of building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.
 }
 \seealso{
 Useful links:
@@ -20,6 +20,11 @@ Useful links:
 Authors:
 \itemize{
   \item Apache Arrow \email{dev@arrow.apache.org} [copyright holder]
+}
+
+Other contributors:
+\itemize{
+  \item Apache Software Foundation \email{dev@arrow.apache.org} [copyright holder]
 }
 
 }

--- a/r/adbcpostgresql/DESCRIPTION
+++ b/r/adbcpostgresql/DESCRIPTION
@@ -7,7 +7,10 @@ Authors@R: c(
       person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph"))
     )
 Description: Provides a developer-facing interface to the Arrow Database
-  Connectivity (ADBC) PostgreSQL driver.
+  Connectivity (ADBC) PostgreSQL driver for the purposes of building high-level
+  database interfaces for users. 'ADBC' <https://arrow.apache.org/adbc/> is
+  an API standard for database access libraries that uses 'Arrow' for result
+  sets and query parameters.
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
@@ -20,7 +23,5 @@ Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
 URL: https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
-Imports:
-    adbcdrivermanager
-Remotes:
-    adbcdrivermanager=apache/arrow-adbc/r/adbcdrivermanager
+Imports: adbcdrivermanager
+

--- a/r/adbcpostgresql/DESCRIPTION
+++ b/r/adbcpostgresql/DESCRIPTION
@@ -4,9 +4,10 @@ Version: 0.5.0.9000
 Authors@R: c(
       person("Dewey", "Dunnington", , "dewey@dunnington.ca", role = c("aut", "cre"),
              comment = c(ORCID = "0000-0002-9415-4582")),
-      person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph"))
+      person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph")),
+      person("Apache Software Foundation", email = "dev@arrow.apache.org", role = c("cph"))
     )
-Description: Provides a developer-facing interface to the Arrow Database
+Description: Provides a developer-facing interface to the 'Arrow' Database
   Connectivity ('ADBC') 'PostgreSQL' driver for the purposes of building high-level
   database interfaces for users. 'ADBC' <https://arrow.apache.org/adbc/> is
   an API standard for database access libraries that uses 'Arrow' for result

--- a/r/adbcpostgresql/DESCRIPTION
+++ b/r/adbcpostgresql/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: adbcpostgresql
-Title: Arrow Database Connectivity (ADBC) PostgreSQL Driver
+Title: 'Arrow' Database Connectivity ('ADBC') 'PostgreSQL' Driver
 Version: 0.5.0.9000
 Authors@R: c(
       person("Dewey", "Dunnington", , "dewey@dunnington.ca", role = c("aut", "cre"),
@@ -7,7 +7,7 @@ Authors@R: c(
       person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph"))
     )
 Description: Provides a developer-facing interface to the Arrow Database
-  Connectivity (ADBC) PostgreSQL driver for the purposes of building high-level
+  Connectivity ('ADBC') 'PostgreSQL' driver for the purposes of building high-level
   database interfaces for users. 'ADBC' <https://arrow.apache.org/adbc/> is
   an API standard for database access libraries that uses 'Arrow' for result
   sets and query parameters.
@@ -24,4 +24,3 @@ Config/build/bootstrap: TRUE
 URL: https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports: adbcdrivermanager
-

--- a/r/adbcpostgresql/R/adbcpostgresql-package.R
+++ b/r/adbcpostgresql/R/adbcpostgresql-package.R
@@ -55,7 +55,7 @@ adbcpostgresql <- function() {
 adbc_database_init.adbcpostgresql_driver_postgresql <- function(driver, ..., uri) {
   adbcdrivermanager::adbc_database_init_default(
     driver,
-    list(uri = uri),
+    list(..., uri = uri),
     subclass = "adbcpostgresql_database"
   )
 }
@@ -65,10 +65,10 @@ adbc_database_init.adbcpostgresql_driver_postgresql <- function(driver, ..., uri
 #' @export
 adbc_connection_init.adbcpostgresql_database <- function(database, ...,
                                                          adbc.connection.autocommit = NULL) {
-  options <- list(adbc.connection.autocommit = adbc.connection.autocommit)
+  options <- list(..., adbc.connection.autocommit = adbc.connection.autocommit)
   adbcdrivermanager::adbc_connection_init_default(
     database,
-    options[!vapply(options, is.null, logical(1))],
+    options,
     subclass = "adbcpostgresql_connection"
   )
 }
@@ -80,13 +80,14 @@ adbc_statement_init.adbcpostgresql_connection <- function(connection, ...,
                                                       adbc.ingest.target_table = NULL,
                                                       adbc.ingest.mode = NULL) {
   options <- list(
+    ...,
     adbc.ingest.target_table = adbc.ingest.target_table,
     adbc.ingest.mode = adbc.ingest.mode
   )
 
   adbcdrivermanager::adbc_statement_init_default(
     connection,
-    options[!vapply(options, is.null, logical(1))],
+    options,
     subclass = "adbcpostgresql_statement"
   )
 }

--- a/r/adbcpostgresql/README.Rmd
+++ b/r/adbcpostgresql/README.Rmd
@@ -44,7 +44,7 @@ You can install the development version of adbcpostgresql from [GitHub](https://
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcpostgresql")
+remotes::install_github("apache/arrow-adbc/r/adbcpostgresql", build = FALSE)
 ```
 
 ## Example

--- a/r/adbcpostgresql/README.Rmd
+++ b/r/adbcpostgresql/README.Rmd
@@ -63,33 +63,19 @@ con <- adbc_connection_init(db)
 flights <- head(nycflights13::flights, 100)
 # (timestamp not supported yet)
 flights$time_hour <- NULL
-
-stmt <- adbc_statement_init(con, adbc.ingest.target_table = "flights")
-adbc_statement_bind(stmt, flights)
-adbc_statement_execute_query(stmt)
-adbc_statement_release(stmt)
+flights |>
+  write_adbc(con, "flights")
 
 # Query it
-stmt <- adbc_statement_init(con)
-stream <- nanoarrow::nanoarrow_allocate_array_stream()
-
-adbc_statement_set_sql_query(stmt, "SELECT * from flights")
-adbc_statement_execute_query(stmt, stream)
-result <- tibble::as_tibble(stream)
-adbc_statement_release(stmt)
-
-result
+con |>
+  read_adbc("SELECT * from flights") |>
+  tibble::as_tibble()
 ```
 
-```{r example-clean-up, include=FALSE}
-stmt <- adbc_statement_init(con)
-adbc_statement_set_sql_query(stmt, "DROP TABLE flights")
-adbc_statement_execute_query(stmt)
-adbc_statement_release(stmt)
-```
-
-```{r example-clean-up2, include=FALSE}
+```{r example-clean-up}
 # Clean up
+con |>
+  execute_adbc("DROP TABLE flights")
 adbc_connection_release(con)
 adbc_database_release(db)
 ```

--- a/r/adbcpostgresql/README.md
+++ b/r/adbcpostgresql/README.md
@@ -32,7 +32,7 @@ You can install the development version of adbcpostgresql from
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcpostgresql")
+remotes::install_github("apache/arrow-adbc/r/adbcpostgresql", build = FALSE)
 ```
 
 ## Example

--- a/r/adbcpostgresql/README.md
+++ b/r/adbcpostgresql/README.md
@@ -51,39 +51,36 @@ con <- adbc_connection_init(db)
 flights <- head(nycflights13::flights, 100)
 # (timestamp not supported yet)
 flights$time_hour <- NULL
-
-stmt <- adbc_statement_init(con, adbc.ingest.target_table = "flights")
-adbc_statement_bind(stmt, flights)
-adbc_statement_execute_query(stmt)
-#> [1] 100
-adbc_statement_release(stmt)
+flights |>
+  write_adbc(con, "flights")
 
 # Query it
-stmt <- adbc_statement_init(con)
-stream <- nanoarrow::nanoarrow_allocate_array_stream()
-
-adbc_statement_set_sql_query(stmt, "SELECT * from flights")
-adbc_statement_execute_query(stmt, stream)
-#> [1] -1
-result <- tibble::as_tibble(stream)
-adbc_statement_release(stmt)
-
-result
+con |>
+  read_adbc("SELECT * from flights") |>
+  tibble::as_tibble()
 #> # A tibble: 100 × 18
-#>     year month   day dep_time sched_de…¹ dep_d…² arr_t…³ sched…⁴ arr_d…⁵ carrier
-#>    <int> <int> <int>    <int>      <int>   <dbl>   <int>   <int>   <dbl> <chr>
-#>  1  2013     1     1      517        515       2     830     819      11 UA
-#>  2  2013     1     1      533        529       4     850     830      20 UA
-#>  3  2013     1     1      542        540       2     923     850      33 AA
-#>  4  2013     1     1      544        545      -1    1004    1022     -18 B6
-#>  5  2013     1     1      554        600      -6     812     837     -25 DL
-#>  6  2013     1     1      554        558      -4     740     728      12 UA
-#>  7  2013     1     1      555        600      -5     913     854      19 B6
-#>  8  2013     1     1      557        600      -3     709     723     -14 EV
-#>  9  2013     1     1      557        600      -3     838     846      -8 B6
-#> 10  2013     1     1      558        600      -2     753     745       8 AA
-#> # … with 90 more rows, 8 more variables: flight <int>, tailnum <chr>,
-#> #   origin <chr>, dest <chr>, air_time <dbl>, distance <dbl>, hour <dbl>,
-#> #   minute <dbl>, and abbreviated variable names ¹​sched_dep_time, ²​dep_delay,
-#> #   ³​arr_time, ⁴​sched_arr_time, ⁵​arr_delay
+#>     year month   day dep_time sched_dep_time dep_delay arr_time sched_arr_time
+#>    <int> <int> <int>    <int>          <int>     <dbl>    <int>          <int>
+#>  1  2013     1     1      517            515         2      830            819
+#>  2  2013     1     1      533            529         4      850            830
+#>  3  2013     1     1      542            540         2      923            850
+#>  4  2013     1     1      544            545        -1     1004           1022
+#>  5  2013     1     1      554            600        -6      812            837
+#>  6  2013     1     1      554            558        -4      740            728
+#>  7  2013     1     1      555            600        -5      913            854
+#>  8  2013     1     1      557            600        -3      709            723
+#>  9  2013     1     1      557            600        -3      838            846
+#> 10  2013     1     1      558            600        -2      753            745
+#> # ℹ 90 more rows
+#> # ℹ 10 more variables: arr_delay <dbl>, carrier <chr>, flight <int>,
+#> #   tailnum <chr>, origin <chr>, dest <chr>, air_time <dbl>, distance <dbl>,
+#> #   hour <dbl>, minute <dbl>
+```
+
+``` r
+# Clean up
+con |>
+  execute_adbc("DROP TABLE flights")
+adbc_connection_release(con)
+adbc_database_release(db)
 ```

--- a/r/adbcpostgresql/man/adbcpostgresql-package.Rd
+++ b/r/adbcpostgresql/man/adbcpostgresql-package.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/adbcpostgresql-package.R
 \docType{package}
 \name{adbcpostgresql-package}
-\title{adbcpostgresql: Arrow Database Connectivity (ADBC) PostgreSQL Driver}
+\title{adbcpostgresql: 'Arrow' Database Connectivity ('ADBC') 'PostgreSQL' Driver}
 \description{
-Provides a developer-facing interface to the Arrow Database Connectivity (ADBC) PostgreSQL driver for the purposes of building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.
+Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADBC') 'PostgreSQL' driver for the purposes of building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.
 }
 \seealso{
 Useful links:
@@ -20,6 +20,11 @@ Useful links:
 Authors:
 \itemize{
   \item Apache Arrow \email{dev@arrow.apache.org} [copyright holder]
+}
+
+Other contributors:
+\itemize{
+  \item Apache Software Foundation \email{dev@arrow.apache.org} [copyright holder]
 }
 
 }

--- a/r/adbcpostgresql/man/adbcpostgresql-package.Rd
+++ b/r/adbcpostgresql/man/adbcpostgresql-package.Rd
@@ -4,7 +4,7 @@
 \name{adbcpostgresql-package}
 \title{adbcpostgresql: Arrow Database Connectivity (ADBC) PostgreSQL Driver}
 \description{
-Provides a developer-facing interface to the Arrow Database Connectivity (ADBC) PostgreSQL driver.
+Provides a developer-facing interface to the Arrow Database Connectivity (ADBC) PostgreSQL driver for the purposes of building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.
 }
 \seealso{
 Useful links:

--- a/r/adbcsnowflake/DESCRIPTION
+++ b/r/adbcsnowflake/DESCRIPTION
@@ -1,13 +1,17 @@
 Package: adbcsnowflake
-Title: Arrow Database Connectivity (ADBC) Snowflake Driver
+Title: Arrow Database Connectivity ('ADBC') 'Snowflake' Driver
 Version: 0.5.0.9000
 Authors@R: c(
       person("Dewey", "Dunnington", , "dewey@dunnington.ca", role = c("aut", "cre"),
              comment = c(ORCID = "0000-0002-9415-4582")),
-      person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph"))
+      person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph")),
+      person("Apache Software Foundation", email = "dev@arrow.apache.org", role = c("cph"))
     )
-Description: Provides a developer-facing interface to the Arrow Database
-  Connectivity (ADBC) Snowflake driver.
+Description: Provides a developer-facing interface to the 'Arrow' Database
+  Connectivity ('ADBC') 'Snowflake' driver for the purposes of building high-level
+  database interfaces for users. 'ADBC' <https://arrow.apache.org/adbc/> is
+  an API standard for database access libraries that uses 'Arrow' for result
+  sets and query parameters.
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
@@ -19,7 +23,4 @@ Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
 URL: https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
-Imports:
-    adbcdrivermanager
-Remotes:
-    adbcdrivermanager=apache/arrow-adbc/r/adbcdrivermanager
+Imports: adbcdrivermanager

--- a/r/adbcsnowflake/R/adbcsnowflake-package.R
+++ b/r/adbcsnowflake/R/adbcsnowflake-package.R
@@ -57,7 +57,7 @@ adbc_database_init.adbcsnowflake_driver_snowflake <- function(driver, ..., uri =
   options <- list(..., uri = uri)
   adbcdrivermanager::adbc_database_init_default(
     driver,
-    options[!vapply(options, is.null, logical(1))],
+    options,
     subclass = "adbcsnowflake_database"
   )
 }
@@ -70,7 +70,7 @@ adbc_connection_init.adbcsnowflake_database <- function(database, ...,
   options <- list(..., adbc.connection.autocommit = adbc.connection.autocommit)
   adbcdrivermanager::adbc_connection_init_default(
     database,
-    options[!vapply(options, is.null, logical(1))],
+    options,
     subclass = "adbcsnowflake_connection"
   )
 }
@@ -89,7 +89,7 @@ adbc_statement_init.adbcsnowflake_connection <- function(connection, ...,
 
   adbcdrivermanager::adbc_statement_init_default(
     connection,
-    options[!vapply(options, is.null, logical(1))],
+    options,
     subclass = "adbcsnowflake_statement"
   )
 }

--- a/r/adbcsnowflake/README.Rmd
+++ b/r/adbcsnowflake/README.Rmd
@@ -44,7 +44,6 @@ You can install the development version of adbcsnowflake from [GitHub](https://g
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcdrivermanager", build = FALSE)
 remotes::install_github("apache/arrow-adbc/r/adbcsnowflake", build = FALSE)
 ```
 
@@ -53,7 +52,6 @@ remotes::install_github("apache/arrow-adbc/r/adbcsnowflake", build = FALSE)
 This is a basic example which shows you how to solve a common problem. For examples
 of `uri` values to use as a connection value, see the documentation for the
 [upstream Go driver implementation](https://github.com/apache/arrow-adbc/blob/main/docs/source/driver/go/snowflake.rst#uri-format).
-
 
 ```{r example}
 library(adbcdrivermanager)
@@ -64,15 +62,9 @@ uri <- Sys.getenv("ADBC_SNOWFLAKE_TEST_URI")
 db <- adbc_database_init(adbcsnowflake::adbcsnowflake(), uri = uri)
 con <- adbc_connection_init(db)
 
-stmt <- adbcdrivermanager::adbc_statement_init(con)
-adbcdrivermanager::adbc_statement_set_sql_query(
-  stmt,
-  "SELECT * FROM REGION ORDER BY R_REGIONKEY"
-)
-
-stream <- nanoarrow::nanoarrow_allocate_array_stream()
-adbcdrivermanager::adbc_statement_execute_query(stmt, stream)
-tibble::as_tibble(stream)
+con |>
+  read_adbc("SELECT * FROM REGION ORDER BY R_REGIONKEY") |>
+  tibble::as_tibble()
 ```
 
 ```{r example-clean-up2}

--- a/r/adbcsnowflake/README.md
+++ b/r/adbcsnowflake/README.md
@@ -32,7 +32,6 @@ You can install the development version of adbcsnowflake from
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcdrivermanager", build = FALSE)
 remotes::install_github("apache/arrow-adbc/r/adbcsnowflake", build = FALSE)
 ```
 
@@ -52,16 +51,9 @@ uri <- Sys.getenv("ADBC_SNOWFLAKE_TEST_URI")
 db <- adbc_database_init(adbcsnowflake::adbcsnowflake(), uri = uri)
 con <- adbc_connection_init(db)
 
-stmt <- adbcdrivermanager::adbc_statement_init(con)
-adbcdrivermanager::adbc_statement_set_sql_query(
-  stmt,
-  "SELECT * FROM REGION ORDER BY R_REGIONKEY"
-)
-
-stream <- nanoarrow::nanoarrow_allocate_array_stream()
-adbcdrivermanager::adbc_statement_execute_query(stmt, stream)
-#> [1] 5
-tibble::as_tibble(stream)
+con |>
+  read_adbc("SELECT * FROM REGION ORDER BY R_REGIONKEY") |>
+  tibble::as_tibble()
 #> # A tibble: 5 × 3
 #>   R_REGIONKEY R_NAME      R_COMMENT
 #>         <dbl> <chr>       <chr>

--- a/r/adbcsnowflake/man/adbcsnowflake-package.Rd
+++ b/r/adbcsnowflake/man/adbcsnowflake-package.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/adbcsnowflake-package.R
 \docType{package}
 \name{adbcsnowflake-package}
-\title{adbcsnowflake: Arrow Database Connectivity (ADBC) Snowflake Driver}
+\title{adbcsnowflake: Arrow Database Connectivity ('ADBC') 'Snowflake' Driver}
 \description{
-Provides a developer-facing interface to the Arrow Database Connectivity (ADBC) Snowflake driver.
+Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADBC') 'Snowflake' driver for the purposes of building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.
 }
 \seealso{
 Useful links:
@@ -20,6 +20,11 @@ Useful links:
 Authors:
 \itemize{
   \item Apache Arrow \email{dev@arrow.apache.org} [copyright holder]
+}
+
+Other contributors:
+\itemize{
+  \item Apache Software Foundation \email{dev@arrow.apache.org} [copyright holder]
 }
 
 }

--- a/r/adbcsqlite/DESCRIPTION
+++ b/r/adbcsqlite/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: adbcsqlite
-Title: 'Arrow' Database Connectivity ('ADBC') SQLite Driver
+Title: 'Arrow' Database Connectivity ('ADBC') 'SQLite' Driver
 Version: 0.5.0.9000
 Authors@R: c(
       person("Dewey", "Dunnington", , "dewey@dunnington.ca", role = c("aut", "cre"),
@@ -8,7 +8,7 @@ Authors@R: c(
       person("Apache Software Foundation", email = "dev@arrow.apache.org", role = c("cph"))
     )
 Description: Provides a developer-facing interface to the 'Arrow' Database
-  Connectivity ('ADBC') SQLite driver for the purposes of building high-level
+  Connectivity ('ADBC') 'SQLite' driver for the purposes of building high-level
   database interfaces for users. 'ADBC' <https://arrow.apache.org/adbc/> is
   an API standard for database access libraries that uses 'Arrow' for result
   sets and query parameters.

--- a/r/adbcsqlite/DESCRIPTION
+++ b/r/adbcsqlite/DESCRIPTION
@@ -8,10 +8,10 @@ Authors@R: c(
       person("Apache Software Foundation", email = "dev@arrow.apache.org", role = c("cph"))
     )
 Description: Provides a developer-facing interface to the 'Arrow' Database
-  Connectivity ('ADBC') SQLite driver. for the purposes of driver development, driver
-  testing, and building high-level database interfaces for users. 'ADBC'
-  <https://arrow.apache.org/adbc/> is an API standard for database access
-  libraries that uses 'Arrow' for result sets and query parameters.
+  Connectivity ('ADBC') SQLite driver for the purposes of building high-level
+  database interfaces for users. 'ADBC' <https://arrow.apache.org/adbc/> is
+  an API standard for database access libraries that uses 'Arrow' for result
+  sets and query parameters.
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/r/adbcsqlite/DESCRIPTION
+++ b/r/adbcsqlite/DESCRIPTION
@@ -1,13 +1,17 @@
 Package: adbcsqlite
-Title: Arrow Database Connectivity (ADBC) SQLite Driver
+Title: 'Arrow' Database Connectivity ('ADBC') SQLite Driver
 Version: 0.5.0.9000
 Authors@R: c(
       person("Dewey", "Dunnington", , "dewey@dunnington.ca", role = c("aut", "cre"),
              comment = c(ORCID = "0000-0002-9415-4582")),
-      person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph"))
+      person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph")),
+      person("Apache Software Foundation", email = "dev@arrow.apache.org", role = c("cph"))
     )
-Description: Provides a developer-facing interface to the Arrow Database
-  Connectivity (ADBC) SQLite driver.
+Description: Provides a developer-facing interface to the 'Arrow' Database
+  Connectivity ('ADBC') SQLite driver. for the purposes of driver development, driver
+  testing, and building high-level database interfaces for users. 'ADBC'
+  <https://arrow.apache.org/adbc/> is an API standard for database access
+  libraries that uses 'Arrow' for result sets and query parameters.
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
@@ -20,7 +24,4 @@ Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
 URL: https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
-Imports:
-    adbcdrivermanager
-Remotes:
-    adbcdrivermanager=apache/arrow-adbc/r/adbcdrivermanager
+Imports: adbcdrivermanager

--- a/r/adbcsqlite/R/adbcsqlite-package.R
+++ b/r/adbcsqlite/R/adbcsqlite-package.R
@@ -55,7 +55,7 @@ adbcsqlite <- function() {
 adbc_database_init.adbcsqlite_driver_sqlite <- function(driver, ..., uri = ":memory:") {
   adbcdrivermanager::adbc_database_init_default(
     driver,
-    list(uri = uri),
+    list(..., uri = uri),
     subclass = "adbcsqlite_database"
   )
 }
@@ -65,10 +65,10 @@ adbc_database_init.adbcsqlite_driver_sqlite <- function(driver, ..., uri = ":mem
 #' @export
 adbc_connection_init.adbcsqlite_database <- function(database, ...,
                                                      adbc.connection.autocommit = NULL) {
-  options <- list(adbc.connection.autocommit = adbc.connection.autocommit)
+  options <- list(..., adbc.connection.autocommit = adbc.connection.autocommit)
   adbcdrivermanager::adbc_connection_init_default(
     database,
-    options[!vapply(options, is.null, logical(1))],
+    options,
     subclass = "adbcsqlite_connection"
   )
 }
@@ -81,6 +81,7 @@ adbc_statement_init.adbcsqlite_connection <- function(connection, ...,
                                                       adbc.ingest.mode = NULL,
                                                       adbc.sqlite.query.batch_rows = NULL) {
   options <- list(
+    ...,
     adbc.ingest.target_table = adbc.ingest.target_table,
     adbc.ingest.mode = adbc.ingest.mode,
     adbc.sqlite.query.batch_rows = adbc.sqlite.query.batch_rows
@@ -88,7 +89,7 @@ adbc_statement_init.adbcsqlite_connection <- function(connection, ...,
 
   adbcdrivermanager::adbc_statement_init_default(
     connection,
-    options[!vapply(options, is.null, logical(1))],
+    options,
     subclass = "adbcsqlite_statement"
   )
 }

--- a/r/adbcsqlite/README.Rmd
+++ b/r/adbcsqlite/README.Rmd
@@ -62,18 +62,18 @@ con <- adbc_connection_init(db)
 flights <- nycflights13::flights
 # (timestamp not supported yet)
 flights$time_hour <- NULL
-flights |> 
+flights |>
   write_adbc(con, "flights")
 
 # Query it
-con |> 
-  read_adbc("SELECT * from flights") |> 
+con |>
+  read_adbc("SELECT * from flights") |>
   tibble::as_tibble()
 ```
 
 ```{r}
 # Clean up
-con |> 
+con |>
   execute_adbc("DROP TABLE flights")
 adbc_connection_release(con)
 adbc_database_release(db)

--- a/r/adbcsqlite/README.Rmd
+++ b/r/adbcsqlite/README.Rmd
@@ -44,7 +44,7 @@ You can install the development version of adbcsqlite from [GitHub](https://gith
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcsqlite")
+pak::pak("apache/arrow-adbc/r/adbcsqlite")
 ```
 
 ## Example
@@ -62,23 +62,19 @@ con <- adbc_connection_init(db)
 flights <- nycflights13::flights
 # (timestamp not supported yet)
 flights$time_hour <- NULL
-
-stmt <- adbc_statement_init(con, adbc.ingest.target_table = "flights")
-adbc_statement_bind(stmt, flights)
-adbc_statement_execute_query(stmt)
-adbc_statement_release(stmt)
+flights |> 
+  write_adbc(con, "flights")
 
 # Query it
-stmt <- adbc_statement_init(con)
-adbc_statement_set_sql_query(stmt, "SELECT * from flights")
-stream <- nanoarrow::nanoarrow_allocate_array_stream()
-adbc_statement_execute_query(stmt, stream)
-result <- tibble::as_tibble(stream)
-adbc_statement_release(stmt)
+con |> 
+  read_adbc("SELECT * from flights") |> 
+  tibble::as_tibble()
+```
 
-result
-
+```{r}
 # Clean up
+con |> 
+  execute_adbc("DROP TABLE flights")
 adbc_connection_release(con)
 adbc_database_release(db)
 ```

--- a/r/adbcsqlite/README.Rmd
+++ b/r/adbcsqlite/README.Rmd
@@ -44,7 +44,7 @@ You can install the development version of adbcsqlite from [GitHub](https://gith
 
 ``` r
 # install.packages("remotes")
-pak::pak("apache/arrow-adbc/r/adbcsqlite")
+remotes::install_github("apache/arrow-adbc/r/adbcsqlite", build = FALSE)
 ```
 
 ## Example

--- a/r/adbcsqlite/README.md
+++ b/r/adbcsqlite/README.md
@@ -32,7 +32,7 @@ You can install the development version of adbcsqlite from
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcsqlite")
+pak::pak("apache/arrow-adbc/r/adbcsqlite")
 ```
 
 ## Example
@@ -50,42 +50,36 @@ con <- adbc_connection_init(db)
 flights <- nycflights13::flights
 # (timestamp not supported yet)
 flights$time_hour <- NULL
-
-stmt <- adbc_statement_init(con, adbc.ingest.target_table = "flights")
-adbc_statement_bind(stmt, flights)
-adbc_statement_execute_query(stmt)
-#> [1] 336776
-adbc_statement_release(stmt)
+flights |>
+  write_adbc(con, "flights")
 
 # Query it
-stmt <- adbc_statement_init(con)
-adbc_statement_set_sql_query(stmt, "SELECT * from flights")
-stream <- nanoarrow::nanoarrow_allocate_array_stream()
-adbc_statement_execute_query(stmt, stream)
-#> [1] -1
-result <- tibble::as_tibble(stream)
-adbc_statement_release(stmt)
-
-result
+con |>
+  read_adbc("SELECT * from flights") |>
+  tibble::as_tibble()
 #> # A tibble: 336,776 × 18
-#>     year month   day dep_time sched_de…¹ dep_d…² arr_t…³ sched…⁴ arr_d…⁵ carrier
-#>    <dbl> <dbl> <dbl>    <dbl>      <dbl>   <dbl>   <dbl>   <dbl>   <dbl> <chr>
-#>  1  2013     1     1      517        515       2     830     819      11 UA
-#>  2  2013     1     1      533        529       4     850     830      20 UA
-#>  3  2013     1     1      542        540       2     923     850      33 AA
-#>  4  2013     1     1      544        545      -1    1004    1022     -18 B6
-#>  5  2013     1     1      554        600      -6     812     837     -25 DL
-#>  6  2013     1     1      554        558      -4     740     728      12 UA
-#>  7  2013     1     1      555        600      -5     913     854      19 B6
-#>  8  2013     1     1      557        600      -3     709     723     -14 EV
-#>  9  2013     1     1      557        600      -3     838     846      -8 B6
-#> 10  2013     1     1      558        600      -2     753     745       8 AA
-#> # … with 336,766 more rows, 8 more variables: flight <dbl>, tailnum <chr>,
-#> #   origin <chr>, dest <chr>, air_time <dbl>, distance <dbl>, hour <dbl>,
-#> #   minute <dbl>, and abbreviated variable names ¹​sched_dep_time, ²​dep_delay,
-#> #   ³​arr_time, ⁴​sched_arr_time, ⁵​arr_delay
+#>     year month   day dep_time sched_dep_time dep_delay arr_time sched_arr_time
+#>    <dbl> <dbl> <dbl>    <dbl>          <dbl>     <dbl>    <dbl>          <dbl>
+#>  1  2013     1     1      517            515         2      830            819
+#>  2  2013     1     1      533            529         4      850            830
+#>  3  2013     1     1      542            540         2      923            850
+#>  4  2013     1     1      544            545        -1     1004           1022
+#>  5  2013     1     1      554            600        -6      812            837
+#>  6  2013     1     1      554            558        -4      740            728
+#>  7  2013     1     1      555            600        -5      913            854
+#>  8  2013     1     1      557            600        -3      709            723
+#>  9  2013     1     1      557            600        -3      838            846
+#> 10  2013     1     1      558            600        -2      753            745
+#> # ℹ 336,766 more rows
+#> # ℹ 10 more variables: arr_delay <dbl>, carrier <chr>, flight <dbl>,
+#> #   tailnum <chr>, origin <chr>, dest <chr>, air_time <dbl>, distance <dbl>,
+#> #   hour <dbl>, minute <dbl>
+```
 
+``` r
 # Clean up
+con |>
+  execute_adbc("DROP TABLE flights")
 adbc_connection_release(con)
 adbc_database_release(db)
 ```

--- a/r/adbcsqlite/README.md
+++ b/r/adbcsqlite/README.md
@@ -32,7 +32,7 @@ You can install the development version of adbcsqlite from
 
 ``` r
 # install.packages("remotes")
-pak::pak("apache/arrow-adbc/r/adbcsqlite")
+remotes::install_github("apache/arrow-adbc/r/adbcsqlite", build = FALSE)
 ```
 
 ## Example

--- a/r/adbcsqlite/man/adbcsqlite-package.Rd
+++ b/r/adbcsqlite/man/adbcsqlite-package.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/adbcsqlite-package.R
 \docType{package}
 \name{adbcsqlite-package}
-\title{adbcsqlite: Arrow Database Connectivity (ADBC) SQLite Driver}
+\title{adbcsqlite: 'Arrow' Database Connectivity ('ADBC') SQLite Driver}
 \description{
-Provides a developer-facing interface to the Arrow Database Connectivity (ADBC) SQLite driver.
+Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADBC') SQLite driver. for the purposes of driver development, driver testing, and building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.
 }
 \seealso{
 Useful links:
@@ -20,6 +20,11 @@ Useful links:
 Authors:
 \itemize{
   \item Apache Arrow \email{dev@arrow.apache.org} [copyright holder]
+}
+
+Other contributors:
+\itemize{
+  \item Apache Software Foundation \email{dev@arrow.apache.org} [copyright holder]
 }
 
 }

--- a/r/adbcsqlite/man/adbcsqlite-package.Rd
+++ b/r/adbcsqlite/man/adbcsqlite-package.Rd
@@ -2,9 +2,9 @@
 % Please edit documentation in R/adbcsqlite-package.R
 \docType{package}
 \name{adbcsqlite-package}
-\title{adbcsqlite: 'Arrow' Database Connectivity ('ADBC') SQLite Driver}
+\title{adbcsqlite: 'Arrow' Database Connectivity ('ADBC') 'SQLite' Driver}
 \description{
-Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADBC') SQLite driver. for the purposes of driver development, driver testing, and building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.
+Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADBC') 'SQLite' driver for the purposes of building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
This PR aligns the R driver packages to use functionality available now that adbcdrivermanager and nanoarrow 0.2.0 is on CRAN. This simplifies installing drivers considerably because CRAN dependencies are picked up automatically (no more `Remotes:`!!), so `remotes::install_github(..., build = FALSE)` should work reliably. It also allows using `read_adbc()` which is much nicer for the README examples for each driver.

While I had all the DESCRIPTIONs open, I also unified them so that they have a maximal chance of passing the CRAN incoming human review.

While I had all the packages open I also unified the database/connection/statement implementations since the details had changed since I wrote the first one (I now pass on `...` so that the user can pass on options that have been added since the last time I looked at what they were, and `options` that are `NULL` are now removed automatically whereas before that bit of code was copied in about 12 places).

edit: It looks like *all* the ways to install a GitHub package are now broken for subdirectories with a fresh install of remotes/pkgbuild. Hopefully that can get sorted soon...the unified install instructions should still work for people who haven't updated those packages recently.