### PR TITLE
Fix ASAN-detected leak

### DIFF
--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -1023,6 +1023,7 @@ void StatementTest::TestSqlIngestType(ArrowType type,
     ASSERT_NO_FATAL_FAILURE(reader.Next());
     ASSERT_EQ(nullptr, reader.array->release);
   }
+  ASSERT_THAT(AdbcStatementRelease(&statement, &error), IsOkStatus(&error));
 }
 
 template <typename CType>
@@ -1162,6 +1163,8 @@ void StatementTest::TestSqlIngestTemporalType() {
     ASSERT_NO_FATAL_FAILURE(reader.Next());
     ASSERT_EQ(nullptr, reader.array->release);
   }
+
+  ASSERT_THAT(AdbcStatementRelease(&statement, &error), IsOkStatus(&error));
 }
 
 void StatementTest::TestSqlIngestTimestamp() {


### PR DESCRIPTION
This started showing up for the timestamp tests. I'm not sure why it wasn't registering for the primitive types, but I updated both the timestamp and primitive type tests to Release the statement at end of use