### PR TITLE
feat(glib): add Vala VAPI for GADBC

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,12 @@ repos:
     hooks:
     - id: isort
       types_or: [python]
+  # TODO: Change this to vala-lang/vala-lint after
+  # https://github.com/vala-lang/vala-lint/pull/179 is merged.
+  - repo: https://github.com/kou/vala-lint
+    rev: pre-commit-hook
+    hooks:
+    - id: vala-lint
   - repo: local
     hooks:
     - id: apache-rat

--- a/ci/linux-packages/debian/control
+++ b/ci/linux-packages/debian/control
@@ -180,8 +180,7 @@ Multi-Arch: same
 Depends:
   ${misc:Depends},
   gir1.2-adbc-1.0 (= ${binary:Version}),
-  libadbc-driver-manager-dev (= ${binary:Version}),
-  libarrow-glib-dev
+  libadbc-driver-manager-dev (= ${binary:Version})
 Description: Apache Arrow Database Connectivity (ADBC) driver manager
  .
  This package provides GLib based header files.

--- a/ci/linux-packages/debian/libadbc-glib-dev.install
+++ b/ci/linux-packages/debian/libadbc-glib-dev.install
@@ -1,4 +1,6 @@
 usr/include/adbc-glib/
 usr/lib/*/libadbc-glib.so
 usr/lib/*/pkgconfig/adbc-glib.pc
+usr/share/adbc-glib/example/
 usr/share/gir-1.0/ADBC-*.gir
+usr/share/vala/vapi/*

--- a/ci/linux-packages/debian/rules
+++ b/ci/linux-packages/debian/rules
@@ -1,3 +1,4 @@
+
 #!/usr/bin/make -f
 # -*- makefile-gmake -*-
 #
@@ -31,23 +32,23 @@ export DEB_BUILD_MAINT_OPTIONS=reproducible=-timeless
 CMAKE_BUILD_TYPE = RelWithDebInfo
 
 override_dh_auto_configure:
-	env \
+	env						\
 	  PATH=/usr/lib/go-1.20/bin:$${PATH}		\
 	  dh_auto_configure				\
-	    --sourcedirectory=c/		        \
-	    --builddirectory=c.build               	\
+	    --sourcedirectory=c/			\
+	    --builddirectory=c.build			\
 	    --buildsystem=cmake+ninja			\
 	    --						\
-	    -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE)      \
-            -DADBC_DRIVER_MANAGER=ON                    \
-            -DADBC_DRIVER_POSTGRESQL=ON                 \
-            -DADBC_DRIVER_SQLITE=ON                     \
-            -DADBC_DRIVER_FLIGHTSQL=ON                  \
-            -DADBC_DRIVER_SNOWFLAKE=ON
+	    -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE)	\
+	    -DADBC_DRIVER_FLIGHTSQL=ON			\
+	    -DADBC_DRIVER_MANAGER=ON			\
+	    -DADBC_DRIVER_POSTGRESQL=ON			\
+	    -DADBC_DRIVER_SNOWFLAKE=ON			\
+	    -DADBC_DRIVER_SQLITE=ON
 
 override_dh_auto_build:
-	dh_auto_build					\
-	  --sourcedirectory=c              		\
+	dh_auto_build				\
+	  --sourcedirectory=c			\
 	  --builddirectory=c.build
 	dh_auto_configure				\
 	  --sourcedirectory=glib			\
@@ -55,7 +56,8 @@ override_dh_auto_build:
 	  --buildsystem=meson+ninja			\
 	  --						\
 	  --buildtype=debugoptimized			\
-	  -Dadbc_build_dir=../c.build/driver_manager
+	  -Dadbc_build_dir=../c.build/driver_manager	\
+	  -Dvapi=true
 	env							\
 	  LD_LIBRARY_PATH=$(CURDIR)/c.build/driver_manager	\
 	    dh_auto_build					\
@@ -64,8 +66,8 @@ override_dh_auto_build:
 	      --buildsystem=meson+ninja
 
 override_dh_auto_install:
-	dh_auto_install					\
-	  --sourcedirectory=c           		\
+	dh_auto_install				\
+	  --sourcedirectory=c			\
 	  --builddirectory=c.build
 	dh_auto_install				\
 	   --sourcedirectory=glib		\

--- a/ci/linux-packages/debian/rules
+++ b/ci/linux-packages/debian/rules
@@ -1,4 +1,3 @@
-
 #!/usr/bin/make -f
 # -*- makefile-gmake -*-
 #

--- a/ci/linux-packages/yum/almalinux-8/Dockerfile
+++ b/ci/linux-packages/yum/almalinux-8/Dockerfile
@@ -38,5 +38,6 @@ RUN \
     python3-pip \
     rpmdevtools \
     sqlite-devel \
-    tar && \
+    tar \
+    vala && \
   yum clean ${quiet} all

--- a/ci/linux-packages/yum/almalinux-9/Dockerfile
+++ b/ci/linux-packages/yum/almalinux-9/Dockerfile
@@ -38,5 +38,6 @@ RUN \
     python3-pip \
     rpmdevtools \
     sqlite-devel \
-    tar && \
+    tar \
+    vala && \
   dnf clean ${quiet} all

--- a/ci/linux-packages/yum/apache-arrow-adbc.spec.in
+++ b/ci/linux-packages/yum/apache-arrow-adbc.spec.in
@@ -48,6 +48,7 @@ BuildRequires:	libpq-devel
 BuildRequires:	ninja-build
 BuildRequires:	pkgconfig
 BuildRequires:	sqlite-devel
+BuildRequires:	vala
 
 %description
 Apache Arrow Database Connectivity (ADBC) is an Apache Arrow based database access API
@@ -63,11 +64,11 @@ cd c
 %adbc_cmake \
   -DCMAKE_BUILD_TYPE=${cmake_build_type} \
   -G"Unix Makefiles" \
+  -DADBC_DRIVER_FLIGHTSQL=ON \
   -DADBC_DRIVER_MANAGER=ON \
   -DADBC_DRIVER_POSTGRESQL=ON \
-  -DADBC_DRIVER_SQLITE=ON \
-  -DADBC_DRIVER_FLIGHTSQL=ON \
-  -DADBC_DRIVER_SNOWFLAKE=ON
+  -DADBC_DRIVER_SNOWFLAKE=ON \
+  -DADBC_DRIVER_SQLITE=ON
 %adbc_cmake_build
 cd -
 
@@ -78,7 +79,8 @@ meson setup build \
   --default-library=both \
   --libdir=%{_libdir} \
   --prefix=%{_prefix} \
-  -Dadbc_build_dir=$PWD/../c/%{adbc_cmake_builddir}/driver_manager
+  -Dadbc_build_dir=$PWD/../c/%{adbc_cmake_builddir}/driver_manager \
+  -Dvapi=true
 
 LD_LIBRARY_PATH=$PWD/../c/%{adbc_cmake_builddir}/driver_manager \
   meson compile -C build %{?_smp_mflags}
@@ -258,7 +260,7 @@ This package contains the libraries for ADBC GLib.
 %defattr(-,root,root,-)
 %doc README.md
 %license LICENSE.txt NOTICE.txt
-%{_libdir}/girepository-1.0/ADBC-*.typelib
+%{_libdir}/girepository-1.0/
 %{_libdir}/libadbc-glib.so.*
 
 %package glib-devel
@@ -276,7 +278,8 @@ Libraries and header files for ADBC GLib.
 %defattr(-,root,root,-)
 %doc README.md
 %license LICENSE.txt NOTICE.txt
-%{_datadir}/gir-1.0/ADBC-*.gir
+%{_datadir}/gir-1.0/
+%{_datadir}/vala/vapi/
 %{_includedir}/adbc-glib/
 %{_libdir}/libadbc-glib.a
 %{_libdir}/libadbc-glib.so
@@ -293,6 +296,7 @@ Documentation for ADBC GLib.
 %defattr(-,root,root,-)
 %doc README.md
 %license LICENSE.txt NOTICE.txt
+%{_datadir}/adbc-glib/example/
 %{_docdir}/adbc-glib/
 
 %changelog

--- a/ci/scripts/glib_build.sh
+++ b/ci/scripts/glib_build.sh
@@ -54,12 +54,12 @@ build_subproject() {
           -Dvapi="${enable_vapi}" \
           "${build_dir}/glib" \
           "${source_dir}/glib"
+    meson install -C "${build_dir}/glib"
     "${build_dir}/glib/example/sqlite"
     if [[ "${enable_vapi}" = "true" ]]; then
         "${build_dir}/glib/example/vala/sqlite"
     fi
     "${build_dir}/build/sqlite"
-    meson install -C "${build_dir}/glib"
 }
 
 main() {

--- a/ci/scripts/glib_build.sh
+++ b/ci/scripts/glib_build.sh
@@ -59,7 +59,6 @@ build_subproject() {
     if [[ "${enable_vapi}" = "true" ]]; then
         "${build_dir}/glib/example/vala/sqlite"
     fi
-    "${build_dir}/build/sqlite"
 }
 
 main() {

--- a/ci/scripts/glib_build.sh
+++ b/ci/scripts/glib_build.sh
@@ -38,6 +38,11 @@ build_subproject() {
         cmake_prefix_path="${CONDA_PREFIX}:${cmake_prefix_path}"
         pkg_config_path="${pkg_config_path}:${CONDA_PREFIX}/lib/pkgconfig"
     fi
+    if type valac > /dev/null 2>&1; then
+        enable_vapi=true
+    else
+        enable_vapi=false
+    fi
 
     meson setup \
           --buildtype=debug \
@@ -45,8 +50,15 @@ build_subproject() {
           --libdir=lib \
           --pkg-config-path="${pkg_config_path}" \
           --prefix="${install_dir}" \
+          -Dexample=true \
+          -Dvapi="${enable_vapi}" \
           "${build_dir}/glib" \
           "${source_dir}/glib"
+    "${build_dir}/glib/example/sqlite"
+    if [[ "${enable_vapi}" = "true" ]]; then
+        "${build_dir}/glib/example/vala/sqlite"
+    fi
+    "${build_dir}/build/sqlite"
     meson install -C "${build_dir}/glib"
 }
 

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -149,6 +149,7 @@ ${APT_INSTALL} libadbc-driver-manager-dev=${package_version}
 required_packages=()
 required_packages+=(cmake)
 required_packages+=(gcc)
+required_packages+=(libc6-dev)
 required_packages+=(make)
 required_packages+=(pkg-config)
 ${APT_INSTALL} ${required_packages[@]}

--- a/glib/adbc-glib/error.h
+++ b/glib/adbc-glib/error.h
@@ -69,7 +69,7 @@ G_BEGIN_DECLS
  *   given operation.
  *   May indicate a database-side error only.
  *
- * The error codes are used by all arrow-glib functions.
+ * The error codes are used by all adbc-glib functions.
  *
  * They are corresponding to `ADBC_STATUS_*` values.
  */

--- a/glib/adbc-glib/meson.build
+++ b/glib/adbc-glib/meson.build
@@ -102,3 +102,9 @@ adbc_glib_gir = gnome.generate_gir(libadbc_glib,
                                    nsversion: api_version,
                                    sources: sources + definition_headers + enums,
                                    symbol_prefix: 'gadbc')
+if generate_vapi
+  adbc_glib_vapi = gnome.generate_vapi('adbc-glib',
+                                  install: true,
+                                  packages: ['gobject-2.0', 'arrow-glib'],
+                                  sources: [adbc_glib_gir[0]])
+endif

--- a/glib/adbc-glib/meson.build
+++ b/glib/adbc-glib/meson.build
@@ -103,8 +103,8 @@ adbc_glib_gir = gnome.generate_gir(libadbc_glib,
                                    sources: sources + definition_headers + enums,
                                    symbol_prefix: 'gadbc')
 if generate_vapi
-  adbc_glib_vapi = gnome.generate_vapi('adbc-glib',
-                                  install: true,
-                                  packages: ['gobject-2.0', 'arrow-glib'],
-                                  sources: [adbc_glib_gir[0]])
+  adbc_glib_vapi = gnome.generate_vapi('gadbc-1.0',
+                                       install: true,
+                                       packages: ['gobject-2.0'],
+                                       sources: [adbc_glib_gir[0]])
 endif

--- a/glib/example/README.md
+++ b/glib/example/README.md
@@ -1,0 +1,32 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# ADBC GLib example
+
+There are example codes in this directory.
+
+C example codes exist in this directory. Language bindings example
+codes exists in sub directories. For example, Vala example codes exists
+in `vala/` sub directory.
+
+## C example codes
+
+Here are example codes in this directory:
+
+  * `sqlite.c`: It shows how to connect to a database using SQLite.

--- a/glib/example/README.md
+++ b/glib/example/README.md
@@ -22,11 +22,12 @@
 There are example codes in this directory.
 
 C example codes exist in this directory. Language bindings example
-codes exists in sub directories. For example, Vala example codes exists
-in `vala/` sub directory.
+codes exists in sub directories:
+
+  * `vala/`: Vala examples
 
 ## C example codes
 
 Here are example codes in this directory:
 
-  * `sqlite.c`: It shows how to connect to a database using SQLite.
+  * `sqlite.c`: It shows how to connect to a SQLite database.

--- a/glib/example/meson.build
+++ b/glib/example/meson.build
@@ -17,11 +17,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-arrow_glib = dependency('arrow-glib')
-
-executable('sqlite', 'sqlite.c',
-           dependencies: [adbc_glib, arrow_glib],
-           link_language: 'c')
+if build_example
+  arrow_glib = dependency('arrow-glib')
+  executable('sqlite', 'sqlite.c',
+             dependencies: [adbc_glib, arrow_glib],
+             link_language: 'c')
+endif
 
 install_data('README.md',
              install_dir: join_paths(data_dir, meson.project_name(), 'example'))

--- a/glib/example/meson.build
+++ b/glib/example/meson.build
@@ -17,12 +17,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option('adbc_build_dir',
-       type: 'string',
-       value: '',
-       description: 'Use this option to build with not installed ADBC')
+arrow_glib = dependency('arrow-glib')
 
-option('vapi',
-       type: 'boolean',
-       value: false,
-       description: 'Build Vala API')
+executable('sqlite', 'sqlite.c',
+           dependencies: [adbc_glib, arrow_glib],
+           link_language: 'c')
+
+install_data('README.md',
+             install_dir: join_paths(data_dir, meson.project_name(), 'example'))
+
+subdir('vala')

--- a/glib/example/meson.build
+++ b/glib/example/meson.build
@@ -24,7 +24,11 @@ if build_example
              link_language: 'c')
 endif
 
-install_data('README.md',
+files = [
+  'README.md',
+  'sqlite.c',
+]
+install_data(files,
              install_dir: join_paths(data_dir, meson.project_name(), 'example'))
 
 subdir('vala')

--- a/glib/example/sqlite.c
+++ b/glib/example/sqlite.c
@@ -23,7 +23,7 @@
 #include <arrow-glib/arrow-glib.h>
 
 int main(int argc, char** argv) {
-  int result = EXIT_FAILURE;
+  int exit_code = EXIT_FAILURE;
   GADBCDatabase* database = NULL;
   GADBCConnection* connection = NULL;
   GADBCStatement* statement = NULL;
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
   g_print("Result:\n%s\n", table_content);
   g_free(table_content);
 
-  result = EXIT_SUCCESS;
+  exit_code = EXIT_SUCCESS;
 
 exit:
   if (error) {
@@ -131,5 +131,5 @@ exit:
     }
     g_object_unref(database);
   }
-  return result;
+  return exit_code;
 }

--- a/glib/example/sqlite.c
+++ b/glib/example/sqlite.c
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdlib.h>
+
+#include <adbc-glib/adbc-glib.h>
+#include <arrow-glib/arrow-glib.h>
+
+int main(int argc, char** argv) {
+  GADBCDatabase* database;
+  GADBCConnection* conn;
+  GError* error = NULL;
+  database = gadbc_database_new(&error);
+  if (!database) {
+    g_print("Error creating a Database: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+
+  if (!gadbc_database_set_option(database, "driver", "adbc_driver_sqlite", &error)) {
+    g_print("Error initializing the database: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+  if (!gadbc_database_set_option(database, "uri", "test.db", &error)) {
+    g_print("Error initializing the database: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+  if (!gadbc_database_init(database, &error)) {
+    g_print("Error initializing the database: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+
+  conn = gadbc_connection_new(&error);
+  if (!conn) {
+    g_print("Error creating a Connection: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    g_object_unref(conn);
+    return EXIT_FAILURE;
+  }
+  if (!gadbc_connection_init(conn, database, &error)) {
+    g_print("Error initializing a Connection: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    g_object_unref(conn);
+    return EXIT_FAILURE;
+  }
+
+  GADBCStatement* statement = gadbc_statement_new(conn, &error);
+  if (!statement) {
+    g_print("Error initializing a statement: %s", error->message);
+    g_error_free(error);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+  if (!gadbc_statement_set_sql_query(statement, "select sqlite_version() as version",
+                                     &error)) {
+    g_print("Error setting a query: %s", error->message);
+    g_error_free(error);
+    g_object_unref(statement);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+
+  gpointer c_abi_array_stream;
+  gint64 n_rows_affected;
+  if (!gadbc_statement_execute(statement, TRUE, &c_abi_array_stream, &n_rows_affected,
+                               &error)) {
+    g_print("Error executing a query: %s", error->message);
+    g_error_free(error);
+    g_object_unref(statement);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+
+  GArrowRecordBatchReader* reader =
+      garrow_record_batch_reader_import(c_abi_array_stream, &error);
+  g_free(c_abi_array_stream);
+  if (!reader) {
+    g_print("Error importing a result: %s", error->message);
+    g_error_free(error);
+    g_object_unref(statement);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+
+  GArrowTable* table = garrow_record_batch_reader_read_all(reader, &error);
+  g_object_unref(reader);
+  if (!table) {
+    g_print("Error reading a result: %s", error->message);
+    g_error_free(error);
+    g_object_unref(statement);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+  gchar* table_content = garrow_table_to_string(table, &error);
+  g_object_unref(table);
+  if (!table_content) {
+    g_print("Error stringify a result: %s", error->message);
+    g_error_free(error);
+    g_object_unref(statement);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+  g_print("Result:\n%s\n", table_content);
+  g_free(table_content);
+  gadbc_statement_release(statement, &error);
+  if (error) {
+    g_print("Error releasing a statement: %s", error->message);
+    g_error_free(error);
+    error = NULL;
+  }
+  g_object_unref(statement);
+  g_object_unref(conn);
+  g_object_unref(database);
+
+  return EXIT_SUCCESS;
+}

--- a/glib/example/vala/README.md
+++ b/glib/example/vala/README.md
@@ -1,0 +1,36 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# ADBC GLib Vala example
+
+There are Vala example codes in this directory.
+
+## How to build
+
+Here is a command line to build an example in this directory:
+
+```console
+$ valac --pkg adbc-glib --pkg posix XXX.vala
+```
+
+## GLib Vala example codes
+
+Here are example codes in this directory:
+
+  * `sqlite.vala`: It shows how to connect to a SQLite database.

--- a/glib/example/vala/README.md
+++ b/glib/example/vala/README.md
@@ -26,10 +26,10 @@ There are Vala example codes in this directory.
 Here is a command line to build an example in this directory:
 
 ```console
-$ valac --pkg adbc-glib --pkg posix XXX.vala
+$ valac --pkg adbc-glib --pkg arrow-glib --pkg posix XXX.vala
 ```
 
-## GLib Vala example codes
+## Vala example codes
 
 Here are example codes in this directory:
 

--- a/glib/example/vala/meson.build
+++ b/glib/example/vala/meson.build
@@ -17,12 +17,27 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option('adbc_build_dir',
-       type: 'string',
-       value: '',
-       description: 'Use this option to build with not installed ADBC')
+if generate_vapi
+  vala_example_executable_kwargs = {
+    'c_args': [
+      '-I' + meson.build_root(),
+      '-I' + meson.source_root(),
+    ],
+    'dependencies': [
+      adbc_glib_vapi,
+      arrow_glib,
+      dependency('gobject-2.0'),
+    ],
+    'vala_args': [
+      '--pkg', 'posix',
+    ],
+  }
+  executable('sqlite', 'sqlite.vala',
+             kwargs: vala_example_executable_kwargs)
+endif
 
-option('vapi',
-       type: 'boolean',
-       value: false,
-       description: 'Build Vala API')
+install_data('README.md',
+             install_dir: join_paths(data_dir,
+                                     meson.project_name(),
+                                     'example',
+                                     'vala'))

--- a/glib/example/vala/meson.build
+++ b/glib/example/vala/meson.build
@@ -37,7 +37,11 @@ if build_example and generate_vapi
              kwargs: vala_example_executable_kwargs)
 endif
 
-install_data('README.md',
+files = [
+  'README.md',
+  'sqlite.vala',
+]
+install_data(files,
              install_dir: join_paths(data_dir,
                                      meson.project_name(),
                                      'example',

--- a/glib/example/vala/meson.build
+++ b/glib/example/vala/meson.build
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-if generate_vapi
+if build_example and generate_vapi
   vala_example_executable_kwargs = {
     'c_args': [
       '-I' + meson.build_root(),
@@ -30,6 +30,7 @@ if generate_vapi
     ],
     'vala_args': [
       '--pkg', 'posix',
+      '--vapidir', arrow_glib.get_variable('vapidir'),
     ],
   }
   executable('sqlite', 'sqlite.vala',

--- a/glib/example/vala/sqlite.vala
+++ b/glib/example/vala/sqlite.vala
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+int main (string[] args) {
+  try {
+    var database = new GADBC.Database ();
+    database.set_option ("driver", "adbc_driver_sqlite");
+    database.set_option ("uri", "test.sqlite");
+    database.init ();
+    GLib.message ("Database initialization done...");
+    try {
+      var conn = new GADBC.Connection ();
+      conn.init (database);
+      GLib.message ("Connection to database initialized...");
+      try {
+        var stm = new GADBC.Statement (conn);
+        string sql = "SELECT sqlite_version() AS version";
+        stm.set_sql_query (sql);
+        void *c_abi_array_stream = null;
+        stm.execute (true, out c_abi_array_stream, null);
+        try {
+            GLib.message ("Statement executed: %s", sql);
+            var reader = GArrow.RecordBatchReader.import (c_abi_array_stream);
+            var table = reader.read_all ();
+            GLib.message ("Executed result: %s", table.to_string ());
+        } finally {
+            GLib.free (c_abi_array_stream);
+        }
+      GLib.message ("Statement executed: %s", sql);
+      }
+      catch (GLib.Error e) {
+        GLib.message ("Error executing statement: %s", e.message);
+      }
+    }
+    catch (GLib.Error e) {
+      GLib.message ("Error initializing the connection: %s", e.message);
+    }
+  }
+  catch (GLib.Error e) {
+    GLib.message ("Error initializing the database: %s", e.message);
+  }
+
+  return Posix.EXIT_SUCCESS;
+}

--- a/glib/meson.build
+++ b/glib/meson.build
@@ -68,6 +68,8 @@ else
                                                 dirs: [adbc_build_dir])
 endif
 
+build_example = get_option('example')
+
 dependency('gobject-introspection-1.0', required: false).found()
 generate_vapi = get_option('vapi')
 if generate_vapi

--- a/glib/meson.build
+++ b/glib/meson.build
@@ -30,7 +30,7 @@ version_major = version_numbers[0].to_int()
 version_minor = version_numbers[1].to_int()
 version_micro = version_numbers[2].to_int()
 
-api_version = '@0@.0'.format(version_major)
+api_version = '1.0'
 so_version = version_major
 library_version = '.'.join(version_numbers)
 
@@ -39,6 +39,7 @@ include_dir = get_option('includedir')
 project_include_sub_dir = meson.project_name()
 data_dir = get_option('datadir')
 gir_dir = prefix / data_dir / 'gir-1.0'
+vapi_dir = data_dir / 'vala' / 'vapi'
 
 gnome = import('gnome')
 pkgconfig = import('pkgconfig')
@@ -67,7 +68,15 @@ else
                                                 dirs: [adbc_build_dir])
 endif
 
+dependency('gobject-introspection-1.0', required: false).found()
+generate_vapi = get_option('vapi')
+if generate_vapi
+  pkgconfig_variables += ['vapidir=@0@'.format(vapi_dir)]
+  add_languages('vala')
+endif
+
 subdir('adbc-glib')
+subdir('example')
 
 install_data('../LICENSE.txt',
              'README.md',

--- a/glib/meson_options.txt
+++ b/glib/meson_options.txt
@@ -22,6 +22,11 @@ option('adbc_build_dir',
        value: '',
        description: 'Use this option to build with not installed ADBC')
 
+option('example',
+       type: 'boolean',
+       value: false,
+       description: 'Build example')
+
 option('vapi',
        type: 'boolean',
        value: false,


### PR DESCRIPTION
Vala VAPI file is generated for current GADBC 1.0 API version.

It is disable by default, but recommended to be enable when a development package is distributed.

This commit force a 1.0 API versioning, replacing the old one where 0 were used for GIR API version (gir_version), so now shows '1.0' instead of '0.0'.