### PR TITLE
chore(ci): bump Go for Windows to 1.20.8

### DIFF
--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -98,7 +98,7 @@ jobs:
             --file ci/conda_env_cpp.txt
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.8
+          go-version: 1.19.13
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum
@@ -302,7 +302,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.8
+          go-version-file: 'go/adbc/go.mod'
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum
@@ -361,7 +361,7 @@ jobs:
             --file ci/conda_env_cpp.txt
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.8
+          go-version: 1.19.13
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum
@@ -441,7 +441,7 @@ jobs:
             --file ci/conda_env_python.txt
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20.8
+          go-version: 1.19.13
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum

--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -98,7 +98,7 @@ jobs:
             --file ci/conda_env_cpp.txt
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.13
+          go-version: 1.20.8
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum
@@ -302,7 +302,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v3
         with:
-          go-version-file: 'go/adbc/go.mod'
+          go-version: 1.20.8
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum
@@ -361,7 +361,7 @@ jobs:
             --file ci/conda_env_cpp.txt
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.13
+          go-version: 1.20.8
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum
@@ -441,7 +441,7 @@ jobs:
             --file ci/conda_env_python.txt
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.13
+          go-version: 1.20.8
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum

--- a/.github/workflows/native-windows.yml
+++ b/.github/workflows/native-windows.yml
@@ -238,7 +238,7 @@ jobs:
         env:
           CGO_ENABLED: "1"
         run: |
-          $env:PATH="$($env:RUNNER_TOOL_CACHE)\go\1.19.13\x64\bin;" + $env:PATH
+          $env:PATH="$($env:RUNNER_TOOL_CACHE)\go\1.20.8\x64\bin;" + $env:PATH
           .\ci\scripts\go_build.ps1 $pwd $pwd\build
       # TODO(apache/arrow#358): enable these tests on Windows
       # - name: Go Test
@@ -246,7 +246,7 @@ jobs:
       #   env:
       #     CGO_ENABLED: "1"
       #   run: |
-      #     $env:PATH="$($env:RUNNER_TOOL_CACHE)\go\1.19.13\x64\bin;" + $env:PATH
+      #     $env:PATH="$($env:RUNNER_TOOL_CACHE)\go\1.20.8\x64\bin;" + $env:PATH
       #     .\ci\scripts\go_test.ps1 $pwd $pwd\build
 
   # ------------------------------------------------------------

--- a/.github/workflows/native-windows.yml
+++ b/.github/workflows/native-windows.yml
@@ -223,7 +223,7 @@ jobs:
             --file ci/conda_env_cpp.txt
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19.13
+          go-version: 1.20.8
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum


### PR DESCRIPTION
Needed to avoid linker issues with cgo