### PR TITLE
chore(c/vendor): Make __int128 safe-math header opt-in

### DIFF
--- a/c/vendor/portable-snippets/safe-math.h
+++ b/c/vendor/portable-snippets/safe-math.h
@@ -166,11 +166,15 @@
 
 #define PSNIP_SAFE_IS_LARGER(ORIG_MAX, DEST_MAX) ((DEST_MAX / ORIG_MAX) >= ORIG_MAX)
 
+// Using __int128 intrinsics causes compilation to fail with -Wpedantic
+// which is required to pass CRAN incoming checks for R packages that use this header
+#if defined(PSNIP_USE_INTRINSIC_INT128)
 #if defined(__GNUC__) && ((__GNUC__ >= 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)) && defined(__SIZEOF_INT128__) && !defined(__ibmxl__)
 #define PSNIP_SAFE_HAVE_128
 typedef __int128  psnip_safe_int128_t;
 typedef unsigned __int128 psnip_safe_uint128_t;
 #endif /* defined(__GNUC__) */
+#endif
 
 #if !defined(PSNIP_SAFE_NO_FIXED)
 #define PSNIP_SAFE_HAVE_INT8_LARGER


### PR DESCRIPTION
When trying to submit adbcpostgres, I get:

```
* checking whether package 'adbcpostgresql' can be installed ... WARNING
Found the following significant warnings:
  vendor/portable-snippets/safe-math.h:171:9: warning: ISO C++ does not support '__int128' for 'psnip_safe_int128_t' [-Wpedantic]
  vendor/portable-snippets/safe-math.h:172:18: warning: ISO C++ does not support '__int128' for 'psnip_safe_uint128_t' [-Wpedantic]
See 'd:/RCompile/CRANguest/R-devel/adbcpostgresql.Rcheck/00install.out' for details.
```

This is the workaround that I'm including in the CRAN packaging branch for 0.6.0 but it would be nice to avoid dealing with it on subsequent submissions. The only function we use from this header is the overflow-safe int64 multiplication for timestamp support in the postgres driver...given that we're always multiplying by a fixed 1000 in that line, we could also probably hard-code the check + test the last supported date?