### PR TITLE
fix(python/adbc_driver_manager): Allow non-indexable sequences in executemany

### DIFF
--- a/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
@@ -701,12 +701,11 @@ class Cursor(_Closeable):
         ):
             arrow_parameters = seq_of_parameters
         elif seq_of_parameters:
-            arrow_parameters = pyarrow.record_batch(
-                [
-                    pyarrow.array([row[col_idx] for row in seq_of_parameters])
-                    for col_idx in range(len(seq_of_parameters[0]))
-                ],
-                names=[str(i) for i in range(len(seq_of_parameters[0]))],
+            arrow_parameters = pyarrow.RecordBatch.from_pydict(
+                {
+                    str(col_idx): pyarrow.array(x)
+                    for col_idx, x in enumerate(map(list, zip(*seq_of_parameters)))
+                },
             )
         else:
             arrow_parameters = pyarrow.record_batch([])

--- a/python/adbc_driver_manager/tests/test_dbapi.py
+++ b/python/adbc_driver_manager/tests/test_dbapi.py
@@ -253,6 +253,7 @@ def test_execute_parameters(sqlite, parameters):
         pyarrow.record_batch([[1, 3], ["a", None]], names=["float", "str"]),
         pyarrow.table([[1, 3], ["a", None]], names=["float", "str"]),
         pyarrow.table([[1, 3], ["a", None]], names=["float", "str"]).to_batches()[0],
+        ((x, y) for x, y in ((1, "a"), (3, None))),
     ],
 )
 def test_executemany_parameters(sqlite, parameters):


### PR DESCRIPTION
fixes https://github.com/apache/arrow-adbc/issues/1076