### PR TITLE
fix(go/adbc): missing  adbc.ingest.temporary

### DIFF
--- a/go/adbc/adbc.go
+++ b/go/adbc/adbc.go
@@ -237,6 +237,7 @@ const (
 	OptionKeyProgress                 = "adbc.statement.exec.progress"
 	OptionKeyMaxProgress              = "adbc.statement.exec.max_progress"
 	OptionKeyIngestTargetTable        = "adbc.ingest.target_table"
+	OptionKeyIngestTemporary          = "adbc.ingest.temporary"
 	OptionKeyIngestMode               = "adbc.ingest.mode"
 	OptionKeyIsolationLevel           = "adbc.connection.transaction.isolation_level"
 	OptionKeyReadOnly                 = "adbc.connection.readonly"

--- a/go/adbc/driver/snowflake/statement.go
+++ b/go/adbc/driver/snowflake/statement.go
@@ -108,6 +108,11 @@ func (st *statement) SetOption(key string, val string) error {
 	case adbc.OptionKeyIngestTargetTable:
 		st.query = ""
 		st.targetTable = val
+	case adbc.OptionKeyIngestTemporary:
+		return adbc.Error{
+			Msg:  fmt.Sprintf("[Snowflake] Unknown statement option '%s'", key),
+			Code: adbc.StatusNotImplemented,
+		}
 	case adbc.OptionKeyIngestMode:
 		switch val {
 		case adbc.OptionValueIngestModeAppend:


### PR DESCRIPTION
See https://github.com/apache/arrow-adbc/issues/1119