### PR TITLE
fix(go/adbc/driver/snowflake): handle result sets without Arrow data

### DIFF
--- a/go/adbc/driver/snowflake/record_reader.go
+++ b/go/adbc/driver/snowflake/record_reader.go
@@ -245,6 +245,25 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, ld gosnowflake
 		return nil, errToAdbcErr(adbc.StatusInternal, err)
 	}
 
+	if len(batches) == 0 {
+		if ld.TotalRows() != 0 {
+			// XXX(https://github.com/apache/arrow-adbc/issues/863): Snowflake won't return Arrow data for certain queries
+			return nil, adbc.Error{
+				Msg:  "[Snowflake] Cannot get Arrow data from this result set (see apache/arrow-adbc#863)",
+				Code: adbc.StatusInternal,
+			}
+		}
+		schema := arrow.NewSchema([]arrow.Field{}, nil)
+		reader, err := array.NewRecordReader(schema, []arrow.Record{})
+		if err != nil {
+			return nil, adbc.Error{
+				Msg:  err.Error(),
+				Code: adbc.StatusInternal,
+			}
+		}
+		return reader, nil
+	}
+
 	ch := make(chan arrow.Record, bufferSize)
 	r, err := batches[0].GetStream(ctx)
 	if err != nil {


### PR DESCRIPTION
Prevents #863 from crashing, but doesn't fix the underlying error.