### PR TITLE
chore(ci): run clang-tidy in parallel

### DIFF
--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -216,7 +216,8 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba install -c conda-forge \
-            --file ci/conda_env_cpp.txt
+            --file ci/conda_env_cpp.txt \
+            --file ci/conda_env_cpp_lint.txt
 
       - name: clang-tidy
         shell: bash -l {0}

--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+clang=14
+clang-tools=14
 cmake
 compilers
 gtest>=1.10.0

--- a/ci/conda_env_cpp_lint.txt
+++ b/ci/conda_env_cpp_lint.txt
@@ -15,11 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake
-compilers
-gtest>=1.10.0
-libpq
-ninja
-pkg-config
-libsqlite
-pkg-config
+clang=14
+clang-tools=14

--- a/ci/scripts/cpp_clang_tidy.sh
+++ b/ci/scripts/cpp_clang_tidy.sh
@@ -65,10 +65,11 @@ build_subproject() {
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}"
 
-    clang-tidy \
-        -p "${build_dir}/compile_commands.json" \
-        --fix \
-        --quiet \
+    run-clang-tidy \
+        -j $(nproc) \
+        -p "${build_dir}" \
+        -fix \
+        -quiet \
         $(jq -r ".[] | .file" "${build_dir}/compile_commands.json")
 
     set +x


### PR DESCRIPTION
Fixes #899.