### PR TITLE
fix(go/adbc/pkg): export Adbc* symbols on Windows

### DIFF
--- a/go/adbc/pkg/_tmpl/driver.go.tmpl
+++ b/go/adbc/pkg/_tmpl/driver.go.tmpl
@@ -19,7 +19,11 @@
 
 package main
 
-// #cgo CXXFLAGS: -std=c++11
+// ADBC_EXPORTING is required on Windows, or else the symbols
+// won't be accessible to the driver manager
+
+// #cgo CFLAGS: -DADBC_EXPORTING
+// #cgo CXXFLAGS: -std=c++11 -DADBC_EXPORTING
 // #include "../../drivermgr/adbc.h"
 // #include "utils.h"
 // #include <stdint.h>

--- a/go/adbc/pkg/flightsql/driver.go
+++ b/go/adbc/pkg/flightsql/driver.go
@@ -21,7 +21,11 @@
 
 package main
 
-// #cgo CXXFLAGS: -std=c++11
+// ADBC_EXPORTING is required on Windows, or else the symbols
+// won't be accessible to the driver manager
+
+// #cgo CFLAGS: -DADBC_EXPORTING
+// #cgo CXXFLAGS: -std=c++11 -DADBC_EXPORTING
 // #include "../../drivermgr/adbc.h"
 // #include "utils.h"
 // #include <stdint.h>

--- a/go/adbc/pkg/panicdummy/driver.go
+++ b/go/adbc/pkg/panicdummy/driver.go
@@ -21,7 +21,11 @@
 
 package main
 
-// #cgo CXXFLAGS: -std=c++11
+// ADBC_EXPORTING is required on Windows, or else the symbols
+// won't be accessible to the driver manager
+
+// #cgo CFLAGS: -DADBC_EXPORTING
+// #cgo CXXFLAGS: -std=c++11 -DADBC_EXPORTING
 // #include "../../drivermgr/adbc.h"
 // #include "utils.h"
 // #include <stdint.h>

--- a/go/adbc/pkg/snowflake/driver.go
+++ b/go/adbc/pkg/snowflake/driver.go
@@ -21,7 +21,11 @@
 
 package main
 
-// #cgo CXXFLAGS: -std=c++11
+// ADBC_EXPORTING is required on Windows, or else the symbols
+// won't be accessible to the driver manager
+
+// #cgo CFLAGS: -DADBC_EXPORTING
+// #cgo CXXFLAGS: -std=c++11 -DADBC_EXPORTING
 // #include "../../drivermgr/adbc.h"
 // #include "utils.h"
 // #include <stdint.h>

--- a/python/adbc_driver_flightsql/tests/test_lowlevel.py
+++ b/python/adbc_driver_flightsql/tests/test_lowlevel.py
@@ -16,9 +16,23 @@
 # under the License.
 
 import pyarrow
+import pytest
 
 import adbc_driver_flightsql
 import adbc_driver_manager
+
+
+def test_load_driver():
+    # Fails, but in environments where we don't spin up testing
+    # servers, this checks that we can at least *load* the driver
+    with pytest.raises(
+        adbc_driver_manager.OperationalError, match="Error while dialing"
+    ):
+        with adbc_driver_flightsql.connect("grpc://127.0.0.100:12345") as db:
+            with adbc_driver_manager.AdbcConnection(db) as conn:
+                with adbc_driver_manager.AdbcStatement(conn) as stmt:
+                    stmt.set_sql_query("SELECT 1")
+                    stmt.execute_query()
 
 
 def test_query_trivial(dremio):

--- a/python/adbc_driver_snowflake/tests/test_lowlevel.py
+++ b/python/adbc_driver_snowflake/tests/test_lowlevel.py
@@ -29,6 +29,14 @@ def snowflake(snowflake_uri: str):
             yield conn
 
 
+def test_load_driver():
+    # Fails, but in environments where we don't spin up testing
+    # servers, this checks that we can at least *load* the driver
+    with pytest.raises(adbc_driver_manager.ProgrammingError, match="account is empty"):
+        with adbc_driver_snowflake.connect(""):
+            pass
+
+
 def test_query_trivial(snowflake):
     with adbc_driver_manager.AdbcStatement(snowflake) as stmt:
         stmt.set_sql_query("SELECT 1")


### PR DESCRIPTION
Fixes #898.