### PR TITLE
fix(r): Ensure that info_codes are coerced to integer

### DIFF
--- a/r/adbcdrivermanager/R/adbc.R
+++ b/r/adbcdrivermanager/R/adbc.R
@@ -212,7 +212,13 @@ adbc_connection_release <- function(connection) {
 adbc_connection_get_info <- function(connection, info_codes) {
   error <- adbc_allocate_error()
   out_stream <- nanoarrow::nanoarrow_allocate_array_stream()
-  status <- .Call(RAdbcConnectionGetInfo, connection, info_codes, out_stream, error)
+  status <- .Call(
+    RAdbcConnectionGetInfo,
+    connection,
+    as.integer(info_codes),
+    out_stream,
+    error
+  )
   stop_for_error(status, error)
 
   out_stream


### PR DESCRIPTION
Closes #919.

Ideally we should also expose symbolic versions of the info codes so that nobody has to look in adbc.h to figure out that 0L is the code for vendor 😬 .

...also, nanoarrow chokes on converting the map<int, int> member of the union array 😬 😬 . I thought I'd handled unions and maps but perhaps the nesting is causing a problem or perhaps I forgot to implement maps.

``` r
library(adbcdrivermanager)

db <- adbc_database_init(adbcsqlite::adbcsqlite(), uri = ":memory:")
con <- adbc_connection_init(db)
adbc_connection_get_info(con, 0)
#> <nanoarrow_array_stream struct<info_name: uint32, info_value: dense_union([0,1,2,3,4,5])<string_value: string, bool_value: bool, int64_value: int64, int32_bitmask: int32, string_list: list<item: string>, int32_to_int32_list_map: map<entries: struct<key: int32, value: list<item: int32>>>>>>
#>  $ get_schema:function ()  
#>  $ get_next  :function (schema = x$get_schema(), validate = TRUE)  
#>  $ release   :function ()
```

<sup>Created on 2023-08-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>