### PR TITLE
feat(go/adbc/driver/flightsql): add context to gRPC errors

### DIFF
--- a/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
@@ -338,7 +338,7 @@ func (ts *TimeoutTests) TestDoActionTimeout() {
 	ts.ErrorAs(stmt.Prepare(context.Background()), &adbcErr)
 	ts.Equal(adbc.StatusTimeout, adbcErr.Code, adbcErr.Error())
 	// Exact match - we don't want extra fluff in the message
-	ts.Equal("context deadline exceeded", adbcErr.Msg)
+	ts.Equal("[FlightSQL] context deadline exceeded (DeadlineExceeded; Prepare)", adbcErr.Msg)
 }
 
 func (ts *TimeoutTests) TestDoGetTimeout() {

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -239,7 +239,7 @@ func (s *statement) ExecuteQuery(ctx context.Context) (rdr array.RecordReader, n
 	}
 
 	if err != nil {
-		return nil, -1, adbcFromFlightStatus(err)
+		return nil, -1, adbcFromFlightStatus(err, "ExecuteQuery")
 	}
 
 	nrec = info.TotalRecords
@@ -259,7 +259,7 @@ func (s *statement) ExecuteUpdate(ctx context.Context) (n int64, err error) {
 	}
 
 	if err != nil {
-		err = adbcFromFlightStatus(err)
+		err = adbcFromFlightStatus(err, "ExecuteUpdate")
 	}
 
 	return
@@ -271,7 +271,7 @@ func (s *statement) Prepare(ctx context.Context) error {
 	ctx = metadata.NewOutgoingContext(ctx, s.hdrs)
 	prep, err := s.query.prepare(ctx, s.cnxn, s.timeouts)
 	if err != nil {
-		return adbcFromFlightStatus(err)
+		return adbcFromFlightStatus(err, "Prepare")
 	}
 	s.prepared = prep
 	return nil
@@ -394,13 +394,13 @@ func (s *statement) ExecutePartitions(ctx context.Context) (*arrow.Schema, adbc.
 	}
 
 	if err != nil {
-		return nil, out, -1, adbcFromFlightStatus(err)
+		return nil, out, -1, adbcFromFlightStatus(err, "ExecutePartitions")
 	}
 
 	if len(info.Schema) > 0 {
 		sc, err = flight.DeserializeSchema(info.Schema, s.alloc)
 		if err != nil {
-			return nil, out, -1, adbcFromFlightStatus(err)
+			return nil, out, -1, adbcFromFlightStatus(err, "ExecutePartitions: could not deserialize FlightInfo schema:")
 		}
 	}
 

--- a/go/adbc/driver/flightsql/record_reader.go
+++ b/go/adbc/driver/flightsql/record_reader.go
@@ -90,7 +90,7 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, cl *flightsql.
 	} else {
 		rdr, err := doGet(ctx, cl, endpoints[0], clCache, opts...)
 		if err != nil {
-			return nil, adbcFromFlightStatus(err)
+			return nil, adbcFromFlightStatus(err, "DoGet: endpoint 0: remote: %s", endpoints[0].Location)
 		}
 		schema = rdr.Schema()
 		group.Go(func() error {
@@ -135,7 +135,7 @@ func newRecordReader(ctx context.Context, alloc memory.Allocator, cl *flightsql.
 
 			rdr, err := doGet(ctx, cl, endpoint, clCache, opts...)
 			if err != nil {
-				return err
+				return adbcFromFlightStatus(err, "DoGet: endpoint %d: %s", endpointIndex, endpoint.Location)
 			}
 			defer rdr.Release()
 

--- a/go/adbc/driver/flightsql/utils.go
+++ b/go/adbc/driver/flightsql/utils.go
@@ -18,12 +18,14 @@
 package flightsql
 
 import (
+	"fmt"
+
 	"github.com/apache/arrow-adbc/go/adbc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-func adbcFromFlightStatus(err error) error {
+func adbcFromFlightStatus(err error, context string, args ...any) error {
 	if _, ok := err.(adbc.Error); ok {
 		return err
 	}
@@ -70,8 +72,9 @@ func adbcFromFlightStatus(err error) error {
 		adbcCode = adbc.StatusUnknown
 	}
 
+	// People don't read error messages, so backload the context and frontload the server error
 	return adbc.Error{
-		Msg:  grpcStatus.Message(),
+		Msg:  fmt.Sprintf("[FlightSQL] %s (%s; %s)", grpcStatus.Message(), grpcStatus.Code(), fmt.Sprintf(context, args...)),
 		Code: adbcCode,
 	}
 }


### PR DESCRIPTION
See #862.

Example:

```
Internal: SqlState: , msg: [FlightSQL] Ballista Error: General("scheduler::from_proto(Action) invalid or missing action") (Internal; DoGet: endpoint 0: [uri:"grpc+tcp://172.24.0.5:50051"])
```

Now we can see that the error comes from issuing a DoGet against a particular location.