### PR TITLE
fix(c/driver_manager): Include cerrno in driver manager

### DIFF
--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cerrno>
 #include <cstring>
 #include <string>
 #include <unordered_map>

--- a/go/adbc/drivermgr/adbc_driver_manager.cc
+++ b/go/adbc/drivermgr/adbc_driver_manager.cc
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cerrno>
 #include <cstring>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
From CRAN on x86_64-apple-darwin17.0 (64-bit)

```
* installing *source* package ‘adbcdrivermanager’ ...
** package ‘adbcdrivermanager’ successfully unpacked and MD5 sums checked
** using staged installation
Found vendored ADBC
** libs
clang++ -mmacosx-version-min=10.13 -std=gnu++14 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I../src -DADBC_EXPORT=""  -I/usr/local/include   -fPIC  -Wall -g -O2  -c adbc_driver_manager.cc -o adbc_driver_manager.o
adbc_driver_manager.cc:271:83: error: use of undeclared identifier 'EINVAL'
  if (stream->release != ErrorArrayStreamRelease || !stream->private_data) return EINVAL;
                                                                                  ^
adbc_driver_manager.cc:278:83: error: use of undeclared identifier 'EINVAL'
  if (stream->release != ErrorArrayStreamRelease || !stream->private_data) return EINVAL;
                                                                                  ^
2 errors generated.
make: *** [adbc_driver_manager.o] Error 1
ERROR: compilation failed for package ‘adbcdrivermanager’
* removing ‘/Volumes/Builds/packages/high-sierra-x86_64/results/4.2/adbcdrivermanager.Rcheck/adbcdrivermanager’
```

I imagine this didn't get caught on CI because their x86 runner for "oldrel" is MacOS 10.13 which we don't check (a good thing...it's very outdated).