### PR TITLE
fix(c/driver/sqlite): Escape tablename in sqlite GetTableSchema

### DIFF
--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -1314,7 +1314,8 @@ AdbcStatusCode PostgresConnection::GetTableSchema(const char* catalog,
   RAISE_ADBC(result_helper.Prepare());
   auto result = result_helper.Execute();
   if (result != ADBC_STATUS_OK) {
-    if (std::string(error->sqlstate, 5) == "42P01") {
+    auto error_code = std::string(error->sqlstate, 5);
+    if ((error_code == "42P01") || (error_code == "42602")) {
       return ADBC_STATUS_NOT_FOUND;
     }
     return result;

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -430,6 +430,20 @@ void ConnectionTest::TestMetadataGetTableSchema() {
                                     {"strings", NANOARROW_TYPE_STRING, NULLABLE}}));
 }
 
+void ConnectionTest::TestMetadataGetTableSchemaEscaping() {
+  if (!quirks()->supports_bulk_ingest(ADBC_INGEST_OPTION_MODE_CREATE)) {
+    GTEST_SKIP();
+  }
+  ASSERT_THAT(AdbcConnectionNew(&connection, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
+
+  Handle<ArrowSchema> schema;
+  ASSERT_THAT(
+      AdbcConnectionGetTableSchema(&connection, /*catalog=*/nullptr,
+                                   /*db_schema=*/nullptr, "table", &schema.value, &error),
+      IsOkStatus(&error));
+};
+
 void ConnectionTest::TestMetadataGetTableSchemaNotFound() {
   ASSERT_THAT(AdbcConnectionNew(&connection, &error), IsOkStatus(&error));
   ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -438,10 +438,10 @@ void ConnectionTest::TestMetadataGetTableSchemaEscaping() {
   ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
 
   Handle<ArrowSchema> schema;
-  ASSERT_THAT(
-      AdbcConnectionGetTableSchema(&connection, /*catalog=*/nullptr,
-                                   /*db_schema=*/nullptr, "table", &schema.value, &error),
-      IsOkStatus(&error));
+  ASSERT_THAT(AdbcConnectionGetTableSchema(&connection, /*catalog=*/nullptr,
+                                           /*db_schema=*/nullptr, "(SELECT CURRENT_TIME)",
+                                           &schema.value, &error),
+              IsStatus(ADBC_STATUS_NOT_FOUND, &error));
 };
 
 void ConnectionTest::TestMetadataGetTableSchemaNotFound() {

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -438,10 +438,10 @@ void ConnectionTest::TestMetadataGetTableSchemaEscaping() {
   ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
 
   Handle<ArrowSchema> schema;
-  ASSERT_THAT(AdbcConnectionGetTableSchema(&connection, /*catalog=*/nullptr,
-                                           /*db_schema=*/nullptr, "(SELECT CURRENT_TIME)",
-                                           &schema.value, &error),
-              IsStatus(ADBC_STATUS_NOT_FOUND, &error));
+  ASSERT_NE(AdbcConnectionGetTableSchema(&connection, /*catalog=*/nullptr,
+                                         /*db_schema=*/nullptr, "(SELECT CURRENT_TIME)",
+                                         &schema.value, &error),
+            ADBC_STATUS_OK);
 };
 
 void ConnectionTest::TestMetadataGetTableSchemaNotFound() {

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -438,10 +438,10 @@ void ConnectionTest::TestMetadataGetTableSchemaEscaping() {
   ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
 
   Handle<ArrowSchema> schema;
-  ASSERT_NE(AdbcConnectionGetTableSchema(&connection, /*catalog=*/nullptr,
-                                         /*db_schema=*/nullptr, "(SELECT CURRENT_TIME)",
-                                         &schema.value, &error),
-            ADBC_STATUS_OK);
+  ASSERT_THAT(AdbcConnectionGetTableSchema(&connection, /*catalog=*/nullptr,
+                                           /*db_schema=*/nullptr, "(SELECT CURRENT_TIME)",
+                                           &schema.value, &error),
+              IsStatus(ADBC_STATUS_NOT_FOUND, &error));
 };
 
 void ConnectionTest::TestMetadataGetTableSchemaNotFound() {

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -188,6 +188,7 @@ class ConnectionTest {
 
   void TestMetadataGetInfo();
   void TestMetadataGetTableSchema();
+  void TestMetadataGetTableSchemaEscaping();
   void TestMetadataGetTableSchemaNotFound();
   void TestMetadataGetTableTypes();
 
@@ -220,6 +221,9 @@ class ConnectionTest {
   TEST_F(FIXTURE, MetadataCurrentDbSchema) { TestMetadataCurrentDbSchema(); }           \
   TEST_F(FIXTURE, MetadataGetInfo) { TestMetadataGetInfo(); }                           \
   TEST_F(FIXTURE, MetadataGetTableSchema) { TestMetadataGetTableSchema(); }             \
+  TEST_F(FIXTURE, MetadataGetTableSchemaEscaping) {                                     \
+    TestMetadataGetTableSchemaEscaping();                                               \
+  }                                                                                     \
   TEST_F(FIXTURE, MetadataGetTableSchemaNotFound) {                                     \
     TestMetadataGetTableSchemaNotFound();                                               \
   }                                                                                     \


### PR DESCRIPTION
closes #1025 