### PR TITLE
fix(r/adbcdrivermanager): Ensure nullable arguments `adbc_connection_get_objects()` can be specified

### DIFF
--- a/r/adbcdrivermanager/R/adbc.R
+++ b/r/adbcdrivermanager/R/adbc.R
@@ -226,8 +226,8 @@ adbc_connection_get_info <- function(connection, info_codes) {
 
 #' @rdname adbc_connection_get_info
 #' @export
-adbc_connection_get_objects <- function(connection, depth, catalog, db_schema,
-                                        table_name, table_type, column_name) {
+adbc_connection_get_objects <- function(connection, depth = 0L, catalog = NULL, db_schema = NULL,
+                                        table_name = NULL, table_type = NULL, column_name = NULL) {
   error <- adbc_allocate_error()
   out_stream <- nanoarrow::nanoarrow_allocate_array_stream()
   status <- .Call(

--- a/r/adbcdrivermanager/man/adbc_connection_get_info.Rd
+++ b/r/adbcdrivermanager/man/adbc_connection_get_info.Rd
@@ -14,12 +14,12 @@ adbc_connection_get_info(connection, info_codes)
 
 adbc_connection_get_objects(
   connection,
-  depth,
-  catalog,
-  db_schema,
-  table_name,
-  table_type,
-  column_name
+  depth = 0L,
+  catalog = NULL,
+  db_schema = NULL,
+  table_name = NULL,
+  table_type = NULL,
+  column_name = NULL
 )
 
 adbc_connection_get_table_schema(connection, catalog, db_schema, table_name)

--- a/r/adbcdrivermanager/src/radbc.h
+++ b/r/adbcdrivermanager/src/radbc.h
@@ -131,7 +131,11 @@ static inline void adbc_xptr_move_attrs(SEXP xptr_old, SEXP xptr_new) {
   UNPROTECT(5);
 }
 
-static inline const char* adbc_as_const_char(SEXP sexp) {
+static inline const char* adbc_as_const_char(SEXP sexp, bool nullable = false) {
+  if (nullable && sexp == R_NilValue) {
+    return nullptr;
+  }
+
   if (TYPEOF(sexp) != STRSXP || Rf_length(sexp) != 1) {
     Rf_error("Expected character(1) for conversion to const char*");
   }


### PR DESCRIPTION
Thanks to @nbenn for the reprex!

``` r
library(adbcdrivermanager)

db <- adbc_database_init(adbcsqlite::adbcsqlite(), uri = ":memory:")
con <- adbc_connection_init(db)

flights <- nycflights13::flights
flights$time_hour <- NULL

write_adbc(flights, con, "flights")
stream <- adbc_connection_get_objects(con)
# pretty wild result type
df <- as.data.frame(stream)
df$catalog_db_schemas[[1]]$db_schema_tables[[1]]$table_name
#> [1] "flights"
df$catalog_db_schemas[[1]]$db_schema_tables[[1]]$table_columns[[1]]$column_name
#>  [1] "year"           "month"          "day"            "dep_time"      
#>  [5] "sched_dep_time" "dep_delay"      "arr_time"       "sched_arr_time"
#>  [9] "arr_delay"      "carrier"        "flight"         "tailnum"       
#> [13] "origin"         "dest"           "air_time"       "distance"      
#> [17] "hour"           "minute"
```

<sup>Created on 2023-09-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>