### PR TITLE
fix(c/driver/sqlite): Provide # of rows affected for non-SELECT statements instead of 0

### DIFF
--- a/c/driver/flightsql/dremio_flightsql_test.cc
+++ b/c/driver/flightsql/dremio_flightsql_test.cc
@@ -92,6 +92,12 @@ class DremioFlightSqlStatementTest : public ::testing::Test,
   void TestSqlIngestColumnEscaping() {
     GTEST_SKIP() << "Column escaping not implemented";
   }
+  void TestSqlQueryRowsAffectedDelete() {
+    GTEST_SKIP() << "Cannot query rows affected in delete (not implemented)";
+  }
+  void TestSqlQueryRowsAffectedDeleteStream() {
+    GTEST_SKIP() << "Cannot query rows affected in delete stream (not implemented)";
+  }
 
  protected:
   DremioFlightSqlQuirks quirks_;

--- a/c/driver/flightsql/sqlite_flightsql_test.cc
+++ b/c/driver/flightsql/sqlite_flightsql_test.cc
@@ -274,6 +274,12 @@ class SqliteFlightSqlStatementTest : public ::testing::Test,
   void TestSqlIngestInterval() {
     GTEST_SKIP() << "Cannot ingest Interval (not implemented)";
   }
+  void TestSqlQueryRowsAffectedDelete() {
+    GTEST_SKIP() << "Cannot query rows affected in delete (not implemented)";
+  }
+  void TestSqlQueryRowsAffectedDeleteStream() {
+    GTEST_SKIP() << "Cannot query rows affected in delete stream (not implemented)";
+  }
 
  protected:
   SqliteFlightSqlQuirks quirks_;

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -816,6 +816,12 @@ class PostgresStatementTest : public ::testing::Test,
   void TestSqlPrepareErrorParamCountMismatch() { GTEST_SKIP() << "Not yet implemented"; }
   void TestSqlPrepareGetParameterSchema() { GTEST_SKIP() << "Not yet implemented"; }
   void TestSqlPrepareSelectParams() { GTEST_SKIP() << "Not yet implemented"; }
+  void TestSqlQueryRowsAffectedDelete() {
+    GTEST_SKIP() << "Cannot query rows affected in delete (not implemented)";
+  }
+  void TestSqlQueryRowsAffectedDeleteStream() {
+    GTEST_SKIP() << "Cannot query rows affected in delete stream (not implemented)";
+  }
 
   void TestConcurrentStatements() {
     // TODO: refactor driver so that we read all the data as soon as

--- a/c/driver/sqlite/sqlite.c
+++ b/c/driver/sqlite/sqlite.c
@@ -1364,7 +1364,13 @@ AdbcStatusCode SqliteStatementExecuteQuery(struct AdbcStatement* statement,
     sqlite3_mutex_leave(sqlite3_db_mutex(stmt->conn));
 
     AdbcSqliteBinderRelease(&stmt->binder);
-    if (rows_affected) *rows_affected = rows;
+    if (rows_affected) {
+      if (sqlite3_column_count(stmt->stmt) == 0) {
+        *rows_affected = sqlite3_changes(stmt->conn);
+      } else {
+        *rows_affected = rows;
+      }
+    }
     return status;
   }
 

--- a/c/integration/duckdb/duckdb_test.cc
+++ b/c/integration/duckdb/duckdb_test.cc
@@ -101,6 +101,12 @@ class DuckDbStatementTest : public ::testing::Test,
   }
 
   void TestSqlQueryErrors() { GTEST_SKIP() << "DuckDB does not set AdbcError.release"; }
+  void TestSqlQueryRowsAffectedDelete() {
+    GTEST_SKIP() << "Cannot query rows affected in delete (not implemented)";
+  }
+  void TestSqlQueryRowsAffectedDeleteStream() {
+    GTEST_SKIP() << "Cannot query rows affected in delete stream (not implemented)";
+  }
 
   void TestErrorCompatibility() {
     GTEST_SKIP() << "DuckDB does not set AdbcError.release";

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -3446,7 +3446,7 @@ void StatementTest::TestSqlQueryRowsAffectedDelete() {
               IsOkStatus(&error));
 
   ASSERT_THAT(AdbcStatementSetSqlQuery(&statement,
-                                       "INSERT INTO delete_test (foo) VALUES (1), (2), (3), (4), (5)", &error),
+              "INSERT INTO delete_test (foo) VALUES (1), (2), (3), (4), (5)", &error),
               IsOkStatus(&error));
   ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
               IsOkStatus(&error));
@@ -3473,7 +3473,7 @@ void StatementTest::TestSqlQueryRowsAffectedDeleteStream() {
               IsOkStatus(&error));
 
   ASSERT_THAT(AdbcStatementSetSqlQuery(&statement,
-                                       "INSERT INTO delete_test (foo) VALUES (1), (2), (3), (4), (5)", &error),
+              "INSERT INTO delete_test (foo) VALUES (1), (2), (3), (4), (5)", &error),
               IsOkStatus(&error));
   ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
               IsOkStatus(&error));

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -3458,7 +3458,8 @@ void StatementTest::TestSqlQueryRowsAffectedDelete() {
   int64_t rows_affected = 0;
   ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, &rows_affected, &error),
               IsOkStatus(&error));
-  ASSERT_EQ(3, rows_affected);
+  ASSERT_THAT(rows_affected,
+              ::testing::AnyOf(::testing::Eq(3), ::testing::Eq(-1)));
 }
 
 void StatementTest::TestSqlQueryRowsAffectedDeleteStream() {
@@ -3486,7 +3487,8 @@ void StatementTest::TestSqlQueryRowsAffectedDeleteStream() {
   ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
                                         &reader.rows_affected, &error),
               IsOkStatus(&error));
-  ASSERT_EQ(-1, reader.rows_affected);
+  ASSERT_THAT(reader.rows_affected,
+              ::testing::AnyOf(::testing::Eq(5), ::testing::Eq(-1)));
 }
 
 

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -365,6 +365,8 @@ class StatementTest {
   void TestSqlQueryCancel();
   void TestSqlQueryErrors();
   void TestSqlQueryTrailingSemicolons();
+  void TestSqlQueryRowsAffectedDelete();
+  void TestSqlQueryRowsAffectedDeleteStream();
 
   void TestSqlSchemaInts();
   void TestSqlSchemaFloats();
@@ -398,70 +400,70 @@ class StatementTest {
                                             const char* timezone);
 };
 
-#define ADBCV_TEST_STATEMENT(FIXTURE)                                                   \
-  static_assert(std::is_base_of<adbc_validation::StatementTest, FIXTURE>::value,        \
-                ADBCV_STRINGIFY(FIXTURE) " must inherit from StatementTest");           \
-  TEST_F(FIXTURE, NewInit) { TestNewInit(); }                                           \
-  TEST_F(FIXTURE, Release) { TestRelease(); }                                           \
-  TEST_F(FIXTURE, SqlIngestBool) { TestSqlIngestBool(); }                               \
-  TEST_F(FIXTURE, SqlIngestInt8) { TestSqlIngestInt8(); }                               \
-  TEST_F(FIXTURE, SqlIngestInt16) { TestSqlIngestInt16(); }                             \
-  TEST_F(FIXTURE, SqlIngestInt32) { TestSqlIngestInt32(); }                             \
-  TEST_F(FIXTURE, SqlIngestInt64) { TestSqlIngestInt64(); }                             \
-  TEST_F(FIXTURE, SqlIngestUInt8) { TestSqlIngestUInt8(); }                             \
-  TEST_F(FIXTURE, SqlIngestUInt16) { TestSqlIngestUInt16(); }                           \
-  TEST_F(FIXTURE, SqlIngestUInt32) { TestSqlIngestUInt32(); }                           \
-  TEST_F(FIXTURE, SqlIngestUInt64) { TestSqlIngestUInt64(); }                           \
-  TEST_F(FIXTURE, SqlIngestFloat32) { TestSqlIngestFloat32(); }                         \
-  TEST_F(FIXTURE, SqlIngestFloat64) { TestSqlIngestFloat64(); }                         \
-  TEST_F(FIXTURE, SqlIngestString) { TestSqlIngestString(); }                           \
-  TEST_F(FIXTURE, SqlIngestLargeString) { TestSqlIngestLargeString(); }                 \
-  TEST_F(FIXTURE, SqlIngestBinary) { TestSqlIngestBinary(); }                           \
-  TEST_F(FIXTURE, SqlIngestDuration) { TestSqlIngestDuration(); }                       \
-  TEST_F(FIXTURE, SqlIngestDate32) { TestSqlIngestDate32(); }                           \
-  TEST_F(FIXTURE, SqlIngestTimestamp) { TestSqlIngestTimestamp(); }                     \
-  TEST_F(FIXTURE, SqlIngestTimestampTz) { TestSqlIngestTimestampTz(); }                 \
-  TEST_F(FIXTURE, SqlIngestInterval) { TestSqlIngestInterval(); }                       \
-  TEST_F(FIXTURE, SqlIngestTableEscaping) { TestSqlIngestTableEscaping(); }             \
-  TEST_F(FIXTURE, SqlIngestColumnEscaping) { TestSqlIngestColumnEscaping(); }           \
-  TEST_F(FIXTURE, SqlIngestAppend) { TestSqlIngestAppend(); }                           \
-  TEST_F(FIXTURE, SqlIngestReplace) { TestSqlIngestReplace(); }                         \
-  TEST_F(FIXTURE, SqlIngestCreateAppend) { TestSqlIngestCreateAppend(); }               \
-  TEST_F(FIXTURE, SqlIngestErrors) { TestSqlIngestErrors(); }                           \
-  TEST_F(FIXTURE, SqlIngestMultipleConnections) { TestSqlIngestMultipleConnections(); } \
-  TEST_F(FIXTURE, SqlIngestSample) { TestSqlIngestSample(); }                           \
-  TEST_F(FIXTURE, SqlIngestTargetCatalog) { TestSqlIngestTargetCatalog(); }             \
-  TEST_F(FIXTURE, SqlIngestTargetSchema) { TestSqlIngestTargetSchema(); }               \
-  TEST_F(FIXTURE, SqlIngestTargetCatalogSchema) { TestSqlIngestTargetCatalogSchema(); } \
-  TEST_F(FIXTURE, SqlIngestTemporary) { TestSqlIngestTemporary(); }                     \
-  TEST_F(FIXTURE, SqlIngestTemporaryAppend) { TestSqlIngestTemporaryAppend(); }         \
-  TEST_F(FIXTURE, SqlIngestTemporaryReplace) { TestSqlIngestTemporaryReplace(); }       \
-  TEST_F(FIXTURE, SqlIngestTemporaryExclusive) { TestSqlIngestTemporaryExclusive(); }   \
-  TEST_F(FIXTURE, SqlPartitionedInts) { TestSqlPartitionedInts(); }                     \
-  TEST_F(FIXTURE, SqlPrepareGetParameterSchema) { TestSqlPrepareGetParameterSchema(); } \
-  TEST_F(FIXTURE, SqlPrepareSelectNoParams) { TestSqlPrepareSelectNoParams(); }         \
-  TEST_F(FIXTURE, SqlPrepareSelectParams) { TestSqlPrepareSelectParams(); }             \
-  TEST_F(FIXTURE, SqlPrepareUpdate) { TestSqlPrepareUpdate(); }                         \
-  TEST_F(FIXTURE, SqlPrepareUpdateNoParams) { TestSqlPrepareUpdateNoParams(); }         \
-  TEST_F(FIXTURE, SqlPrepareUpdateStream) { TestSqlPrepareUpdateStream(); }             \
-  TEST_F(FIXTURE, SqlPrepareErrorNoQuery) { TestSqlPrepareErrorNoQuery(); }             \
-  TEST_F(FIXTURE, SqlPrepareErrorParamCountMismatch) {                                  \
-    TestSqlPrepareErrorParamCountMismatch();                                            \
-  }                                                                                     \
-  TEST_F(FIXTURE, SqlQueryInts) { TestSqlQueryInts(); }                                 \
-  TEST_F(FIXTURE, SqlQueryFloats) { TestSqlQueryFloats(); }                             \
-  TEST_F(FIXTURE, SqlQueryStrings) { TestSqlQueryStrings(); }                           \
-  TEST_F(FIXTURE, SqlQueryInsertRollback) { TestSqlQueryInsertRollback(); }             \
-  TEST_F(FIXTURE, SqlQueryCancel) { TestSqlQueryCancel(); }                             \
-  TEST_F(FIXTURE, SqlQueryErrors) { TestSqlQueryErrors(); }                             \
-  TEST_F(FIXTURE, SqlQueryTrailingSemicolons) { TestSqlQueryTrailingSemicolons(); }     \
-  TEST_F(FIXTURE, SqlSchemaInts) { TestSqlSchemaInts(); }                               \
-  TEST_F(FIXTURE, SqlSchemaFloats) { TestSqlSchemaFloats(); }                           \
-  TEST_F(FIXTURE, SqlSchemaStrings) { TestSqlSchemaStrings(); }                         \
-  TEST_F(FIXTURE, SqlSchemaErrors) { TestSqlSchemaErrors(); }                           \
-  TEST_F(FIXTURE, Transactions) { TestTransactions(); }                                 \
-  TEST_F(FIXTURE, ConcurrentStatements) { TestConcurrentStatements(); }                 \
-  TEST_F(FIXTURE, ErrorCompatibility) { TestErrorCompatibility(); }                     \
+#define ADBCV_TEST_STATEMENT(FIXTURE)                                                               \
+  static_assert(std::is_base_of<adbc_validation::StatementTest, FIXTURE>::value,                    \
+                ADBCV_STRINGIFY(FIXTURE) " must inherit from StatementTest");                       \
+  TEST_F(FIXTURE, NewInit) { TestNewInit(); }                                                       \
+  TEST_F(FIXTURE, Release) { TestRelease(); }                                                       \
+  TEST_F(FIXTURE, SqlIngestBool) { TestSqlIngestBool(); }                                           \
+  TEST_F(FIXTURE, SqlIngestInt8) { TestSqlIngestInt8(); }                                           \
+  TEST_F(FIXTURE, SqlIngestInt16) { TestSqlIngestInt16(); }                                         \
+  TEST_F(FIXTURE, SqlIngestInt32) { TestSqlIngestInt32(); }                                         \
+  TEST_F(FIXTURE, SqlIngestInt64) { TestSqlIngestInt64(); }                                         \
+  TEST_F(FIXTURE, SqlIngestUInt8) { TestSqlIngestUInt8(); }                                         \
+  TEST_F(FIXTURE, SqlIngestUInt16) { TestSqlIngestUInt16(); }                                       \
+  TEST_F(FIXTURE, SqlIngestUInt32) { TestSqlIngestUInt32(); }                                       \
+  TEST_F(FIXTURE, SqlIngestUInt64) { TestSqlIngestUInt64(); }                                       \
+  TEST_F(FIXTURE, SqlIngestFloat32) { TestSqlIngestFloat32(); }                                     \
+  TEST_F(FIXTURE, SqlIngestFloat64) { TestSqlIngestFloat64(); }                                     \
+  TEST_F(FIXTURE, SqlIngestString) { TestSqlIngestString(); }                                       \
+  TEST_F(FIXTURE, SqlIngestLargeString) { TestSqlIngestLargeString(); }                             \
+  TEST_F(FIXTURE, SqlIngestBinary) { TestSqlIngestBinary(); }                                       \
+  TEST_F(FIXTURE, SqlIngestDuration) { TestSqlIngestDuration(); }                                   \
+  TEST_F(FIXTURE, SqlIngestDate32) { TestSqlIngestDate32(); }                                       \
+  TEST_F(FIXTURE, SqlIngestTimestamp) { TestSqlIngestTimestamp(); }                                 \
+  TEST_F(FIXTURE, SqlIngestTimestampTz) { TestSqlIngestTimestampTz(); }                             \
+  TEST_F(FIXTURE, SqlIngestInterval) { TestSqlIngestInterval(); }                                   \
+  TEST_F(FIXTURE, SqlIngestTableEscaping) { TestSqlIngestTableEscaping(); }                         \
+  TEST_F(FIXTURE, SqlIngestColumnEscaping) { TestSqlIngestColumnEscaping(); }                       \
+  TEST_F(FIXTURE, SqlIngestAppend) { TestSqlIngestAppend(); }                                       \
+  TEST_F(FIXTURE, SqlIngestReplace) { TestSqlIngestReplace(); }                                     \
+  TEST_F(FIXTURE, SqlIngestCreateAppend) { TestSqlIngestCreateAppend(); }                           \
+  TEST_F(FIXTURE, SqlIngestErrors) { TestSqlIngestErrors(); }                                       \
+  TEST_F(FIXTURE, SqlIngestMultipleConnections) { TestSqlIngestMultipleConnections(); }             \
+  TEST_F(FIXTURE, SqlIngestSample) { TestSqlIngestSample(); }                                       \
+  TEST_F(FIXTURE, SqlIngestTargetCatalog) { TestSqlIngestTargetCatalog(); }                         \
+  TEST_F(FIXTURE, SqlIngestTargetSchema) { TestSqlIngestTargetSchema(); }                           \
+  TEST_F(FIXTURE, SqlIngestTargetCatalogSchema) { TestSqlIngestTargetCatalogSchema(); }             \
+  TEST_F(FIXTURE, SqlIngestTemporary) { TestSqlIngestTemporary(); }                                 \
+  TEST_F(FIXTURE, SqlIngestTemporaryAppend) { TestSqlIngestTemporaryAppend(); }                     \
+  TEST_F(FIXTURE, SqlIngestTemporaryReplace) { TestSqlIngestTemporaryReplace(); }                   \
+  TEST_F(FIXTURE, SqlIngestTemporaryExclusive) { TestSqlIngestTemporaryExclusive(); }               \
+  TEST_F(FIXTURE, SqlPartitionedInts) { TestSqlPartitionedInts(); }                                 \
+  TEST_F(FIXTURE, SqlPrepareGetParameterSchema) { TestSqlPrepareGetParameterSchema(); }             \
+  TEST_F(FIXTURE, SqlPrepareSelectNoParams) { TestSqlPrepareSelectNoParams(); }                     \
+  TEST_F(FIXTURE, SqlPrepareSelectParams) { TestSqlPrepareSelectParams(); }                         \
+  TEST_F(FIXTURE, SqlPrepareUpdate) { TestSqlPrepareUpdate(); }                                     \
+  TEST_F(FIXTURE, SqlPrepareUpdateNoParams) { TestSqlPrepareUpdateNoParams(); }                     \
+  TEST_F(FIXTURE, SqlPrepareUpdateStream) { TestSqlPrepareUpdateStream(); }                         \
+  TEST_F(FIXTURE, SqlPrepareErrorNoQuery) { TestSqlPrepareErrorNoQuery(); }                         \
+  TEST_F(FIXTURE, SqlPrepareErrorParamCountMismatch) { TestSqlPrepareErrorParamCountMismatch(); }   \
+  TEST_F(FIXTURE, SqlQueryInts) { TestSqlQueryInts(); }                                             \
+  TEST_F(FIXTURE, SqlQueryFloats) { TestSqlQueryFloats(); }                                         \
+  TEST_F(FIXTURE, SqlQueryStrings) { TestSqlQueryStrings(); }                                       \
+  TEST_F(FIXTURE, SqlQueryInsertRollback) { TestSqlQueryInsertRollback(); }                         \
+  TEST_F(FIXTURE, SqlQueryCancel) { TestSqlQueryCancel(); }                                         \
+  TEST_F(FIXTURE, SqlQueryErrors) { TestSqlQueryErrors(); }                                         \
+  TEST_F(FIXTURE, SqlQueryTrailingSemicolons) { TestSqlQueryTrailingSemicolons(); }                 \
+  TEST_F(FIXTURE, SqlQueryRowsAffectedDelete) { TestSqlQueryRowsAffectedDelete(); }                 \
+  TEST_F(FIXTURE, SqlQueryRowsAffectedDeleteStream) { TestSqlQueryRowsAffectedDeleteStream(); }     \
+  TEST_F(FIXTURE, SqlSchemaInts) { TestSqlSchemaInts(); }                                           \
+  TEST_F(FIXTURE, SqlSchemaFloats) { TestSqlSchemaFloats(); }                                       \
+  TEST_F(FIXTURE, SqlSchemaStrings) { TestSqlSchemaStrings(); }                                     \
+  TEST_F(FIXTURE, SqlSchemaErrors) { TestSqlSchemaErrors(); }                                       \
+  TEST_F(FIXTURE, Transactions) { TestTransactions(); }                                             \
+  TEST_F(FIXTURE, ConcurrentStatements) { TestConcurrentStatements(); }                             \
+  TEST_F(FIXTURE, ErrorCompatibility) { TestErrorCompatibility(); }                                 \
   TEST_F(FIXTURE, ResultInvalidation) { TestResultInvalidation(); }
 
 }  // namespace adbc_validation

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -400,70 +400,74 @@ class StatementTest {
                                             const char* timezone);
 };
 
-#define ADBCV_TEST_STATEMENT(FIXTURE)                                                               \
-  static_assert(std::is_base_of<adbc_validation::StatementTest, FIXTURE>::value,                    \
-                ADBCV_STRINGIFY(FIXTURE) " must inherit from StatementTest");                       \
-  TEST_F(FIXTURE, NewInit) { TestNewInit(); }                                                       \
-  TEST_F(FIXTURE, Release) { TestRelease(); }                                                       \
-  TEST_F(FIXTURE, SqlIngestBool) { TestSqlIngestBool(); }                                           \
-  TEST_F(FIXTURE, SqlIngestInt8) { TestSqlIngestInt8(); }                                           \
-  TEST_F(FIXTURE, SqlIngestInt16) { TestSqlIngestInt16(); }                                         \
-  TEST_F(FIXTURE, SqlIngestInt32) { TestSqlIngestInt32(); }                                         \
-  TEST_F(FIXTURE, SqlIngestInt64) { TestSqlIngestInt64(); }                                         \
-  TEST_F(FIXTURE, SqlIngestUInt8) { TestSqlIngestUInt8(); }                                         \
-  TEST_F(FIXTURE, SqlIngestUInt16) { TestSqlIngestUInt16(); }                                       \
-  TEST_F(FIXTURE, SqlIngestUInt32) { TestSqlIngestUInt32(); }                                       \
-  TEST_F(FIXTURE, SqlIngestUInt64) { TestSqlIngestUInt64(); }                                       \
-  TEST_F(FIXTURE, SqlIngestFloat32) { TestSqlIngestFloat32(); }                                     \
-  TEST_F(FIXTURE, SqlIngestFloat64) { TestSqlIngestFloat64(); }                                     \
-  TEST_F(FIXTURE, SqlIngestString) { TestSqlIngestString(); }                                       \
-  TEST_F(FIXTURE, SqlIngestLargeString) { TestSqlIngestLargeString(); }                             \
-  TEST_F(FIXTURE, SqlIngestBinary) { TestSqlIngestBinary(); }                                       \
-  TEST_F(FIXTURE, SqlIngestDuration) { TestSqlIngestDuration(); }                                   \
-  TEST_F(FIXTURE, SqlIngestDate32) { TestSqlIngestDate32(); }                                       \
-  TEST_F(FIXTURE, SqlIngestTimestamp) { TestSqlIngestTimestamp(); }                                 \
-  TEST_F(FIXTURE, SqlIngestTimestampTz) { TestSqlIngestTimestampTz(); }                             \
-  TEST_F(FIXTURE, SqlIngestInterval) { TestSqlIngestInterval(); }                                   \
-  TEST_F(FIXTURE, SqlIngestTableEscaping) { TestSqlIngestTableEscaping(); }                         \
-  TEST_F(FIXTURE, SqlIngestColumnEscaping) { TestSqlIngestColumnEscaping(); }                       \
-  TEST_F(FIXTURE, SqlIngestAppend) { TestSqlIngestAppend(); }                                       \
-  TEST_F(FIXTURE, SqlIngestReplace) { TestSqlIngestReplace(); }                                     \
-  TEST_F(FIXTURE, SqlIngestCreateAppend) { TestSqlIngestCreateAppend(); }                           \
-  TEST_F(FIXTURE, SqlIngestErrors) { TestSqlIngestErrors(); }                                       \
-  TEST_F(FIXTURE, SqlIngestMultipleConnections) { TestSqlIngestMultipleConnections(); }             \
-  TEST_F(FIXTURE, SqlIngestSample) { TestSqlIngestSample(); }                                       \
-  TEST_F(FIXTURE, SqlIngestTargetCatalog) { TestSqlIngestTargetCatalog(); }                         \
-  TEST_F(FIXTURE, SqlIngestTargetSchema) { TestSqlIngestTargetSchema(); }                           \
-  TEST_F(FIXTURE, SqlIngestTargetCatalogSchema) { TestSqlIngestTargetCatalogSchema(); }             \
-  TEST_F(FIXTURE, SqlIngestTemporary) { TestSqlIngestTemporary(); }                                 \
-  TEST_F(FIXTURE, SqlIngestTemporaryAppend) { TestSqlIngestTemporaryAppend(); }                     \
-  TEST_F(FIXTURE, SqlIngestTemporaryReplace) { TestSqlIngestTemporaryReplace(); }                   \
-  TEST_F(FIXTURE, SqlIngestTemporaryExclusive) { TestSqlIngestTemporaryExclusive(); }               \
-  TEST_F(FIXTURE, SqlPartitionedInts) { TestSqlPartitionedInts(); }                                 \
-  TEST_F(FIXTURE, SqlPrepareGetParameterSchema) { TestSqlPrepareGetParameterSchema(); }             \
-  TEST_F(FIXTURE, SqlPrepareSelectNoParams) { TestSqlPrepareSelectNoParams(); }                     \
-  TEST_F(FIXTURE, SqlPrepareSelectParams) { TestSqlPrepareSelectParams(); }                         \
-  TEST_F(FIXTURE, SqlPrepareUpdate) { TestSqlPrepareUpdate(); }                                     \
-  TEST_F(FIXTURE, SqlPrepareUpdateNoParams) { TestSqlPrepareUpdateNoParams(); }                     \
-  TEST_F(FIXTURE, SqlPrepareUpdateStream) { TestSqlPrepareUpdateStream(); }                         \
-  TEST_F(FIXTURE, SqlPrepareErrorNoQuery) { TestSqlPrepareErrorNoQuery(); }                         \
-  TEST_F(FIXTURE, SqlPrepareErrorParamCountMismatch) { TestSqlPrepareErrorParamCountMismatch(); }   \
-  TEST_F(FIXTURE, SqlQueryInts) { TestSqlQueryInts(); }                                             \
-  TEST_F(FIXTURE, SqlQueryFloats) { TestSqlQueryFloats(); }                                         \
-  TEST_F(FIXTURE, SqlQueryStrings) { TestSqlQueryStrings(); }                                       \
-  TEST_F(FIXTURE, SqlQueryInsertRollback) { TestSqlQueryInsertRollback(); }                         \
-  TEST_F(FIXTURE, SqlQueryCancel) { TestSqlQueryCancel(); }                                         \
-  TEST_F(FIXTURE, SqlQueryErrors) { TestSqlQueryErrors(); }                                         \
-  TEST_F(FIXTURE, SqlQueryTrailingSemicolons) { TestSqlQueryTrailingSemicolons(); }                 \
-  TEST_F(FIXTURE, SqlQueryRowsAffectedDelete) { TestSqlQueryRowsAffectedDelete(); }                 \
-  TEST_F(FIXTURE, SqlQueryRowsAffectedDeleteStream) { TestSqlQueryRowsAffectedDeleteStream(); }     \
-  TEST_F(FIXTURE, SqlSchemaInts) { TestSqlSchemaInts(); }                                           \
-  TEST_F(FIXTURE, SqlSchemaFloats) { TestSqlSchemaFloats(); }                                       \
-  TEST_F(FIXTURE, SqlSchemaStrings) { TestSqlSchemaStrings(); }                                     \
-  TEST_F(FIXTURE, SqlSchemaErrors) { TestSqlSchemaErrors(); }                                       \
-  TEST_F(FIXTURE, Transactions) { TestTransactions(); }                                             \
-  TEST_F(FIXTURE, ConcurrentStatements) { TestConcurrentStatements(); }                             \
-  TEST_F(FIXTURE, ErrorCompatibility) { TestErrorCompatibility(); }                                 \
+#define ADBCV_TEST_STATEMENT(FIXTURE)                                                   \
+  static_assert(std::is_base_of<adbc_validation::StatementTest, FIXTURE>::value,        \
+                ADBCV_STRINGIFY(FIXTURE) " must inherit from StatementTest");           \
+  TEST_F(FIXTURE, NewInit) { TestNewInit(); }                                           \
+  TEST_F(FIXTURE, Release) { TestRelease(); }                                           \
+  TEST_F(FIXTURE, SqlIngestBool) { TestSqlIngestBool(); }                               \
+  TEST_F(FIXTURE, SqlIngestInt8) { TestSqlIngestInt8(); }                               \
+  TEST_F(FIXTURE, SqlIngestInt16) { TestSqlIngestInt16(); }                             \
+  TEST_F(FIXTURE, SqlIngestInt32) { TestSqlIngestInt32(); }                             \
+  TEST_F(FIXTURE, SqlIngestInt64) { TestSqlIngestInt64(); }                             \
+  TEST_F(FIXTURE, SqlIngestUInt8) { TestSqlIngestUInt8(); }                             \
+  TEST_F(FIXTURE, SqlIngestUInt16) { TestSqlIngestUInt16(); }                           \
+  TEST_F(FIXTURE, SqlIngestUInt32) { TestSqlIngestUInt32(); }                           \
+  TEST_F(FIXTURE, SqlIngestUInt64) { TestSqlIngestUInt64(); }                           \
+  TEST_F(FIXTURE, SqlIngestFloat32) { TestSqlIngestFloat32(); }                         \
+  TEST_F(FIXTURE, SqlIngestFloat64) { TestSqlIngestFloat64(); }                         \
+  TEST_F(FIXTURE, SqlIngestString) { TestSqlIngestString(); }                           \
+  TEST_F(FIXTURE, SqlIngestLargeString) { TestSqlIngestLargeString(); }                 \
+  TEST_F(FIXTURE, SqlIngestBinary) { TestSqlIngestBinary(); }                           \
+  TEST_F(FIXTURE, SqlIngestDuration) { TestSqlIngestDuration(); }                       \
+  TEST_F(FIXTURE, SqlIngestDate32) { TestSqlIngestDate32(); }                           \
+  TEST_F(FIXTURE, SqlIngestTimestamp) { TestSqlIngestTimestamp(); }                     \
+  TEST_F(FIXTURE, SqlIngestTimestampTz) { TestSqlIngestTimestampTz(); }                 \
+  TEST_F(FIXTURE, SqlIngestInterval) { TestSqlIngestInterval(); }                       \
+  TEST_F(FIXTURE, SqlIngestTableEscaping) { TestSqlIngestTableEscaping(); }             \
+  TEST_F(FIXTURE, SqlIngestColumnEscaping) { TestSqlIngestColumnEscaping(); }           \
+  TEST_F(FIXTURE, SqlIngestAppend) { TestSqlIngestAppend(); }                           \
+  TEST_F(FIXTURE, SqlIngestReplace) { TestSqlIngestReplace(); }                         \
+  TEST_F(FIXTURE, SqlIngestCreateAppend) { TestSqlIngestCreateAppend(); }               \
+  TEST_F(FIXTURE, SqlIngestErrors) { TestSqlIngestErrors(); }                           \
+  TEST_F(FIXTURE, SqlIngestMultipleConnections) { TestSqlIngestMultipleConnections(); } \
+  TEST_F(FIXTURE, SqlIngestSample) { TestSqlIngestSample(); }                           \
+  TEST_F(FIXTURE, SqlIngestTargetCatalog) { TestSqlIngestTargetCatalog(); }             \
+  TEST_F(FIXTURE, SqlIngestTargetSchema) { TestSqlIngestTargetSchema(); }               \
+  TEST_F(FIXTURE, SqlIngestTargetCatalogSchema) { TestSqlIngestTargetCatalogSchema(); } \
+  TEST_F(FIXTURE, SqlIngestTemporary) { TestSqlIngestTemporary(); }                     \
+  TEST_F(FIXTURE, SqlIngestTemporaryAppend) { TestSqlIngestTemporaryAppend(); }         \
+  TEST_F(FIXTURE, SqlIngestTemporaryReplace) { TestSqlIngestTemporaryReplace(); }       \
+  TEST_F(FIXTURE, SqlIngestTemporaryExclusive) { TestSqlIngestTemporaryExclusive(); }   \
+  TEST_F(FIXTURE, SqlPartitionedInts) { TestSqlPartitionedInts(); }                     \
+  TEST_F(FIXTURE, SqlPrepareGetParameterSchema) { TestSqlPrepareGetParameterSchema(); } \
+  TEST_F(FIXTURE, SqlPrepareSelectNoParams) { TestSqlPrepareSelectNoParams(); }         \
+  TEST_F(FIXTURE, SqlPrepareSelectParams) { TestSqlPrepareSelectParams(); }             \
+  TEST_F(FIXTURE, SqlPrepareUpdate) { TestSqlPrepareUpdate(); }                         \
+  TEST_F(FIXTURE, SqlPrepareUpdateNoParams) { TestSqlPrepareUpdateNoParams(); }         \
+  TEST_F(FIXTURE, SqlPrepareUpdateStream) { TestSqlPrepareUpdateStream(); }             \
+  TEST_F(FIXTURE, SqlPrepareErrorNoQuery) { TestSqlPrepareErrorNoQuery(); }             \
+  TEST_F(FIXTURE, SqlPrepareErrorParamCountMismatch) { 
+    TestSqlPrepareErrorParamCountMismatch();
+  }                                                                                     \
+  TEST_F(FIXTURE, SqlQueryInts) { TestSqlQueryInts(); }                                 \
+  TEST_F(FIXTURE, SqlQueryFloats) { TestSqlQueryFloats(); }                             \
+  TEST_F(FIXTURE, SqlQueryStrings) { TestSqlQueryStrings(); }                           \
+  TEST_F(FIXTURE, SqlQueryInsertRollback) { TestSqlQueryInsertRollback(); }             \
+  TEST_F(FIXTURE, SqlQueryCancel) { TestSqlQueryCancel(); }                             \
+  TEST_F(FIXTURE, SqlQueryErrors) { TestSqlQueryErrors(); }                             \
+  TEST_F(FIXTURE, SqlQueryTrailingSemicolons) { TestSqlQueryTrailingSemicolons(); }     \
+  TEST_F(FIXTURE, SqlQueryRowsAffectedDelete) { TestSqlQueryRowsAffectedDelete(); }     \
+  TEST_F(FIXTURE, SqlQueryRowsAffectedDeleteStream) { 
+    TestSqlQueryRowsAffectedDeleteStream();
+  }                                                                                     \
+  TEST_F(FIXTURE, SqlSchemaInts) { TestSqlSchemaInts(); }                               \
+  TEST_F(FIXTURE, SqlSchemaFloats) { TestSqlSchemaFloats(); }                           \
+  TEST_F(FIXTURE, SqlSchemaStrings) { TestSqlSchemaStrings(); }                         \
+  TEST_F(FIXTURE, SqlSchemaErrors) { TestSqlSchemaErrors(); }                           \
+  TEST_F(FIXTURE, Transactions) { TestTransactions(); }                                 \
+  TEST_F(FIXTURE, ConcurrentStatements) { TestConcurrentStatements(); }                 \
+  TEST_F(FIXTURE, ErrorCompatibility) { TestErrorCompatibility(); }                     \
   TEST_F(FIXTURE, ResultInvalidation) { TestResultInvalidation(); }
 
 }  // namespace adbc_validation

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -447,7 +447,7 @@ class StatementTest {
   TEST_F(FIXTURE, SqlPrepareUpdateNoParams) { TestSqlPrepareUpdateNoParams(); }         \
   TEST_F(FIXTURE, SqlPrepareUpdateStream) { TestSqlPrepareUpdateStream(); }             \
   TEST_F(FIXTURE, SqlPrepareErrorNoQuery) { TestSqlPrepareErrorNoQuery(); }             \
-  TEST_F(FIXTURE, SqlPrepareErrorParamCountMismatch) { 
+  TEST_F(FIXTURE, SqlPrepareErrorParamCountMismatch) {
     TestSqlPrepareErrorParamCountMismatch();
   }                                                                                     \
   TEST_F(FIXTURE, SqlQueryInts) { TestSqlQueryInts(); }                                 \
@@ -458,7 +458,7 @@ class StatementTest {
   TEST_F(FIXTURE, SqlQueryErrors) { TestSqlQueryErrors(); }                             \
   TEST_F(FIXTURE, SqlQueryTrailingSemicolons) { TestSqlQueryTrailingSemicolons(); }     \
   TEST_F(FIXTURE, SqlQueryRowsAffectedDelete) { TestSqlQueryRowsAffectedDelete(); }     \
-  TEST_F(FIXTURE, SqlQueryRowsAffectedDeleteStream) { 
+  TEST_F(FIXTURE, SqlQueryRowsAffectedDeleteStream) {
     TestSqlQueryRowsAffectedDeleteStream();
   }                                                                                     \
   TEST_F(FIXTURE, SqlSchemaInts) { TestSqlSchemaInts(); }                               \

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -447,8 +447,8 @@ class StatementTest {
   TEST_F(FIXTURE, SqlPrepareUpdateNoParams) { TestSqlPrepareUpdateNoParams(); }         \
   TEST_F(FIXTURE, SqlPrepareUpdateStream) { TestSqlPrepareUpdateStream(); }             \
   TEST_F(FIXTURE, SqlPrepareErrorNoQuery) { TestSqlPrepareErrorNoQuery(); }             \
-  TEST_F(FIXTURE, SqlPrepareErrorParamCountMismatch) {
-    TestSqlPrepareErrorParamCountMismatch();
+  TEST_F(FIXTURE, SqlPrepareErrorParamCountMismatch) {                                  \
+    TestSqlPrepareErrorParamCountMismatch();                                            \
   }                                                                                     \
   TEST_F(FIXTURE, SqlQueryInts) { TestSqlQueryInts(); }                                 \
   TEST_F(FIXTURE, SqlQueryFloats) { TestSqlQueryFloats(); }                             \
@@ -458,8 +458,8 @@ class StatementTest {
   TEST_F(FIXTURE, SqlQueryErrors) { TestSqlQueryErrors(); }                             \
   TEST_F(FIXTURE, SqlQueryTrailingSemicolons) { TestSqlQueryTrailingSemicolons(); }     \
   TEST_F(FIXTURE, SqlQueryRowsAffectedDelete) { TestSqlQueryRowsAffectedDelete(); }     \
-  TEST_F(FIXTURE, SqlQueryRowsAffectedDeleteStream) {
-    TestSqlQueryRowsAffectedDeleteStream();
+  TEST_F(FIXTURE, SqlQueryRowsAffectedDeleteStream) {                                   \
+    TestSqlQueryRowsAffectedDeleteStream();                                             \
   }                                                                                     \
   TEST_F(FIXTURE, SqlSchemaInts) { TestSqlSchemaInts(); }                               \
   TEST_F(FIXTURE, SqlSchemaFloats) { TestSqlSchemaFloats(); }                           \


### PR DESCRIPTION
Fixes #1145 

If we prefer consistency with the stream case for # of rows affected instead of the actual # of rows affected, we can change this line:
```
*rows_affected = sqlite3_changes(stmt->conn);
```

to be:
```
*rows_affected = -1;
```