### PR TITLE
chore(r): Ensure package documentation has `\alias`

### DIFF
--- a/r/adbcflightsql/R/adbcflightsql-package.R
+++ b/r/adbcflightsql/R/adbcflightsql-package.R
@@ -16,7 +16,7 @@
 # under the License.
 
 #' @keywords internal
-#' @aliases NULL
+#' @aliases adbcflightsql-package
 "_PACKAGE"
 
 ## usethis namespace: start

--- a/r/adbcflightsql/man/adbcflightsql-package.Rd
+++ b/r/adbcflightsql/man/adbcflightsql-package.Rd
@@ -2,6 +2,8 @@
 % Please edit documentation in R/adbcflightsql-package.R
 \docType{package}
 \name{adbcflightsql-package}
+\alias{adbcflightsql-package}
+\alias{_PACKAGE}
 \title{adbcflightsql: 'Arrow' Database Connectivity ('ADBC') 'FlightSQL' Driver}
 \description{
 Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADBC') 'FlightSQL' driver for the purposes of building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.

--- a/r/adbcpostgresql/R/adbcpostgresql-package.R
+++ b/r/adbcpostgresql/R/adbcpostgresql-package.R
@@ -16,7 +16,7 @@
 # under the License.
 
 #' @keywords internal
-#' @aliases NULL
+#' @aliases adbcpostgresql-package
 "_PACKAGE"
 
 ## usethis namespace: start

--- a/r/adbcpostgresql/man/adbcpostgresql-package.Rd
+++ b/r/adbcpostgresql/man/adbcpostgresql-package.Rd
@@ -2,6 +2,8 @@
 % Please edit documentation in R/adbcpostgresql-package.R
 \docType{package}
 \name{adbcpostgresql-package}
+\alias{adbcpostgresql-package}
+\alias{_PACKAGE}
 \title{adbcpostgresql: 'Arrow' Database Connectivity ('ADBC') 'PostgreSQL' Driver}
 \description{
 Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADBC') 'PostgreSQL' driver for the purposes of building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.

--- a/r/adbcsnowflake/R/adbcsnowflake-package.R
+++ b/r/adbcsnowflake/R/adbcsnowflake-package.R
@@ -16,7 +16,7 @@
 # under the License.
 
 #' @keywords internal
-#' @aliases NULL
+#' @aliases adbcsnowflake-package
 "_PACKAGE"
 
 ## usethis namespace: start

--- a/r/adbcsnowflake/man/adbcsnowflake-package.Rd
+++ b/r/adbcsnowflake/man/adbcsnowflake-package.Rd
@@ -2,6 +2,8 @@
 % Please edit documentation in R/adbcsnowflake-package.R
 \docType{package}
 \name{adbcsnowflake-package}
+\alias{adbcsnowflake-package}
+\alias{_PACKAGE}
 \title{adbcsnowflake: Arrow Database Connectivity ('ADBC') 'Snowflake' Driver}
 \description{
 Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADBC') 'Snowflake' driver for the purposes of building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.

--- a/r/adbcsqlite/R/adbcsqlite-package.R
+++ b/r/adbcsqlite/R/adbcsqlite-package.R
@@ -16,7 +16,7 @@
 # under the License.
 
 #' @keywords internal
-#' @aliases NULL
+#' @aliases adbcsqlite-package
 "_PACKAGE"
 
 ## usethis namespace: start

--- a/r/adbcsqlite/man/adbcsqlite-package.Rd
+++ b/r/adbcsqlite/man/adbcsqlite-package.Rd
@@ -2,6 +2,8 @@
 % Please edit documentation in R/adbcsqlite-package.R
 \docType{package}
 \name{adbcsqlite-package}
+\alias{adbcsqlite-package}
+\alias{_PACKAGE}
 \title{adbcsqlite: 'Arrow' Database Connectivity ('ADBC') 'SQLite' Driver}
 \description{
 Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADBC') 'SQLite' driver for the purposes of building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.


### PR DESCRIPTION
Remotes a CMD check NOTE on R-devel:

```
* checking Rd metadata ... NOTE
Rd files without \alias:
  'adbcsqlite-package.Rd'
```

I had used `@aliases NULL` because each driver package has an identically named function and using `@aliases NULL` ensured that there were no duplicate aliases. Recent r-devel added a check for .Rd files with no alias, hence the need for an update.

For #1010, #1011, and #1012.