### PR TITLE
fix(java/driver/flight-sql): fix leak in InfoMetadataBuilder

### DIFF
--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
@@ -110,8 +110,9 @@ public class FlightSqlConnection implements AdbcConnection {
   @Override
   public ArrowReader getInfo(int[] infoCodes) throws AdbcException {
     try (InfoMetadataBuilder builder = new InfoMetadataBuilder(allocator, client, infoCodes)) {
-      final VectorSchemaRoot root = builder.build();
-      return RootArrowReader.fromRoot(allocator, root);
+      try (final VectorSchemaRoot root = builder.build()) {
+        return RootArrowReader.fromRoot(allocator, root);
+      }
     } catch (Exception e) {
       throw AdbcException.invalidState("[Flight SQL] Failed to get info");
     }

--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
@@ -109,9 +109,11 @@ public class FlightSqlConnection implements AdbcConnection {
 
   @Override
   public ArrowReader getInfo(int[] infoCodes) throws AdbcException {
-    try (final VectorSchemaRoot root =
-        new InfoMetadataBuilder(allocator, client, infoCodes).build()) {
+    try (InfoMetadataBuilder builder = new InfoMetadataBuilder(allocator, client, infoCodes)) {
+      final VectorSchemaRoot root = builder.build();
       return RootArrowReader.fromRoot(allocator, root);
+    } catch (Exception e) {
+      throw AdbcException.invalidState("[Flight SQL] Failed to get info");
     }
   }
 


### PR DESCRIPTION
If an exception was thrown in InfoMetadataBuilder, the inner VectorSchemaRoot would leak.