### PR TITLE
fix(python): Fix option for adbc.ingest.temporary

### DIFF
--- a/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
@@ -866,13 +866,13 @@ class Cursor(_Closeable):
         if temporary:
             self._stmt.set_options(
                 **{
-                    adbc_driver_manager.StatementOptions.INGEST_TEMPORARY.value: "true",
+                    adbc_driver_manager.StatementOptions.INGEST_TEMPORARY.value: True,
                 }
             )
         else:
             # Need to explicitly clear it, but not all drivers support this
             options = {
-                adbc_driver_manager.StatementOptions.INGEST_TEMPORARY.value: "false",
+                adbc_driver_manager.StatementOptions.INGEST_TEMPORARY.value: False,
             }
             try:
                 self._stmt.set_options(**options)


### PR DESCRIPTION
Fixes the following issue on ingest

```python
Cell In[2], line 10
      8     data = pa.array([1, 2, 4])
      9     tbl = pa.Table.from_arrays([data], names=["CAPITALIZED"])
---> 10     cur.adbc_ingest("test_table", tbl, mode="create")
     11 conn.commit()

File ~/clones/arrow-adbc/python/adbc_driver_manager/adbc_driver_manager/dbapi.py:878, in Cursor.adbc_ingest(self, table_name, data, mode, catalog_name, db_schema_name, temporary)
    874 options = {
    875     adbc_driver_manager.StatementOptions.INGEST_TEMPORARY.value: "false",
    876 }
    877 try:
--> 878     self._stmt.set_options(**options)
    879 except NotSupportedError:
    880     pass

File adbc_driver_manager/_lib.pyx:1374, in adbc_driver_manager._lib.AdbcStatement.set_options()

File adbc_driver_manager/_lib.pyx:227, in adbc_driver_manager._lib.check_error()

ProgrammingError: INVALID_ARGUMENT: [libpq] Invalid value 'false' for option 'adbc.ingest.temporary'

```