### PR TITLE
ci: add Python 3.12 wheels

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -675,7 +675,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.9", "3.10", "3.11"]
+        python_version: ["3.9", "3.10", "3.11", "3.12"]
     env:
       PYTHON_VERSION: "${{ matrix.python_version }}"
       # Where to install vcpkg
@@ -727,9 +727,11 @@ jobs:
           .\bootstrap-vcpkg.bat -disableMetrics
           popd
 
+      # Windows needs newer Go than 1.19
+      # https://github.com/golang/go/issues/51007
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.13
+          go-version: 1.20.8
           check-latest: true
           cache: true
           cache-dependency-path: adbc/go/adbc/go.sum


### PR DESCRIPTION
Linux/macOS use cibuildwheel so they already picked up 3.12.

Fixes #1116.