### PR TITLE
fix(go/adbc/driver/flightsql): Have GetTableSchema check for table name match instead of the first schema it receives

### DIFF
--- a/go/adbc/driver/flightsql/flightsql_adbc.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc.go
@@ -1200,6 +1200,7 @@ func (c *cnxn) getObjectsTables(ctx context.Context, depth adbc.ObjectDepth, cat
 	return
 }
 
+// Regression test for https://github.com/apache/arrow-adbc/issues/934
 func (c *cnxn) GetTableSchema(ctx context.Context, catalog *string, dbSchema *string, tableName string) (*arrow.Schema, error) {
 	opts := &flightsql.GetTablesOpts{
 		Catalog:                catalog,
@@ -1232,12 +1233,12 @@ func (c *cnxn) GetTableSchema(ctx context.Context, catalog *string, dbSchema *st
 	}
 
 	numRows := rec.NumRows()
-	if numRows == 0 {
+	switch {
+	case numRows == 0:
 		return nil, adbc.Error{
 			Code: adbc.StatusNotFound,
 		}
-	}
-	if numRows > math.MaxInt32 {
+	case numRows > math.MaxInt32:
 		return nil, adbc.Error{
 			Msg:  "[Flight SQL] GetTableSchema cannot handle tables with number of rows > 2^31 - 1",
 			Code: adbc.StatusNotImplemented,

--- a/go/adbc/driver/flightsql/flightsql_adbc.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc.go
@@ -1200,7 +1200,6 @@ func (c *cnxn) getObjectsTables(ctx context.Context, depth adbc.ObjectDepth, cat
 	return
 }
 
-// Regression test for https://github.com/apache/arrow-adbc/issues/934
 func (c *cnxn) GetTableSchema(ctx context.Context, catalog *string, dbSchema *string, tableName string) (*arrow.Schema, error) {
 	opts := &flightsql.GetTablesOpts{
 		Catalog:                catalog,

--- a/go/adbc/driver/flightsql/flightsql_adbc.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc.go
@@ -1254,7 +1254,7 @@ func (c *cnxn) GetTableSchema(ctx context.Context, catalog *string, dbSchema *st
 			//    2: table_name: utf8 not null
 			//    3: table_type: utf8 not null
 			//    4: table_schema: bytes not null
-			schemaBytes := rec.Column(4).(*array.Binary).Value(0)
+			schemaBytes := rec.Column(4).(*array.Binary).Value(i)
 			s, err = flight.DeserializeSchema(schemaBytes, c.db.alloc)
 			if err != nil {
 				return nil, adbcFromFlightStatus(err, "GetTableSchema")

--- a/go/adbc/driver/flightsql/flightsql_adbc.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc.go
@@ -1231,24 +1231,42 @@ func (c *cnxn) GetTableSchema(ctx context.Context, catalog *string, dbSchema *st
 		return nil, adbcFromFlightStatus(err, "GetTableSchema(DoGet)")
 	}
 
-	if rec.NumRows() == 0 {
+	numRows := rec.NumRows()
+	if numRows == 0 {
 		return nil, adbc.Error{
 			Code: adbc.StatusNotFound,
 		}
 	}
-
-	// returned schema should be
-	//    0: catalog_name: utf8
-	//    1: db_schema_name: utf8
-	//    2: table_name: utf8 not null
-	//    3: table_type: utf8 not null
-	//    4: table_schema: bytes not null
-	schemaBytes := rec.Column(4).(*array.Binary).Value(0)
-	s, err := flight.DeserializeSchema(schemaBytes, c.db.alloc)
-	if err != nil {
-		return nil, adbcFromFlightStatus(err, "GetTableSchema")
+	if numRows > math.MaxInt32 {
+		return nil, adbc.Error{
+			Msg:  "[Flight SQL] GetTableSchema cannot handle tables with number of rows > 2^31 - 1",
+			Code: adbc.StatusNotImplemented,
+		}
 	}
-	return s, nil
+
+	var s *arrow.Schema
+	for i := 0; i < int(numRows); i++ {
+		currentTableName := rec.Column(2).(*array.String).Value(i)
+		if currentTableName == tableName {
+			// returned schema should be
+			//    0: catalog_name: utf8
+			//    1: db_schema_name: utf8
+			//    2: table_name: utf8 not null
+			//    3: table_type: utf8 not null
+			//    4: table_schema: bytes not null
+			schemaBytes := rec.Column(4).(*array.Binary).Value(0)
+			s, err = flight.DeserializeSchema(schemaBytes, c.db.alloc)
+			if err != nil {
+				return nil, adbcFromFlightStatus(err, "GetTableSchema")
+			}
+			return s, nil
+		}
+	}
+
+	return s, adbc.Error{
+		Msg:  "[Flight SQL] GetTableSchema could not find a table with a matching schema",
+		Code: adbc.StatusNotFound,
+	}
 }
 
 // GetTableTypes returns a list of the table types in the database.

--- a/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
@@ -683,14 +683,13 @@ func (server *MultiTableTestServer) DoGetTables(ctx context.Context, cmd flights
 
 	sc1 := arrow.NewSchema([]arrow.Field{{Name: "a", Type: arrow.PrimitiveTypes.Int32, Nullable: true}}, nil)
 	sc2 := arrow.NewSchema([]arrow.Field{{Name: "b", Type: arrow.PrimitiveTypes.Int32, Nullable: true}}, nil)
-	buf1 := flight.SerializeSchema(sc1, memory.DefaultAllocator)
-	buf2 := flight.SerializeSchema(sc2, memory.DefaultAllocator)
+	buf1 := flight.SerializeSchema(sc1, server.Alloc)
+	buf2 := flight.SerializeSchema(sc2, server.Alloc)
 
 	bldr.Field(4).(*array.BinaryBuilder).AppendValues([][]byte{buf1, buf2}, nil)
 	defer bldr.Release()
 
 	rec := bldr.NewRecord()
-	defer rec.Release()
 
 	ch := make(chan flight.StreamChunk)
 	go func() {
@@ -717,5 +716,5 @@ func (suite *MultiTableTests) TestGetTableSchema() {
 	suite.NoError(err)
 
 	expectedSchema := arrow.NewSchema([]arrow.Field{{Name: "b", Type: arrow.PrimitiveTypes.Int32, Nullable: true}}, nil)
-	suite.True(expectedSchema.Equal(actualSchema))
+	suite.Equal(expectedSchema, actualSchema)
 }

--- a/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
@@ -711,6 +711,7 @@ func (suite *MultiTableTests) SetupSuite() {
 	suite.DoSetupSuite(&MultiTableTestServer{}, nil, map[string]string{})
 }
 
+// Regression test for https://github.com/apache/arrow-adbc/issues/934
 func (suite *MultiTableTests) TestGetTableSchema() {
 	actualSchema, err := suite.cnxn.GetTableSchema(context.Background(), nil, nil, "tbl2")
 	suite.NoError(err)

--- a/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/apache/arrow/go/v13/arrow/array"
 	"github.com/apache/arrow/go/v13/arrow/flight"
 	"github.com/apache/arrow/go/v13/arrow/flight/flightsql"
+	"github.com/apache/arrow/go/v13/arrow/flight/flightsql/schema_ref"
 	"github.com/apache/arrow/go/v13/arrow/memory"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/exp/maps"
@@ -638,22 +639,42 @@ type MultiTableTestServer struct {
 	flightsql.BaseServer
 }
 
-func (server *MultiTableTestServer) GetFlightInfoTables(ctx context.Context, cmd flightsql.GetTables, desc *flight.FlightDescriptor) (*flight.FlightInfo, error) {
-	tkt, _ := flightsql.CreateStatementQueryTicket([]byte{})
-	info := &flight.FlightInfo{
+func (server *MultiTableTestServer) GetFlightInfoStatement(ctx context.Context, cmd flightsql.StatementQuery, desc *flight.FlightDescriptor) (*flight.FlightInfo, error) {
+	query := cmd.GetQuery()
+	tkt, err := flightsql.CreateStatementQueryTicket([]byte(query))
+	if err != nil {
+		return nil, err
+	}
+
+	return &flight.FlightInfo{
+		Endpoint:         []*flight.FlightEndpoint{{Ticket: &flight.Ticket{Ticket: tkt}}},
 		FlightDescriptor: desc,
+		TotalRecords:     -1,
+		TotalBytes:       -1,
+	}, nil
+}
+
+func (server *MultiTableTestServer) GetFlightInfoTables(ctx context.Context, cmd flightsql.GetTables, desc *flight.FlightDescriptor) (*flight.FlightInfo, error) {
+	schema := schema_ref.Tables
+	if cmd.GetIncludeSchema() {
+		schema = schema_ref.TablesWithIncludedSchema
+	}
+	server.Alloc = memory.NewCheckedAllocator(memory.DefaultAllocator)
+	info := &flight.FlightInfo{
 		Endpoint: []*flight.FlightEndpoint{
-			{Ticket: &flight.Ticket{Ticket: tkt}},
+			{Ticket: &flight.Ticket{Ticket: desc.Cmd}},
 		},
-		TotalRecords: -1,
-		TotalBytes:   -1,
+		FlightDescriptor: desc,
+		Schema:           flight.SerializeSchema(schema, server.Alloc),
+		TotalRecords:     -1,
+		TotalBytes:       -1,
 	}
 
 	return info, nil
 }
 
-func (server *MultiTableTestServer) DoGetStatement(ctx context.Context, tkt flightsql.StatementQueryTicket) (*arrow.Schema, <-chan flight.StreamChunk, error) {
-	bldr := array.NewRecordBuilder(memory.DefaultAllocator, adbc.GetTableSchemaSchema)
+func (server *MultiTableTestServer) DoGetTables(ctx context.Context, cmd flightsql.GetTables) (*arrow.Schema, <-chan flight.StreamChunk, error) {
+	bldr := array.NewRecordBuilder(server.Alloc, adbc.GetTableSchemaSchema)
 
 	bldr.Field(0).(*array.StringBuilder).AppendValues([]string{"", ""}, nil)
 	bldr.Field(1).(*array.StringBuilder).AppendValues([]string{"", ""}, nil)
@@ -692,10 +713,7 @@ func (suite *MultiTableTests) SetupSuite() {
 }
 
 func (suite *MultiTableTests) TestGetTableSchema() {
-	catalog := ""
-	schema := ""
-	table := "tbl2"
-	actualSchema, err := suite.cnxn.GetTableSchema(context.Background(), &catalog, &schema, table)
+	actualSchema, err := suite.cnxn.GetTableSchema(context.Background(), nil, nil, "tbl2")
 	suite.NoError(err)
 
 	expectedSchema := arrow.NewSchema([]arrow.Field{{Name: "b", Type: arrow.PrimitiveTypes.Int32, Nullable: true}}, nil)


### PR DESCRIPTION
Fixes #934.