### PR TITLE
fix(csharp): include GetInfo and GetObjects call for .NET 4.7.2

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverExporter.cs
+++ b/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverExporter.cs
@@ -75,7 +75,7 @@ namespace Apache.Arrow.Adbc.C
         private static unsafe readonly NativeDelegate<DatabaseSetOption> s_databaseSetOption = new NativeDelegate<DatabaseSetOption>(SetDatabaseOption);
         private static IntPtr DatabaseSetOptionPtr => s_databaseSetOption.Pointer;
 
-        private unsafe delegate AdbcStatusCode ConnectionGetObjects(CAdbcConnection* connection, int depth, byte* catalog, byte* db_schema, byte* table_name, byte** table_type, byte* column_name, CArrowArrayStream* stream, CAdbcError* error);
+        internal unsafe delegate AdbcStatusCode ConnectionGetObjects(CAdbcConnection* connection, int depth, byte* catalog, byte* db_schema, byte* table_name, byte** table_type, byte* column_name, CArrowArrayStream* stream, CAdbcError* error);
         private static unsafe readonly NativeDelegate<ConnectionGetObjects> s_connectionGetObjects = new NativeDelegate<ConnectionGetObjects>(GetConnectionObjects);
         private static IntPtr ConnectionGetObjectsPtr => s_connectionGetObjects.Pointer;
         private unsafe delegate AdbcStatusCode ConnectionGetTableSchema(CAdbcConnection* connection, byte* catalog, byte* db_schema, byte* table_name, CArrowSchema* schema, CAdbcError* error);
@@ -93,7 +93,7 @@ namespace Apache.Arrow.Adbc.C
         private static IntPtr ConnectionCommitPtr => s_connectionCommit.Pointer;
         private static unsafe readonly NativeDelegate<ConnectionFn> s_connectionRelease = new NativeDelegate<ConnectionFn>(ReleaseConnection);
         private static IntPtr ConnectionReleasePtr => s_connectionRelease.Pointer;
-        private unsafe delegate AdbcStatusCode ConnectionGetInfo(CAdbcConnection* connection, byte* info_codes, int info_codes_length, CArrowArrayStream* stream, CAdbcError* error);
+        internal unsafe delegate AdbcStatusCode ConnectionGetInfo(CAdbcConnection* connection, byte* info_codes, int info_codes_length, CArrowArrayStream* stream, CAdbcError* error);
         private static unsafe readonly NativeDelegate<ConnectionGetInfo> s_connectionGetInfo = new NativeDelegate<ConnectionGetInfo>(GetConnectionInfo);
         private static IntPtr ConnectionGetInfoPtr => s_connectionGetInfo.Pointer;
         private unsafe delegate AdbcStatusCode ConnectionReadPartition(CAdbcConnection* connection, byte* serialized_partition, int serialized_length, CArrowArrayStream* stream, CAdbcError* error);

--- a/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
+++ b/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
@@ -635,6 +635,15 @@ namespace Apache.Arrow.Adbc.C
 #endif
             {
                 byte* bcatalog, bDb_schema, bTable_name, bColumn_Name;
+
+                if(table_types == null)
+                {
+                    table_types = new List<string>();
+                }
+
+                // need to terminate with a null entry per https://github.com/apache/arrow-adbc/blob/b97e22c4d6524b60bf261e1970155500645be510/adbc.h#L909-L911
+                table_types.Add(null);
+
                 byte** bTable_type = (byte**)Marshal.AllocHGlobal(IntPtr.Size * table_types.Count);
 
                 for (int i = 0; i < table_types.Count; i++)

--- a/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
+++ b/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
@@ -22,8 +22,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Apache.Arrow.C;
 using Apache.Arrow.Ipc;
-using static Apache.Arrow.Adbc.C.CAdbcDriverExporter;
-using System.Data.Common;
 
 #if NETSTANDARD
 using Apache.Arrow.Adbc.Extensions;
@@ -672,10 +670,10 @@ namespace Apache.Arrow.Adbc.C
                 fixed (CAdbcConnection* cn = &connection)
                 fixed (CAdbcError* e = &_error)
                 {
-#if NETSTANDARD
-                    TranslateCode(Marshal.GetDelegateForFunctionPointer<CAdbcDriverExporter.ConnectionGetObjects>(fn)(cn, depth, bcatalog, bDb_schema, bTable_name, bTable_type, bColumn_Name, stream, e));
-#else
+#if NET5_0_OR_GREATER
                     TranslateCode(fn(cn, depth, bcatalog, bDb_schema, bTable_name, bTable_type, bColumn_Name, stream, e));
+#else
+                    TranslateCode(Marshal.GetDelegateForFunctionPointer<CAdbcDriverExporter.ConnectionGetObjects>(fn)(cn, depth, bcatalog, bDb_schema, bTable_name, bTable_type, bColumn_Name, stream, e));
 #endif
                 }
             }

--- a/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
+++ b/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
@@ -18,8 +18,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Apache.Arrow.C;
+using Apache.Arrow.Ipc;
+using static Apache.Arrow.Adbc.C.CAdbcDriverExporter;
+using System.Data.Common;
 
 #if NETSTANDARD
 using Apache.Arrow.Adbc.Extensions;
@@ -220,6 +224,38 @@ namespace Apache.Arrow.Adbc.C
                 return new AdbcStatementNative(_nativeDriver, nativeStatement);
             }
 
+            public override IArrowArrayStream GetInfo(List<AdbcInfoCode> codes)
+            {
+                return GetInfo(codes.Select(x => (int)x).ToList<int>());
+            }
+
+            public override unsafe IArrowArrayStream GetInfo(List<int> codes)
+            {
+                CArrowArrayStream* nativeArrayStream = CArrowArrayStream.Create();
+
+                using (CallHelper caller = new CallHelper())
+                {
+                    caller.Call(_nativeDriver.ConnectionGetInfo, ref _nativeConnection, codes, nativeArrayStream);
+                }
+
+                IArrowArrayStream arrowArrayStream = CArrowArrayStreamImporter.ImportArrayStream(nativeArrayStream);
+
+                return arrowArrayStream;
+            }
+
+            public override unsafe IArrowArrayStream GetObjects(GetObjectsDepth depth, string catalogPattern, string dbSchemaPattern, string tableNamePattern, List<string> tableTypes, string columnNamePattern)
+            {
+                CArrowArrayStream* nativeArrayStream = CArrowArrayStream.Create();
+
+                using (CallHelper caller = new CallHelper())
+                {
+                    caller.Call(_nativeDriver.ConnectionGetObjects, ref _nativeConnection, (int)depth, catalogPattern, dbSchemaPattern, tableNamePattern, tableTypes, columnNamePattern, nativeArrayStream);
+                }
+
+                IArrowArrayStream arrowArrayStream = CArrowArrayStreamImporter.ImportArrayStream(nativeArrayStream);
+
+                return arrowArrayStream;
+            }
         }
 
         /// <summary>
@@ -567,6 +603,83 @@ namespace Apache.Arrow.Adbc.C
                 }
             }
 
+#if NET5_0_OR_GREATER
+            public unsafe void Call(delegate* unmanaged<CAdbcConnection*, byte*, int, CArrowArrayStream*, CAdbcError*, AdbcStatusCode> fn, ref CAdbcConnection connection, List<int> infoCodes, CArrowArrayStream* stream)
+#else
+            public unsafe void Call(IntPtr ptr, ref CAdbcConnection connection, List<int> infoCodes, CArrowArrayStream* stream)
+#endif
+            {
+                int numInts = infoCodes.Count;
+
+                // Calculate the total number of bytes needed
+                int totalBytes = numInts * sizeof(int);
+
+                IntPtr bytePtr = Marshal.AllocHGlobal(totalBytes);
+
+                int[] intArray = infoCodes.ToArray();
+                Marshal.Copy(intArray, 0, bytePtr, numInts);
+
+                fixed (CAdbcConnection* cn = &connection)
+                fixed (CAdbcError* e = &_error)
+                {
+#if NET5_0_OR_GREATER
+                    TranslateCode(fn(cn, (byte*)bytePtr, infoCodes.Count, stream, e));
+#else
+                    TranslateCode(Marshal.GetDelegateForFunctionPointer<CAdbcDriverExporter.ConnectionGetInfo>(ptr)(cn, (byte*)bytePtr, infoCodes.Count, stream, e));
+#endif
+                }
+            }
+
+#if NET5_0_OR_GREATER
+            public unsafe void Call(delegate* unmanaged<CAdbcConnection*, int, byte*, byte*, byte*, byte**, byte*, CArrowArrayStream*, CAdbcError*, AdbcStatusCode> fn, ref CAdbcConnection connection, int depth, string catalog, string db_schema, string table_name, List<string> table_types, string column_name, CArrowArrayStream* stream)
+#else
+            public unsafe void Call(IntPtr fn, ref CAdbcConnection connection, int depth, string catalog, string db_schema, string table_name, List<string> table_types, string column_name, CArrowArrayStream* stream)
+#endif
+            {
+                byte* bcatalog, bDb_schema, bTable_name, bColumn_Name;
+                byte** bTable_type = (byte**)Marshal.AllocHGlobal(IntPtr.Size * table_types.Count);
+
+                for (int i = 0; i < table_types.Count; i++)
+                {
+                    string tableType = table_types[i];
+#if NETSTANDARD
+                    bTable_type[i] = (byte*)MarshalExtensions.StringToCoTaskMemUTF8(tableType);
+#else
+                    bTable_type[i] = (byte*)Marshal.StringToCoTaskMemUTF8(tableType);
+#endif
+                }
+
+                using (Utf8Helper helper = new Utf8Helper(catalog))
+                {
+                    bcatalog = (byte*)(IntPtr)(helper);
+                }
+
+                using (Utf8Helper helper = new Utf8Helper(db_schema))
+                {
+                    bDb_schema = (byte*)(IntPtr)(helper);
+                }
+
+                using (Utf8Helper helper = new Utf8Helper(table_name))
+                {
+                    bTable_name = (byte*)(IntPtr)(helper);
+                }
+
+                using (Utf8Helper helper = new Utf8Helper(column_name))
+                {
+                    bColumn_Name = (byte*)(IntPtr)(helper);
+                }
+
+                fixed (CAdbcConnection* cn = &connection)
+                fixed (CAdbcError* e = &_error)
+                {
+#if NETSTANDARD
+                    TranslateCode(Marshal.GetDelegateForFunctionPointer<CAdbcDriverExporter.ConnectionGetObjects>(fn)(cn, depth, bcatalog, bDb_schema, bTable_name, bTable_type, bColumn_Name, stream, e));
+#else
+                    TranslateCode(fn(cn, depth, bcatalog, bDb_schema, bTable_name, bTable_type, bColumn_Name, stream, e));
+#endif
+                }
+            }
+
             private unsafe void TranslateCode(AdbcStatusCode statusCode)
             {
                 if (statusCode != AdbcStatusCode.Success)
@@ -580,7 +693,9 @@ namespace Apache.Arrow.Adbc.C
                         message = Marshal.PtrToStringUTF8((IntPtr)_error.message);
 #endif
                     }
+
                     Dispose();
+
                     throw new AdbcException(message);
                 }
             }

--- a/csharp/src/Apache.Arrow.Adbc/StandardSchemas.cs
+++ b/csharp/src/Apache.Arrow.Adbc/StandardSchemas.cs
@@ -67,7 +67,7 @@ namespace Apache.Arrow.Adbc
                                 )
                             },
                             // TBD if this line is the best approach but its a good one-liner
-                            new int[] {0, 1, 2, 3, 4, 5}.SelectMany(BitConverter.GetBytes).ToArray(),
+                            new int[] {0, 1, 2, 3, 4, 5}.ToArray(),
                             UnionMode.Dense),
                         true)
                 },


### PR DESCRIPTION
Continuation of https://github.com/apache/arrow-adbc/issues/930 