### PR TITLE
fix(r/adbcdrivermanager): Use ADBC_VERSION_1_1_0 to initialize drivers internally

### DIFF
--- a/r/adbcdrivermanager/src/driver_log.c
+++ b/r/adbcdrivermanager/src/driver_log.c
@@ -287,7 +287,7 @@ static AdbcStatusCode LogStatementSetSqlQuery(struct AdbcStatement* statement,
 
 static AdbcStatusCode LogDriverInitFunc(int version, void* raw_driver,
                                         struct AdbcError* error) {
-  if (version != ADBC_VERSION_1_0_0) return ADBC_STATUS_NOT_IMPLEMENTED;
+  if (version != ADBC_VERSION_1_1_0) return ADBC_STATUS_NOT_IMPLEMENTED;
   struct AdbcDriver* driver = (struct AdbcDriver*)raw_driver;
   memset(driver, 0, sizeof(struct AdbcDriver));
 

--- a/r/adbcdrivermanager/src/driver_monkey.c
+++ b/r/adbcdrivermanager/src/driver_monkey.c
@@ -286,7 +286,7 @@ static AdbcStatusCode MonkeyStatementSetSqlQuery(struct AdbcStatement* statement
 
 static AdbcStatusCode MonkeyDriverInitFunc(int version, void* raw_driver,
                                            struct AdbcError* error) {
-  if (version != ADBC_VERSION_1_0_0) return ADBC_STATUS_NOT_IMPLEMENTED;
+  if (version != ADBC_VERSION_1_1_0) return ADBC_STATUS_NOT_IMPLEMENTED;
   struct AdbcDriver* driver = (struct AdbcDriver*)raw_driver;
   memset(driver, 0, sizeof(struct AdbcDriver));
 

--- a/r/adbcdrivermanager/src/driver_void.c
+++ b/r/adbcdrivermanager/src/driver_void.c
@@ -260,7 +260,7 @@ static AdbcStatusCode VoidStatementSetSqlQuery(struct AdbcStatement* statement,
 
 static AdbcStatusCode VoidDriverInitFunc(int version, void* raw_driver,
                                          struct AdbcError* error) {
-  if (version != ADBC_VERSION_1_0_0) return ADBC_STATUS_NOT_IMPLEMENTED;
+  if (version != ADBC_VERSION_1_1_0) return ADBC_STATUS_NOT_IMPLEMENTED;
   struct AdbcDriver* driver = (struct AdbcDriver*)raw_driver;
   memset(driver, 0, sizeof(struct AdbcDriver));
 

--- a/r/adbcdrivermanager/src/radbc.cc
+++ b/r/adbcdrivermanager/src/radbc.cc
@@ -86,11 +86,15 @@ extern "C" SEXP RAdbcLoadDriver(SEXP driver_name_sexp, SEXP entrypoint_sexp) {
   SEXP driver_xptr = PROTECT(adbc_allocate_xptr<AdbcDriver>());
   auto driver = adbc_from_xptr<AdbcDriver>(driver_xptr);
 
-  AdbcError error;
-  memset(&error, 0, sizeof(AdbcError));
   int status =
-      AdbcLoadDriver(driver_name, entrypoint, ADBC_VERSION_1_0_0, driver, &error);
-  adbc_error_stop(status, &error, "RAdbcLoadDriver()");
+      AdbcLoadDriver(driver_name, entrypoint, ADBC_VERSION_1_1_0, driver, nullptr);
+  if (status == ADBC_STATUS_NOT_IMPLEMENTED) {
+    status = AdbcLoadDriver(driver_name, entrypoint, ADBC_VERSION_1_0_0, driver, nullptr);
+  }
+
+  if (status != ADBC_STATUS_OK) {
+    Rf_error("Failed to initialize driver");
+  }
 
   UNPROTECT(1);
   return driver_xptr;
@@ -107,11 +111,16 @@ extern "C" SEXP RAdbcLoadDriverFromInitFunc(SEXP driver_init_func_xptr) {
   R_RegisterCFinalizer(driver_xptr, &finalize_driver_xptr);
   auto driver = adbc_from_xptr<AdbcDriver>(driver_xptr);
 
-  AdbcError error;
-  memset(&error, 0, sizeof(AdbcError));
   int status =
-      AdbcLoadDriverFromInitFunc(driver_init_func, ADBC_VERSION_1_0_0, driver, &error);
-  adbc_error_stop(status, &error, "RAdbcLoadDriverFromInitFunc()");
+      AdbcLoadDriverFromInitFunc(driver_init_func, ADBC_VERSION_1_1_0, driver, nullptr);
+  if (status == ADBC_STATUS_NOT_IMPLEMENTED) {
+    status =
+        AdbcLoadDriverFromInitFunc(driver_init_func, ADBC_VERSION_1_0_0, driver, nullptr);
+  }
+
+  if (status != ADBC_STATUS_OK) {
+    Rf_error("Failed to initialize driver");
+  }
 
   UNPROTECT(1);
   return driver_xptr;


### PR DESCRIPTION
The existing code should have worked (and probably still did), but I'd like to eliminate any complexity arising from managing multiple driver versions for the purposes of eliminating potential causes of #1161.