### PR TITLE
ci: use pytest-error-for-skips for integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -128,6 +128,7 @@ jobs:
           mamba install -c conda-forge \
             --file ci/conda_env_cpp.txt \
             --file ci/conda_env_python.txt
+          pip install pytest-error-for-skips
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19.13
@@ -176,6 +177,7 @@ jobs:
           ADBC_DREMIO_FLIGHTSQL_USER: "dremio"
           ADBC_DREMIO_FLIGHTSQL_PASS: "dremio123"
           ADBC_TEST_FLIGHTSQL_URI: "grpc+tcp://localhost:41414"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           ./ci/scripts/python_test.sh "$(pwd)" "$(pwd)/build"
       - name: Stop SQLite server and Dremio
@@ -213,6 +215,7 @@ jobs:
           mamba install -c conda-forge \
             --file ci/conda_env_cpp.txt \
             --file ci/conda_env_python.txt
+          pip install pytest-error-for-skips
       - name: Build PostgreSQL Driver
         shell: bash -l {0}
         env:
@@ -237,6 +240,7 @@ jobs:
           ADBC_USE_ASAN: "ON"
           ADBC_USE_UBSAN: "ON"
           ADBC_POSTGRESQL_TEST_URI: "postgresql://localhost:5432/postgres?user=postgres&password=password"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           env POSTGRES_VERSION=11 docker compose up --wait --detach postgres-test
           ./ci/scripts/cpp_test.sh "$(pwd)/build"
@@ -250,6 +254,7 @@ jobs:
           ADBC_USE_ASAN: "ON"
           ADBC_USE_UBSAN: "ON"
           ADBC_POSTGRESQL_TEST_URI: "postgresql://localhost:5432/postgres?user=postgres&password=password"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           env POSTGRES_VERSION=12 docker compose up --wait --detach postgres-test
           ./ci/scripts/cpp_test.sh "$(pwd)/build"
@@ -263,6 +268,7 @@ jobs:
           ADBC_USE_ASAN: "ON"
           ADBC_USE_UBSAN: "ON"
           ADBC_POSTGRESQL_TEST_URI: "postgresql://localhost:5432/postgres?user=postgres&password=password"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           env POSTGRES_VERSION=13 docker compose up --wait --detach postgres-test
           ./ci/scripts/cpp_test.sh "$(pwd)/build"
@@ -276,6 +282,7 @@ jobs:
           ADBC_USE_ASAN: "ON"
           ADBC_USE_UBSAN: "ON"
           ADBC_POSTGRESQL_TEST_URI: "postgresql://localhost:5432/postgres?user=postgres&password=password"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           env POSTGRES_VERSION=14 docker compose up --wait --detach postgres-test
           ./ci/scripts/cpp_test.sh "$(pwd)/build"
@@ -289,6 +296,7 @@ jobs:
           ADBC_USE_ASAN: "ON"
           ADBC_USE_UBSAN: "ON"
           ADBC_POSTGRESQL_TEST_URI: "postgresql://localhost:5432/postgres?user=postgres&password=password"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           env POSTGRES_VERSION=15 docker compose up --wait --detach postgres-test
           ./ci/scripts/cpp_test.sh "$(pwd)/build"
@@ -325,6 +333,7 @@ jobs:
           mamba install -c conda-forge \
             --file ci/conda_env_cpp.txt \
             --file ci/conda_env_python.txt
+          pip install pytest-error-for-skips
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19.13
@@ -347,6 +356,7 @@ jobs:
           BUILD_DRIVER_MANAGER: "1"
           BUILD_DRIVER_SNOWFLAKE: "1"
           ADBC_SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           ./ci/scripts/python_build.sh "$(pwd)" "$(pwd)/build"
           env BUILD_DRIVER_MANAGER=0 ./ci/scripts/python_test.sh "$(pwd)" "$(pwd)/build"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -333,7 +333,6 @@ jobs:
           mamba install -c conda-forge \
             --file ci/conda_env_cpp.txt \
             --file ci/conda_env_python.txt
-          pip install pytest-error-for-skips
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19.13
@@ -356,7 +355,6 @@ jobs:
           BUILD_DRIVER_MANAGER: "1"
           BUILD_DRIVER_SNOWFLAKE: "1"
           ADBC_SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
-          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           ./ci/scripts/python_build.sh "$(pwd)" "$(pwd)/build"
           env BUILD_DRIVER_MANAGER=0 ./ci/scripts/python_test.sh "$(pwd)" "$(pwd)/build"


### PR DESCRIPTION
Fixes #999.