### PR TITLE
feat(c/driver/sqlite): Sqlite timestamp write support

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,1 +1,0 @@
-filter=-runtime/printf

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,1 @@
+filter=-runtime/printf

--- a/c/driver/sqlite/CMakeLists.txt
+++ b/c/driver/sqlite/CMakeLists.txt
@@ -56,6 +56,10 @@ foreach(LIB_TARGET ${ADBC_LIBRARIES})
   target_compile_definitions(${LIB_TARGET} PRIVATE ADBC_EXPORTING)
 endforeach()
 
+include(CheckTypeSize)
+check_type_size("time_t" SIZEOF_TIME_T)
+add_definitions(-DSIZEOF_TIME_T=${SIZEOF_TIME_T})
+
 if(ADBC_TEST_LINKAGE STREQUAL "shared")
   set(TEST_LINK_LIBS adbc_driver_sqlite_shared)
 else()

--- a/c/driver/sqlite/sqlite_test.cc
+++ b/c/driver/sqlite/sqlite_test.cc
@@ -39,7 +39,8 @@ class SqliteQuirks : public adbc_validation::DriverQuirks {
   AdbcStatusCode SetupDatabase(struct AdbcDatabase* database,
                                struct AdbcError* error) const override {
     // Shared DB required for transaction tests
-    return AdbcDatabaseSetOption(database, "uri", "file:Sqlite_Transactions", error);
+    return AdbcDatabaseSetOption(
+        database, "uri", "file:Sqlite_Transactions?mode=memory&cache=shared", error);
   }
 
   AdbcStatusCode DropTable(struct AdbcConnection* connection, const std::string& name,

--- a/c/driver/sqlite/sqlite_test.cc
+++ b/c/driver/sqlite/sqlite_test.cc
@@ -171,9 +171,6 @@ class SqliteStatementTest : public ::testing::Test,
 
   void TestSqlIngestUInt64() { GTEST_SKIP() << "Cannot ingest UINT64 (out of range)"; }
   void TestSqlIngestBinary() { GTEST_SKIP() << "Cannot ingest BINARY (not implemented)"; }
-  void TestSqlIngestTimestamp() {
-    GTEST_SKIP() << "Cannot ingest TIMESTAMP (not implemented)";
-  }
   void TestSqlIngestTimestampTz() {
     GTEST_SKIP() << "Cannot ingest TIMESTAMP WITH TIMEZONE (not implemented)";
   }

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -162,19 +162,19 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000);
-      snprintf(tsstr + 20, 4, "%03d", rem);
+      snprintf(tsstr + 20, 4, "%0d", rem);
       break;
     case NANOARROW_TIME_UNIT_MICRO:
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000000);
-      snprintf(tsstr + 20, 7, "%06d", rem);
+      snprintf(tsstr + 20, 7, "%0d", rem);
       break;
     case NANOARROW_TIME_UNIT_NANO:
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000000000);
-      snprintf(tsstr + 20, 10, "%09d", rem);
+      snprintf(tsstr + 20, 10, "%0d", rem);
       break;
   }
 

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -95,14 +95,12 @@ AdbcStatusCode AdbcSqliteBinderSetArrayStream(struct AdbcSqliteBinder* binder,
 /* caller is responsible for freeing data */
 static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit unit) {
   int64_t seconds;
-  int strlen;
-  int rem;
-  int scale;
+  int scale = 1;
+  int strlen = 20;
+  int rem = 0;
 
   switch (unit) {
     case NANOARROW_TIME_UNIT_SECOND:
-      scale = 1;
-      strlen = 20;
       break;
     case NANOARROW_TIME_UNIT_MILLI:
       scale = 1000;

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -149,20 +149,17 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
       break;
     case NANOARROW_TIME_UNIT_MILLI:
       tsstr[19] = '.';
-      assert(rem >= 0);
-      assert(rem < scale);
+      assert(rem < 1000);
       snprintf(tsstr + 20, strlen - 20, "%03d", rem);
       break;
     case NANOARROW_TIME_UNIT_MICRO:
       tsstr[19] = '.';
-      assert(rem >= 0);
-      assert(rem < scale);
+      assert(rem < 1000000);
       snprintf(tsstr + 20, strlen - 20, "%06d", rem);
       break;
     case NANOARROW_TIME_UNIT_NANO:
       tsstr[19] = '.';
-      assert(rem >= 0);
-      assert(rem < scale);
+      assert(rem < 1000000000);
       snprintf(tsstr + 20, strlen - 20, "%09d", rem);
       break;
   }

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -161,15 +161,15 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
       break;
     case NANOARROW_TIME_UNIT_MILLI:
       tsstr[19] = '.';
-      snprintf(tsstr + 20, 4, "%03d", rem % 1000u);
+      snprintf(tsstr + 20, strlen - 20, "%03d", rem % 1000u);
       break;
     case NANOARROW_TIME_UNIT_MICRO:
       tsstr[19] = '.';
-      snprintf(tsstr + 20, 7, "%06d", rem % 1000000u);
+      snprintf(tsstr + 20, strlen - 20, "%06d", rem % 1000000u);
       break;
     case NANOARROW_TIME_UNIT_NANO:
       tsstr[19] = '.';
-      snprintf(tsstr + 20, 10, "%09d", rem % 1000000000u);
+      snprintf(tsstr + 20, strlen - 20, "%09d", rem % 1000000000u);
       break;
   }
 

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -155,26 +155,21 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
     return NULL;
   }
 
+  assert(rem >= 0);
   switch (unit) {
     case NANOARROW_TIME_UNIT_SECOND:
       break;
     case NANOARROW_TIME_UNIT_MILLI:
       tsstr[19] = '.';
-      assert(rem >= 0);
-      assert(rem < 1000);
-      snprintf(tsstr + 20, 4, "%03d", rem);
+      snprintf(tsstr + 20, 4, "%03d", rem % 1000u);
       break;
     case NANOARROW_TIME_UNIT_MICRO:
       tsstr[19] = '.';
-      assert(rem >= 0);
-      assert(rem < 1000000);
-      snprintf(tsstr + 20, 7, "%06d", rem);
+      snprintf(tsstr + 20, 7, "%06d", rem % 1000000u);
       break;
     case NANOARROW_TIME_UNIT_NANO:
       tsstr[19] = '.';
-      assert(rem >= 0);
-      assert(rem < 1000000000);
-      snprintf(tsstr + 20, 10, "%09d", rem);
+      snprintf(tsstr + 20, 10, "%09d", rem % 1000000000u);
       break;
   }
 

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -124,6 +124,7 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
   if (rem < 0) {
     rem = scale + rem;
   }
+  assert(rem >= 0);
 
   struct tm broken_down_time;
   if (gmtime_r(&seconds, &broken_down_time) != &broken_down_time) {
@@ -144,20 +145,14 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
     case NANOARROW_TIME_UNIT_SECOND:
       break;
     case NANOARROW_TIME_UNIT_MILLI:
-      assert(rem >= 0);
-      assert(rem < 1000);
       tsstr[19] = '.';
       snprintf(tsstr + 20, strlen - 20, "%03d", rem);
       break;
     case NANOARROW_TIME_UNIT_MICRO:
-      assert(rem >= 0);
-      assert(rem < 1000000);
       tsstr[19] = '.';
       snprintf(tsstr + 20, strlen - 20, "%06d", rem);
       break;
     case NANOARROW_TIME_UNIT_NANO:
-      assert(rem >= 0);
-      assert(rem < 1000000000);
       tsstr[19] = '.';
       snprintf(tsstr + 20, strlen - 20, "%09d", rem);
       break;

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -164,19 +164,19 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000);
-      sprintf(tsstr + 20, "%03d", rem);
+      snprintf(tsstr + 20, 4, "%03d", rem);
       break;
     case NANOARROW_TIME_UNIT_MICRO:
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000000);
-      sprintf(tsstr + 20, "%06d", rem);
+      snprintf(tsstr + 20, 7, "%06d", rem);
       break;
     case NANOARROW_TIME_UNIT_NANO:
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000000000);
-      sprintf(tsstr + 20, "%09d", rem);
+      snprintf(tsstr + 20, 10, "%09d", rem);
       break;
   }
 

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -116,21 +116,19 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
       break;
   }
 
-  int64_t seconds = value / scale;
-  time_t time;
+  const int64_t seconds = value / scale;
 
 #if SIZEOF_TIME_T < 8
   if ((seconds > INT32_MAX) || (seconds < INT32_MIN)) {
     // TODO: give better error visibility
     return NULL;
   }
-  time = (time_t)seconds;
+  const time_t time = (time_t)seconds;
 #else
-  time = seconds;
+  const time_t time = seconds;
 #endif
 
   rem = value % scale;
-
   if (rem < 0) {
     rem = scale + rem;
   }

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -120,14 +120,13 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
   seconds = value / scale;
   rem = value % scale;
 
-  // TODO: add tests for negative timestamps
   if (rem < 0) {
     rem = scale + rem;
   }
   assert(rem >= 0);
 
   struct tm broken_down_time;
-#ifdef _MSVC_VER
+#if defined(_WIN32)
   if (gmtime_s(&broken_down_time, &seconds) != 0) {
     return NULL;
   }

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -127,9 +127,15 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
   assert(rem >= 0);
 
   struct tm broken_down_time;
+#ifdef _MSVC_VER
+  if (gmtime_s(&broken_down_time, &seconds) != 0) {
+    return NULL;
+  }
+#else
   if (gmtime_r(&seconds, &broken_down_time) != &broken_down_time) {
     return NULL;
   }
+#endif
 
   char* tsstr = malloc(strlen + 1);
   if (tsstr == NULL) {

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -150,19 +150,19 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000);
-      snprintf(tsstr + 20, strlen - 20, "%03d", rem);
+      sprintf(tsstr + 20, "%03d", rem);
       break;
     case NANOARROW_TIME_UNIT_MICRO:
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000000);
-      snprintf(tsstr + 20, strlen - 20, "%06d", rem);
+      sprintf(tsstr + 20, "%06d", rem);
       break;
     case NANOARROW_TIME_UNIT_NANO:
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000000000);
-      snprintf(tsstr + 20, strlen - 20, "%09d", rem);
+      sprintf(tsstr + 20, "%09d", rem);
       break;
   }
 

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -149,14 +149,17 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
       break;
     case NANOARROW_TIME_UNIT_MILLI:
       tsstr[19] = '.';
+      assert(rem > 0);
       snprintf(tsstr + 20, strlen - 20, "%03d", rem);
       break;
     case NANOARROW_TIME_UNIT_MICRO:
       tsstr[19] = '.';
+      assert(rem > 0);
       snprintf(tsstr + 20, strlen - 20, "%06d", rem);
       break;
     case NANOARROW_TIME_UNIT_NANO:
       tsstr[19] = '.';
+      assert(rem > 0);
       snprintf(tsstr + 20, strlen - 20, "%09d", rem);
       break;
   }

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -121,7 +121,6 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
   if (rem < 0) {
     rem = scale + rem;
   }
-  assert(rem >= 0);
 
   struct tm broken_down_time;
 #if defined(_WIN32)
@@ -149,16 +148,19 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
       break;
     case NANOARROW_TIME_UNIT_MILLI:
       tsstr[19] = '.';
+      assert(rem >= 0);
       assert(rem < 1000);
       snprintf(tsstr + 20, strlen - 20, "%03d", rem);
       break;
     case NANOARROW_TIME_UNIT_MICRO:
       tsstr[19] = '.';
+      assert(rem >= 0);
       assert(rem < 1000000);
       snprintf(tsstr + 20, strlen - 20, "%06d", rem);
       break;
     case NANOARROW_TIME_UNIT_NANO:
       tsstr[19] = '.';
+      assert(rem >= 0);
       assert(rem < 1000000000);
       snprintf(tsstr + 20, strlen - 20, "%09d", rem);
       break;

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -149,17 +149,20 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
       break;
     case NANOARROW_TIME_UNIT_MILLI:
       tsstr[19] = '.';
-      assert(rem > 0);
+      assert(rem >= 0);
+      assert(rem < scale);
       snprintf(tsstr + 20, strlen - 20, "%03d", rem);
       break;
     case NANOARROW_TIME_UNIT_MICRO:
       tsstr[19] = '.';
-      assert(rem > 0);
+      assert(rem >= 0);
+      assert(rem < scale);
       snprintf(tsstr + 20, strlen - 20, "%06d", rem);
       break;
     case NANOARROW_TIME_UNIT_NANO:
       tsstr[19] = '.';
-      assert(rem > 0);
+      assert(rem >= 0);
+      assert(rem < scale);
       snprintf(tsstr + 20, strlen - 20, "%09d", rem);
       break;
   }

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -162,19 +162,19 @@ static const char* ArrowTimestampToIsoString(int64_t value, enum ArrowTimeUnit u
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000);
-      snprintf(tsstr + 20, 4, "%0d", rem);
+      snprintf(tsstr + 20, 4, "%03d", rem);
       break;
     case NANOARROW_TIME_UNIT_MICRO:
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000000);
-      snprintf(tsstr + 20, 7, "%0d", rem);
+      snprintf(tsstr + 20, 7, "%06d", rem);
       break;
     case NANOARROW_TIME_UNIT_NANO:
       tsstr[19] = '.';
       assert(rem >= 0);
       assert(rem < 1000000000);
-      snprintf(tsstr + 20, 10, "%0d", rem);
+      snprintf(tsstr + 20, 10, "%09d", rem);
       break;
   }
 

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -1107,7 +1107,7 @@ void StatementTest::TestSqlIngestTemporalType(const char* timezone) {
   Handle<struct ArrowSchema> schema;
   Handle<struct ArrowArray> array;
   struct ArrowError na_error;
-  const std::vector<std::optional<int64_t>> values = {std::nullopt, 0, 42};
+  const std::vector<std::optional<int64_t>> values = {std::nullopt, -42, 0, 42};
   const ArrowType type = NANOARROW_TYPE_TIMESTAMP;
 
   // much of this code is shared with TestSqlIngestType with minor


### PR DESCRIPTION
Currently writes as a string. Here's what it looks like in the db at the end of the temporal test

```bash
sqlite> select * FROM bulk_ingest;

1970-01-01T00:00:00.000000000
1970-01-01T00:00:00.000000042
```