### PR TITLE
docs(python/adbc_driver_manager): improve docstrings for set_options

### DIFF
--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -570,7 +570,7 @@ cdef class AdbcDatabase(_AdbcHandle):
     def set_options(self, **kwargs) -> None:
         """Set arbitrary key-value options.
 
-        Pass options as kwargs: set_options(**{"some.option": "value"})
+        Pass options as kwargs: ``set_options(**{"some.option": "value"})``.
 
         Note, not all drivers support setting options after creation.
 
@@ -827,7 +827,7 @@ cdef class AdbcConnection(_AdbcHandle):
     def set_options(self, **kwargs) -> None:
         """Set arbitrary key-value options.
 
-        Pass options as kwargs: set_options(**{"some.option": "value"})
+        Pass options as kwargs: ``set_options(**{"some.option": "value"})``.
 
         Note, not all drivers support setting options after creation.
 
@@ -1096,7 +1096,7 @@ cdef class AdbcStatement(_AdbcHandle):
     def set_options(self, **kwargs) -> None:
         """Set arbitrary key-value options for this statement only.
 
-        Pass options as kwargs: set_options(**{"some.option": "value"})
+        Pass options as kwargs: ``set_options(**{"some.option": "value"})``.
 
         See Also
         --------

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -570,6 +570,8 @@ cdef class AdbcDatabase(_AdbcHandle):
     def set_options(self, **kwargs) -> None:
         """Set arbitrary key-value options.
 
+        Pass options as kwargs: set_options(**{"some.option": "value"})
+
         Note, not all drivers support setting options after creation.
 
         See Also
@@ -824,6 +826,8 @@ cdef class AdbcConnection(_AdbcHandle):
 
     def set_options(self, **kwargs) -> None:
         """Set arbitrary key-value options.
+
+        Pass options as kwargs: set_options(**{"some.option": "value"})
 
         Note, not all drivers support setting options after creation.
 
@@ -1090,7 +1094,9 @@ cdef class AdbcStatement(_AdbcHandle):
         check_error(status, &c_error)
 
     def set_options(self, **kwargs) -> None:
-        """Set arbitrary key-value options.
+        """Set arbitrary key-value options for this statement only.
+
+        Pass options as kwargs: set_options(**{"some.option": "value"})
 
         See Also
         --------


### PR DESCRIPTION
Add example usage for how to set options from the Python bindings.