### PR TITLE
feat(c/driver/postgresql): TimestampTz write

### DIFF
--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -1025,6 +1025,18 @@ AdbcStatusCode PostgresConnection::SetOption(const char* key, const char* value,
     }
     return ADBC_STATUS_OK;
   }
+
+  if (std::strcmp(key, "TIME ZONE") == 0) {
+    std::string query = std::string("SET TIME ZONE '") + std::string(value) + "'";
+    PGresult* result = PQexec(conn_, query.c_str());
+    if (PQresultStatus(result) != PGRES_COMMAND_OK) {
+      PQclear(result);
+      return ADBC_STATUS_IO;
+    }
+    PQclear(result);
+    return ADBC_STATUS_OK;
+  }
+
   SetError(error, "%s%s", "[libpq] Unknown option ", key);
   return ADBC_STATUS_NOT_IMPLEMENTED;
 }

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -1025,18 +1025,6 @@ AdbcStatusCode PostgresConnection::SetOption(const char* key, const char* value,
     }
     return ADBC_STATUS_OK;
   }
-
-  if (std::strcmp(key, "TIME ZONE") == 0) {
-    std::string query = std::string("SET TIME ZONE '") + std::string(value) + "'";
-    PGresult* result = PQexec(conn_, query.c_str());
-    if (PQresultStatus(result) != PGRES_COMMAND_OK) {
-      PQclear(result);
-      return ADBC_STATUS_IO;
-    }
-    PQclear(result);
-    return ADBC_STATUS_OK;
-  }
-
   SetError(error, "%s%s", "[libpq] Unknown option ", key);
   return ADBC_STATUS_NOT_IMPLEMENTED;
 }

--- a/c/driver/postgresql/connection.h
+++ b/c/driver/postgresql/connection.h
@@ -54,7 +54,7 @@ class PostgresConnection {
   const std::shared_ptr<PostgresTypeResolver>& type_resolver() const {
     return type_resolver_;
   }
-  const bool autocommit() { return autocommit_; }
+  bool autocommit() const { return autocommit_; }
 
  private:
   std::shared_ptr<PostgresDatabase> database_;

--- a/c/driver/postgresql/connection.h
+++ b/c/driver/postgresql/connection.h
@@ -54,6 +54,7 @@ class PostgresConnection {
   const std::shared_ptr<PostgresTypeResolver>& type_resolver() const {
     return type_resolver_;
   }
+  const bool autocommit() { return autocommit_; }
 
  private:
   std::shared_ptr<PostgresDatabase> database_;

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -391,6 +391,46 @@ struct BindStream {
           }
         }
 
+        bool has_timezone = false;
+        for (int64_t col = 0; col < array_view->n_children; col++) {
+          if ((bind_schema_fields[col].type == ArrowType::NANOARROW_TYPE_TIMESTAMP) &&
+              !(strcmp("", bind_schema_fields[col].timezone))) {
+            has_timezone = true;
+          }
+        }
+
+        char* current_tz;
+        if (has_timezone) {
+          PGresult* begin_result = PQexec(conn, "BEGIN TRANSACTION");
+          if (PQresultStatus(begin_result) != PGRES_COMMAND_OK) {
+            SetError(error, "[libpq] Failed to begin transaction: %s",
+                     PQerrorMessage(conn));
+            PQclear(begin_result);
+            return ADBC_STATUS_IO;
+          }
+          PQclear(begin_result);
+
+          PGresult* get_tz_result = PQexec(conn, "SELECT current_setting('TIMEZONE')");
+          if (PQresultStatus(get_tz_result) != PGRES_TUPLES_OK) {
+            SetError(error, "[libpq] Could not query current timezone: %s",
+                     PQerrorMessage(conn));
+            PQclear(get_tz_result);
+            return ADBC_STATUS_IO;
+          }
+
+          current_tz = PQgetvalue(get_tz_result, 0, 0);
+          PQclear(get_tz_result);
+
+          PGresult* set_utc_result = PQexec(conn, "SET TIME ZONE 'UTC'");
+          if (PQresultStatus(set_utc_result) != PGRES_COMMAND_OK) {
+            SetError(error, "[libpq] Failed to set time zone to UTC: %s",
+                     PQerrorMessage(conn));
+            PQclear(set_utc_result);
+            return ADBC_STATUS_IO;
+          }
+          PQclear(set_utc_result);
+        }
+
         result = PQexecPrepared(conn, /*stmtName=*/"",
                                 /*nParams=*/bind_schema->n_children, param_values.data(),
                                 param_lengths.data(), param_formats.data(),
@@ -404,6 +444,27 @@ struct BindStream {
         }
 
         PQclear(result);
+
+        if (has_timezone) {
+          std::string reset_query = "SET TIME ZONE '" + std::string(current_tz) + "'";
+          PGresult* reset_tz_result = PQexec(conn, reset_query.c_str());
+          if (PQresultStatus(reset_tz_result) != PGRES_COMMAND_OK) {
+            SetError(error, "[libpq] Failed to reset time zone: %s",
+                     PQerrorMessage(conn));
+            PQclear(reset_tz_result);
+            return ADBC_STATUS_IO;
+          }
+          PQclear(reset_tz_result);
+
+          PGresult* commit_result = PQexec(conn, "COMMIT");
+          if (PQresultStatus(commit_result) != PGRES_COMMAND_OK) {
+            SetError(error, "[libpq] Failed to commit transaction: %s",
+                     PQerrorMessage(conn));
+            PQclear(commit_result);
+            return ADBC_STATUS_IO;
+          }
+          PQclear(commit_result);
+        }
       }
       if (rows_affected) *rows_affected += array->length;
     }

--- a/c/driver/sqlite/sqlite_test.cc
+++ b/c/driver/sqlite/sqlite_test.cc
@@ -174,6 +174,9 @@ class SqliteStatementTest : public ::testing::Test,
   void TestSqlIngestTimestamp() {
     GTEST_SKIP() << "Cannot ingest TIMESTAMP (not implemented)";
   }
+  void TestSqlIngestTimestampTz() {
+    GTEST_SKIP() << "Cannot ingest TIMESTAMP WITH TIMEZONE (not implemented)";
+  }
 
  protected:
   SqliteQuirks quirks_;

--- a/c/driver_manager/adbc_driver_manager_test.cc
+++ b/c/driver_manager/adbc_driver_manager_test.cc
@@ -229,6 +229,9 @@ class SqliteStatementTest : public ::testing::Test,
   void TestSqlIngestTimestamp() {
     GTEST_SKIP() << "Cannot ingest TIMESTAMP (not implemented)";
   }
+  void TestSqlIngestTimestampTz() {
+    GTEST_SKIP() << "Cannot ingest TIMESTAMP WITH TIMEZONE (not implemented)";
+  }
 
  protected:
   SqliteQuirks quirks_;

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -231,6 +231,7 @@ class StatementTest {
 
   // Temporal
   void TestSqlIngestTimestamp();
+  void TestSqlIngestTimestampTz();
 
   // ---- End Type-specific tests ----------------
 
@@ -274,7 +275,7 @@ class StatementTest {
   void TestSqlIngestNumericType(ArrowType type);
 
   template <enum ArrowTimeUnit TU>
-  void TestSqlIngestTemporalType();
+  void TestSqlIngestTemporalType(const char* timezone);
 };
 
 #define ADBCV_TEST_STATEMENT(FIXTURE)                                                   \
@@ -295,6 +296,7 @@ class StatementTest {
   TEST_F(FIXTURE, SqlIngestString) { TestSqlIngestString(); }                           \
   TEST_F(FIXTURE, SqlIngestBinary) { TestSqlIngestBinary(); }                           \
   TEST_F(FIXTURE, SqlIngestTimestamp) { TestSqlIngestTimestamp(); }                     \
+  TEST_F(FIXTURE, SqlIngestTimestampTz) { TestSqlIngestTimestampTz(); }                 \
   TEST_F(FIXTURE, SqlIngestAppend) { TestSqlIngestAppend(); }                           \
   TEST_F(FIXTURE, SqlIngestErrors) { TestSqlIngestErrors(); }                           \
   TEST_F(FIXTURE, SqlIngestMultipleConnections) { TestSqlIngestMultipleConnections(); } \


### PR DESCRIPTION
closes #867 

The lifecycle of setting the session time zone in this isn't great. I think should be handled during connect somehow? But not sure if postgres even supports that reading things like:

https://stackoverflow.com/a/11779621/621736

I think there is also something awry with the release callback for timezone schemas; needs further investigation