### PR TITLE
chore(r): Update CI and READMEs for latest pkgbuild release

### DIFF
--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -643,8 +643,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          # Pin of pkgbuild can be removed after version 1.4.2 is released
-          extra-packages: any::rcmdcheck, local::../adbcdrivermanager, github::r-lib/pkgbuild@v1.4.0
+          extra-packages: any::rcmdcheck, local::../adbcdrivermanager
           needs: check
           working-directory: r/${{ matrix.config.pkg }}
 

--- a/docs/source/driver/flight_sql.rst
+++ b/docs/source/driver/flight_sql.rst
@@ -75,8 +75,8 @@ Installation
 
       .. code-block:: r
 
-         # install.packages("remotes")
-         remotes::install_github("apache/arrow-adbc/r/adbcflightsql", build = FALSE)
+         # install.packages("pak")
+         pak::pak("apache/arrow-adbc/r/adbcflightsql")
 
 Usage
 =====

--- a/docs/source/driver/installation.rst
+++ b/docs/source/driver/installation.rst
@@ -76,3 +76,14 @@ From conda-forge_:
 - ``mamba install adbc-driver-flightsql``
 - ``mamba install adbc-driver-postgresql``
 - ``mamba install adbc-driver-sqlite``
+
+R
+======
+
+Install the appropriate driver package from GitHub:
+
+.. code-block:: r
+
+   # install.packages("pak")
+   pak::pak("apache/arrow-adbc/r/adbcsqlite")
+

--- a/docs/source/driver/installation.rst
+++ b/docs/source/driver/installation.rst
@@ -86,4 +86,3 @@ Install the appropriate driver package from GitHub:
 
    # install.packages("pak")
    pak::pak("apache/arrow-adbc/r/adbcsqlite")
-

--- a/docs/source/driver/postgresql.rst
+++ b/docs/source/driver/postgresql.rst
@@ -75,8 +75,8 @@ Installation
 
       .. code-block:: r
 
-         # install.packages("remotes")
-         remotes::install_github("apache/arrow-adbc/r/adbcpostgresql", build = FALSE)
+         # install.packages("pak")
+         pak::pak("apache/arrow-adbc/r/adbcpostgresql")
 
 Usage
 =====

--- a/docs/source/driver/snowflake.rst
+++ b/docs/source/driver/snowflake.rst
@@ -60,8 +60,8 @@ Installation
 
       .. code-block:: shell
 
-         # install.packages("remotes")
-         remotes::install_github("apache/arrow-adbc/r/adbcsnowflake", build = FALSE)
+         # install.packages("pak")
+         pak::pak("apache/arrow-adbc/r/adbcsnowflake")
 
 Usage
 =====

--- a/docs/source/driver/sqlite.rst
+++ b/docs/source/driver/sqlite.rst
@@ -57,8 +57,8 @@ Installation
 
       .. code-block:: shell
 
-         # install.packages("remotes")
-         remotes::install_github("apache/arrow-adbc/r/adbcsqlite", build = FALSE)
+         # install.packages("pak")
+         pak::pak("apache/arrow-adbc/r/adbcsqlite")
 
    .. tab-item:: Go
       :sync: go

--- a/r/adbcdrivermanager/README.Rmd
+++ b/r/adbcdrivermanager/README.Rmd
@@ -50,8 +50,14 @@ install.packages("adbcdrivermanager")
 You can install the development version of adbcdrivermanager from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcdrivermanager", build = FALSE)
+# install.packages("pak")
+pak::pak("apache/arrow-adbc/r/adbcdrivermanager")
+```
+
+ADBC drivers for R use a relatively new feature of pkgbuild to enable installation from GitHub via pak. Depending on when you installed pak, you may need to update its internal version of pkgbuild.
+
+``` r
+install.packages("pkgbuild", pak:::private_lib_dir())
 ```
 
 ## Example

--- a/r/adbcdrivermanager/README.Rmd
+++ b/r/adbcdrivermanager/README.Rmd
@@ -58,6 +58,7 @@ ADBC drivers for R use a relatively new feature of pkgbuild to enable installati
 
 ``` r
 install.packages("pkgbuild", pak:::private_lib_dir())
+pak::cache_clean()
 ```
 
 ## Example

--- a/r/adbcdrivermanager/README.md
+++ b/r/adbcdrivermanager/README.md
@@ -40,8 +40,16 @@ You can install the development version of adbcdrivermanager from
 [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcdrivermanager", build = FALSE)
+# install.packages("pak")
+pak::pak("apache/arrow-adbc/r/adbcdrivermanager")
+```
+
+ADBC drivers for R use a relatively new feature of pkgbuild to enable
+installation from GitHub via pak. Depending on when you installed pak,
+you may need to update its internal version of pkgbuild.
+
+``` r
+install.packages("pkgbuild", pak:::private_lib_dir())
 ```
 
 ## Example

--- a/r/adbcdrivermanager/README.md
+++ b/r/adbcdrivermanager/README.md
@@ -50,6 +50,7 @@ you may need to update its internal version of pkgbuild.
 
 ``` r
 install.packages("pkgbuild", pak:::private_lib_dir())
+pak::cache_clean()
 ```
 
 ## Example

--- a/r/adbcflightsql/README.Rmd
+++ b/r/adbcflightsql/README.Rmd
@@ -40,7 +40,7 @@ to the Arrow Database Connectivity (ADBC) FlightSQL driver.
 
 ## Installation
 
-You can install the development version of adbcflightsql from [GitHub](https://github.com/) with:`
+You can install the development version of adbcflightsql from [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("pak")

--- a/r/adbcflightsql/README.Rmd
+++ b/r/adbcflightsql/README.Rmd
@@ -40,11 +40,17 @@ to the Arrow Database Connectivity (ADBC) FlightSQL driver.
 
 ## Installation
 
-You can install the development version of adbcflightsql from [GitHub](https://github.com/) with:
+You can install the development version of adbcflightsql from [GitHub](https://github.com/) with:`
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcflightsql", build = FALSE)
+# install.packages("pak")
+pak::pak("apache/arrow-adbc/r/adbcflightsql")
+```
+
+ADBC drivers for R use a relatively new feature of pkgbuild to enable installation from GitHub via pak. Depending on when you installed pak, you may need to update its internal version of pkgbuild.
+
+``` r
+install.packages("pkgbuild", pak:::private_lib_dir())
 ```
 
 ## Example

--- a/r/adbcflightsql/README.Rmd
+++ b/r/adbcflightsql/README.Rmd
@@ -51,6 +51,7 @@ ADBC drivers for R use a relatively new feature of pkgbuild to enable installati
 
 ``` r
 install.packages("pkgbuild", pak:::private_lib_dir())
+pak::cache_clean()
 ```
 
 ## Example

--- a/r/adbcflightsql/README.md
+++ b/r/adbcflightsql/README.md
@@ -41,6 +41,7 @@ you may need to update its internal version of pkgbuild.
 
 ``` r
 install.packages("pkgbuild", pak:::private_lib_dir())
+pak::cache_clean()
 ```
 
 ## Example

--- a/r/adbcflightsql/README.md
+++ b/r/adbcflightsql/README.md
@@ -28,7 +28,7 @@ interface to the Arrow Database Connectivity (ADBC) FlightSQL driver.
 ## Installation
 
 You can install the development version of adbcflightsql from
-[GitHub](https://github.com/) with:\`
+[GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("pak")

--- a/r/adbcflightsql/README.md
+++ b/r/adbcflightsql/README.md
@@ -28,11 +28,19 @@ interface to the Arrow Database Connectivity (ADBC) FlightSQL driver.
 ## Installation
 
 You can install the development version of adbcflightsql from
-[GitHub](https://github.com/) with:
+[GitHub](https://github.com/) with:\`
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcflightsql", build = FALSE)
+# install.packages("pak")
+pak::pak("apache/arrow-adbc/r/adbcflightsql")
+```
+
+ADBC drivers for R use a relatively new feature of pkgbuild to enable
+installation from GitHub via pak. Depending on when you installed pak,
+you may need to update its internal version of pkgbuild.
+
+``` r
+install.packages("pkgbuild", pak:::private_lib_dir())
 ```
 
 ## Example

--- a/r/adbcpostgresql/README.Rmd
+++ b/r/adbcpostgresql/README.Rmd
@@ -51,6 +51,7 @@ ADBC drivers for R use a relatively new feature of pkgbuild to enable installati
 
 ``` r
 install.packages("pkgbuild", pak:::private_lib_dir())
+pak::cache_clean()
 ```
 
 ## Example

--- a/r/adbcpostgresql/README.Rmd
+++ b/r/adbcpostgresql/README.Rmd
@@ -43,8 +43,14 @@ to the Arrow Database Connectivity (ADBC) PostgreSQL driver.
 You can install the development version of adbcpostgresql from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcpostgresql", build = FALSE)
+# install.packages("pak")
+pak::pak("apache/arrow-adbc/r/adbcpostgresql")
+```
+
+ADBC drivers for R use a relatively new feature of pkgbuild to enable installation from GitHub via pak. Depending on when you installed pak, you may need to update its internal version of pkgbuild.
+
+``` r
+install.packages("pkgbuild", pak:::private_lib_dir())
 ```
 
 ## Example

--- a/r/adbcpostgresql/README.md
+++ b/r/adbcpostgresql/README.md
@@ -41,6 +41,7 @@ you may need to update its internal version of pkgbuild.
 
 ``` r
 install.packages("pkgbuild", pak:::private_lib_dir())
+pak::cache_clean()
 ```
 
 ## Example

--- a/r/adbcpostgresql/README.md
+++ b/r/adbcpostgresql/README.md
@@ -31,8 +31,16 @@ You can install the development version of adbcpostgresql from
 [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcpostgresql", build = FALSE)
+# install.packages("pak")
+pak::pak("apache/arrow-adbc/r/adbcpostgresql")
+```
+
+ADBC drivers for R use a relatively new feature of pkgbuild to enable
+installation from GitHub via pak. Depending on when you installed pak,
+you may need to update its internal version of pkgbuild.
+
+``` r
+install.packages("pkgbuild", pak:::private_lib_dir())
 ```
 
 ## Example

--- a/r/adbcsnowflake/README.Rmd
+++ b/r/adbcsnowflake/README.Rmd
@@ -43,8 +43,14 @@ to the Arrow Database Connectivity (ADBC) Snowflake driver.
 You can install the development version of adbcsnowflake from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcsnowflake", build = FALSE)
+# install.packages("pak")
+pak::pak("apache/arrow-adbc/r/adbcsnowflake")
+```
+
+ADBC drivers for R use a relatively new feature of pkgbuild to enable installation from GitHub via pak. Depending on when you installed pak, you may need to update its internal version of pkgbuild.
+
+``` r
+install.packages("pkgbuild", pak:::private_lib_dir())
 ```
 
 ## Example

--- a/r/adbcsnowflake/README.Rmd
+++ b/r/adbcsnowflake/README.Rmd
@@ -51,6 +51,7 @@ ADBC drivers for R use a relatively new feature of pkgbuild to enable installati
 
 ``` r
 install.packages("pkgbuild", pak:::private_lib_dir())
+pak::cache_clean()
 ```
 
 ## Example

--- a/r/adbcsnowflake/README.md
+++ b/r/adbcsnowflake/README.md
@@ -64,12 +64,12 @@ con |>
   read_adbc("SELECT * FROM REGION ORDER BY R_REGIONKEY") |>
   tibble::as_tibble()
 #> # A tibble: 5 × 3
-#>   R_REGIONKEY R_NAME      R_COMMENT                                             
-#>         <dbl> <chr>       <chr>                                                 
+#>   R_REGIONKEY R_NAME      R_COMMENT
+#>         <dbl> <chr>       <chr>
 #> 1           0 AFRICA      "lar deposits. blithely final packages cajole. regula…
-#> 2           1 AMERICA     "hs use ironic, even requests. s"                     
-#> 3           2 ASIA        "ges. thinly even pinto beans ca"                     
-#> 4           3 EUROPE      "ly final courts cajole furiously final excuse"       
+#> 2           1 AMERICA     "hs use ironic, even requests. s"
+#> 3           2 ASIA        "ges. thinly even pinto beans ca"
+#> 4           3 EUROPE      "ly final courts cajole furiously final excuse"
 #> 5           4 MIDDLE EAST "uickly special accounts cajole carefully blithely cl…
 ```
 

--- a/r/adbcsnowflake/README.md
+++ b/r/adbcsnowflake/README.md
@@ -41,6 +41,7 @@ you may need to update its internal version of pkgbuild.
 
 ``` r
 install.packages("pkgbuild", pak:::private_lib_dir())
+pak::cache_clean()
 ```
 
 ## Example

--- a/r/adbcsnowflake/README.md
+++ b/r/adbcsnowflake/README.md
@@ -31,8 +31,16 @@ You can install the development version of adbcsnowflake from
 [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcsnowflake", build = FALSE)
+# install.packages("pak")
+pak::pak("apache/arrow-adbc/r/adbcsnowflake")
+```
+
+ADBC drivers for R use a relatively new feature of pkgbuild to enable
+installation from GitHub via pak. Depending on when you installed pak,
+you may need to update its internal version of pkgbuild.
+
+``` r
+install.packages("pkgbuild", pak:::private_lib_dir())
 ```
 
 ## Example
@@ -55,12 +63,12 @@ con |>
   read_adbc("SELECT * FROM REGION ORDER BY R_REGIONKEY") |>
   tibble::as_tibble()
 #> # A tibble: 5 × 3
-#>   R_REGIONKEY R_NAME      R_COMMENT
-#>         <dbl> <chr>       <chr>
+#>   R_REGIONKEY R_NAME      R_COMMENT                                             
+#>         <dbl> <chr>       <chr>                                                 
 #> 1           0 AFRICA      "lar deposits. blithely final packages cajole. regula…
-#> 2           1 AMERICA     "hs use ironic, even requests. s"
-#> 3           2 ASIA        "ges. thinly even pinto beans ca"
-#> 4           3 EUROPE      "ly final courts cajole furiously final excuse"
+#> 2           1 AMERICA     "hs use ironic, even requests. s"                     
+#> 3           2 ASIA        "ges. thinly even pinto beans ca"                     
+#> 4           3 EUROPE      "ly final courts cajole furiously final excuse"       
 #> 5           4 MIDDLE EAST "uickly special accounts cajole carefully blithely cl…
 ```
 

--- a/r/adbcsqlite/README.Rmd
+++ b/r/adbcsqlite/README.Rmd
@@ -43,8 +43,14 @@ to the Arrow Database Connectivity (ADBC) SQLite driver.
 You can install the development version of adbcsqlite from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcsqlite", build = FALSE)
+# install.packages("pak")
+pak::pak("apache/arrow-adbc/r/adbcsqlite")
+```
+
+ADBC drivers for R use a relatively new feature of pkgbuild to enable installation from GitHub via pak. Depending on when you installed pak, you may need to update its internal version of pkgbuild.
+
+``` r
+install.packages("pkgbuild", pak:::private_lib_dir())
 ```
 
 ## Example

--- a/r/adbcsqlite/README.Rmd
+++ b/r/adbcsqlite/README.Rmd
@@ -51,6 +51,7 @@ ADBC drivers for R use a relatively new feature of pkgbuild to enable installati
 
 ``` r
 install.packages("pkgbuild", pak:::private_lib_dir())
+pak::cache_clean()
 ```
 
 ## Example

--- a/r/adbcsqlite/README.md
+++ b/r/adbcsqlite/README.md
@@ -31,8 +31,16 @@ You can install the development version of adbcsqlite from
 [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("apache/arrow-adbc/r/adbcsqlite", build = FALSE)
+# install.packages("pak")
+pak::pak("apache/arrow-adbc/r/adbcsqlite")
+```
+
+ADBC drivers for R use a relatively new feature of pkgbuild to enable
+installation from GitHub via pak. Depending on when you installed pak,
+you may need to update its internal version of pkgbuild.
+
+``` r
+install.packages("pkgbuild", pak:::private_lib_dir())
 ```
 
 ## Example

--- a/r/adbcsqlite/README.md
+++ b/r/adbcsqlite/README.md
@@ -41,6 +41,7 @@ you may need to update its internal version of pkgbuild.
 
 ``` r
 install.packages("pkgbuild", pak:::private_lib_dir())
+pak::cache_clean()
 ```
 
 ## Example


### PR DESCRIPTION
The latest pkgbuild release fixes a bug in version 1.4.1 that prevented installation from GitHub from working properly. Our driver packages currently can *only* be installed from GitHub and so this was a bit of a problem. Thankfully, this was fixed in 1.4.2 which was just released. This PR updates READMEs and CI with install instructions that actually work 😬 .

You should be able to install any package using (e.g.):

```r
# install.packages("pak")
pak::pak("apache/arrow-adbc/r/adbcsqlite")
```

If you didn't *just* install pak, you have update the internal version of pkgbuild and clean its build cache. I think I successfully got this down to two lines:

```r
install.packages("pkgbuild", pak:::private_lib_dir())
pak::cache_clean()
```