### PR TITLE
docs(python): Fix README for python drivers

### DIFF
--- a/python/adbc_driver_flightsql/README.md
+++ b/python/adbc_driver_flightsql/README.md
@@ -40,7 +40,7 @@ Set the environment variable `ADBC_FLIGHTSQL_LIBRARY` to the path to
 pip install -e ../adbc_driver_manager
 
 export ADBC_FLIGHTSQL_LIBRARY=/path/to/libadbc_driver_flightsql.so
-pip install -e --no-deps .
+pip install --no-deps -e .
 ```
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for details on the

--- a/python/adbc_driver_postgresql/README.md
+++ b/python/adbc_driver_postgresql/README.md
@@ -40,7 +40,7 @@ Set the environment variable `ADBC_POSTGRESQL_LIBRARY` to the path to
 pip install -e ../adbc_driver_manager
 
 export ADBC_POSTGRESQL_LIBRARY=/path/to/libadbc_driver_postgresql.so
-pip install -e --no-deps .
+pip install --no-deps -e .
 ```
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for details on the

--- a/python/adbc_driver_snowflake/README.md
+++ b/python/adbc_driver_snowflake/README.md
@@ -40,7 +40,7 @@ Set the environment variable `ADBC_SNOWFLAKE_LIBRARY` to the path to
 pip install -e ../adbc_driver_manager
 
 export ADBC_SNOWFLAKE_LIBRARY=/path/to/libadbc_driver_snowflake.so
-pip install -e --no-deps .
+pip install --no-deps -e .
 ```
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for details on the

--- a/python/adbc_driver_sqlite/README.md
+++ b/python/adbc_driver_sqlite/README.md
@@ -40,7 +40,7 @@ Set the environment variable `ADBC_SQLITE_LIBRARY` to the path to
 pip install -e ../adbc_driver_manager
 
 export ADBC_SQLITE_LIBRARY=/path/to/libadbc_driver_sqlite.so
-pip install -e --no-deps .
+pip install --no-deps -e .
 ```
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) for details on the


### PR DESCRIPTION
Following current instructions yields

```sh
ERROR: --no-deps is not a valid editable requirement. It should either be a path to a local project or a VCS URL (beginning with bzr+http, bzr+https, bzr+ssh, bzr+sftp, bzr+ftp, bzr+lp, bzr+file, git+http, git+https, git+ssh, git+git, git+file, hg+file, hg+http, hg+https, hg+ssh, hg+static-http, svn+ssh, svn+http, svn+https, svn+svn, svn+file).
```