### PR TITLE
fix(c/driver/postgresql): Support trailing semicolon(s) for queries inside COPY statements

### DIFF
--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -1070,7 +1070,6 @@ AdbcStatusCode PostgresStatement::ExecuteQuery(struct ArrowArrayStream* stream,
   // 2. Execute the query with COPY to get binary tuples
   {
     std::string copy_query = "COPY (" + query_ + ") TO STDOUT (FORMAT binary)";
-
     reader_.result_ =
         PQexecParams(connection_->conn(), copy_query.c_str(), /*nParams=*/0,
                      /*paramTypes=*/nullptr, /*paramValues=*/nullptr,

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -1064,7 +1064,12 @@ AdbcStatusCode PostgresStatement::ExecuteQuery(struct ArrowArrayStream* stream,
 
   // 2. Execute the query with COPY to get binary tuples
   {
+    // Remove trailing semicolon(s) from the query before feeding it into COPY
+    while (!query_.empty() && query_.back() == ';') {
+      query_.pop_back();
+    }
     std::string copy_query = "COPY (" + query_ + ") TO STDOUT (FORMAT binary)";
+
     reader_.result_ =
         PQexecParams(connection_->conn(), copy_query.c_str(), /*nParams=*/0,
                      /*paramTypes=*/nullptr, /*paramValues=*/nullptr,

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -3410,6 +3410,21 @@ void StatementTest::TestSqlQueryErrors() {
   ASSERT_NE(ADBC_STATUS_OK, code);
 }
 
+void StatementTest::TestSqlQueryTrailingSemicolons() {
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT current_date;;;", &error),
+              IsOkStatus(&error));
+
+  {
+    StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+  }
+
+  ASSERT_THAT(AdbcStatementRelease(&statement, &error), IsOkStatus(&error));
+}
+
 void StatementTest::TestTransactions() {
   if (!quirks()->supports_transactions() || quirks()->ddl_implicit_commit_txn()) {
     GTEST_SKIP();

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -364,6 +364,7 @@ class StatementTest {
 
   void TestSqlQueryCancel();
   void TestSqlQueryErrors();
+  void TestSqlQueryTrailingSemicolons();
 
   void TestSqlSchemaInts();
   void TestSqlSchemaFloats();
@@ -453,6 +454,7 @@ class StatementTest {
   TEST_F(FIXTURE, SqlQueryInsertRollback) { TestSqlQueryInsertRollback(); }             \
   TEST_F(FIXTURE, SqlQueryCancel) { TestSqlQueryCancel(); }                             \
   TEST_F(FIXTURE, SqlQueryErrors) { TestSqlQueryErrors(); }                             \
+  TEST_F(FIXTURE, SqlQueryTrailingSemicolons) { TestSqlQueryTrailingSemicolons(); }     \
   TEST_F(FIXTURE, SqlSchemaInts) { TestSqlSchemaInts(); }                               \
   TEST_F(FIXTURE, SqlSchemaFloats) { TestSqlSchemaFloats(); }                           \
   TEST_F(FIXTURE, SqlSchemaStrings) { TestSqlSchemaStrings(); }                         \


### PR DESCRIPTION
Fixes #1147 

