### PR TITLE
fix(go/adbc/driver/snowflake): Prevent database options from getting overwritten

### DIFF
--- a/go/adbc/driver/snowflake/driver.go
+++ b/go/adbc/driver/snowflake/driver.go
@@ -330,6 +330,7 @@ func (d *database) SetOptions(cnOptions map[string]string) error {
 
 	var err error
 	for k, v := range cnOptions {
+		v := v // copy into loop scope
 		switch k {
 		case adbc.OptionKeyUsername:
 			d.cfg.User = v

--- a/go/adbc/driver/snowflake/driver_test.go
+++ b/go/adbc/driver/snowflake/driver_test.go
@@ -584,3 +584,25 @@ func (suite *SnowflakeTests) TestMetadataGetObjectsColumnsXdbc() {
 		})
 	}
 }
+
+func (suite *SnowflakeTests) TestNewDatabaseGetSetOptions() {
+	key1, val1 := "key1", "val1"
+	key2, val2 := "key2", "val2"
+
+	db, err := suite.driver.NewDatabase(map[string]string{
+		key1: val1,
+		key2: val2,
+	})
+	suite.NoError(err)
+	suite.NotNil(db)
+
+	getSetDB, ok := db.(adbc.GetSetOptions)
+	suite.True(ok)
+
+	optVal1, err := getSetDB.GetOption(key1)
+	suite.NoError(err)
+	suite.Equal(optVal1, val1)
+	optVal2, err := getSetDB.GetOption(key2)
+	suite.NoError(err)
+	suite.Equal(optVal2, val2)
+}

--- a/go/adbc/validation/validation.go
+++ b/go/adbc/validation/validation.go
@@ -102,6 +102,33 @@ func (d *DatabaseTests) TestNewDatabase() {
 	d.Implements((*adbc.Database)(nil), db)
 }
 
+func (d *DatabaseTests) TestNewDatabaseGetSetOptions() {
+	if !d.Quirks.SupportsGetSetOptions() {
+		d.T().SkipNow()
+	}
+
+	key1, val1 := "key1", "val1"
+	key2, val2 := "key2", "val2"
+
+	opts := d.Quirks.DatabaseOptions()
+	opts[key1] = val1
+	opts[key2] = val2
+
+	db, err := d.Driver.NewDatabase(opts)
+	d.NoError(err)
+	d.NotNil(db)
+
+	getSetDB, ok := db.(adbc.GetSetOptions)
+	d.True(ok)
+
+	optVal1, err := getSetDB.GetOption(key1)
+	d.NoError(err)
+	d.Equal(optVal1, val1)
+	optVal2, err := getSetDB.GetOption(key2)
+	d.NoError(err)
+	d.Equal(optVal2, val2)
+}
+
 type ConnectionTests struct {
 	suite.Suite
 

--- a/go/adbc/validation/validation.go
+++ b/go/adbc/validation/validation.go
@@ -102,33 +102,6 @@ func (d *DatabaseTests) TestNewDatabase() {
 	d.Implements((*adbc.Database)(nil), db)
 }
 
-func (d *DatabaseTests) TestNewDatabaseGetSetOptions() {
-	if !d.Quirks.SupportsGetSetOptions() {
-		d.T().SkipNow()
-	}
-
-	key1, val1 := "key1", "val1"
-	key2, val2 := "key2", "val2"
-
-	opts := d.Quirks.DatabaseOptions()
-	opts[key1] = val1
-	opts[key2] = val2
-
-	db, err := d.Driver.NewDatabase(opts)
-	d.NoError(err)
-	d.NotNil(db)
-
-	getSetDB, ok := db.(adbc.GetSetOptions)
-	d.True(ok)
-
-	optVal1, err := getSetDB.GetOption(key1)
-	d.NoError(err)
-	d.Equal(optVal1, val1)
-	optVal2, err := getSetDB.GetOption(key2)
-	d.NoError(err)
-	d.Equal(optVal2, val2)
-}
-
 type ConnectionTests struct {
 	suite.Suite
 


### PR DESCRIPTION
Fixes #1074 