### PR TITLE
chore(dev/release): use `--verify-tag` to guard against mistakes

### DIFF
--- a/ci/conda_env_dev.txt
+++ b/ci/conda_env_dev.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 commitizen
-gh
+gh>=2.32.0
 jq
 pre-commit
 twine

--- a/dev/release/post-02-binary.sh
+++ b/dev/release/post-02-binary.sh
@@ -39,6 +39,7 @@ main() {
     header "Publishing release ${version}"
 
     gh release edit \
+       --verify-tag \
        --repo "${REPOSITORY}" \
        "${tag}" \
        --title="ADBC Libraries ${version}" \


### PR DESCRIPTION
Fixes #851.