### PR TITLE
fix(c/driver/postgresql): reset transaction after rollback

### DIFF
--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -629,7 +629,7 @@ AdbcStatusCode PostgresConnection::Commit(struct AdbcError* error) {
     return ADBC_STATUS_INVALID_STATE;
   }
 
-  PGresult* result = PQexec(conn_, "COMMIT");
+  PGresult* result = PQexec(conn_, "COMMIT; BEGIN TRANSACTION");
   if (PQresultStatus(result) != PGRES_COMMAND_OK) {
     AdbcStatusCode code = SetError(error, result, "%s%s",
                                    "[libpq] Failed to commit: ", PQerrorMessage(conn_));

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -332,6 +332,8 @@ class StatementTest {
   void TestSqlQueryFloats();
   void TestSqlQueryStrings();
 
+  void TestSqlQueryInsertRollback();
+
   void TestSqlQueryCancel();
   void TestSqlQueryErrors();
 
@@ -420,6 +422,7 @@ class StatementTest {
   TEST_F(FIXTURE, SqlQueryInts) { TestSqlQueryInts(); }                                 \
   TEST_F(FIXTURE, SqlQueryFloats) { TestSqlQueryFloats(); }                             \
   TEST_F(FIXTURE, SqlQueryStrings) { TestSqlQueryStrings(); }                           \
+  TEST_F(FIXTURE, SqlQueryInsertRollback) { TestSqlQueryInsertRollback(); }             \
   TEST_F(FIXTURE, SqlQueryCancel) { TestSqlQueryCancel(); }                             \
   TEST_F(FIXTURE, SqlQueryErrors) { TestSqlQueryErrors(); }                             \
   TEST_F(FIXTURE, SqlSchemaInts) { TestSqlSchemaInts(); }                               \

--- a/docs/source/python/recipe/postgresql_create_append_table.py
+++ b/docs/source/python/recipe/postgresql_create_append_table.py
@@ -68,6 +68,8 @@ with conn.cursor() as cur:
     else:
         raise RuntimeError("Should have failed!")
 
+conn.rollback()
+
 #: Instead, we can append to the table.
 with conn.cursor() as cur:
     cur.adbc_ingest("example", data, mode="append")

--- a/python/adbc_driver_postgresql/tests/test_dbapi.py
+++ b/python/adbc_driver_postgresql/tests/test_dbapi.py
@@ -118,11 +118,15 @@ def test_query_cancel(postgres: dbapi.Connection) -> None:
         with pytest.raises(postgres.OperationalError, match="canceling statement"):
             cur.fetchone()
 
+    postgres.rollback()
+
     with postgres.cursor() as cur:
         cur.execute("SELECT * FROM test_batch_size")
         cur.adbc_cancel()
         with pytest.raises(postgres.OperationalError, match="canceling statement"):
             cur.fetch_arrow_table()
+
+    postgres.rollback()
 
     with postgres.cursor() as cur:
         cur.execute("SELECT * FROM test_batch_size")


### PR DESCRIPTION
Fixes #1158.