### PR TITLE
fix(r): Build with __USE_MINGW_ANSI_STDIO to enable use of lld in format strings

### DIFF
--- a/c/driver/common/utils.h
+++ b/c/driver/common/utils.h
@@ -30,12 +30,13 @@ extern "C" {
 
 int AdbcStatusCodeToErrno(AdbcStatusCode code);
 
-// The printf checking attribute doesn't work properly on gcc 4.8
-// and results in spurious compiler warnings
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 5)
-#define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(printf, 2, 3)))
+// On mingw we have to specify a slightly different format attribute and ensure
+// that we use the version that knows how to deal with %lld
+#if defined(_WIN32) && !defined(MSVC)
+#define __USE_MINGW_ANSI_STDIO 1
+#define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(__MINGW_PRINTF_FORMAT, 2, 3)))
 #else
-#define ADBC_CHECK_PRINTF_ATTRIBUTE
+#define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(printf, 2, 3)))
 #endif
 
 /// Set error message using a format string.

--- a/c/driver/common/utils.h
+++ b/c/driver/common/utils.h
@@ -32,7 +32,7 @@ int AdbcStatusCodeToErrno(AdbcStatusCode code);
 
 // On mingw we have to specify a slightly different format attribute and ensure
 // that we use the version that knows how to deal with %lld
-#if defined(_WIN32) && !defined(MSVC)
+#if defined(__MINGW32__)
 #define __USE_MINGW_ANSI_STDIO 1
 #define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(__MINGW_PRINTF_FORMAT, 2, 3)))
 #else

--- a/c/driver/common/utils.h
+++ b/c/driver/common/utils.h
@@ -37,6 +37,8 @@ int AdbcStatusCodeToErrno(AdbcStatusCode code);
 #define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(__MINGW_PRINTF_FORMAT, 2, 3)))
 #elif defined(__GNUC__)
 #define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(printf, 2, 3)))
+#else
+#define ADBC_CHECK_PRINTF_ATTRIBUTE
 #endif
 
 /// Set error message using a format string.

--- a/c/driver/common/utils.h
+++ b/c/driver/common/utils.h
@@ -32,10 +32,10 @@ int AdbcStatusCodeToErrno(AdbcStatusCode code);
 
 // On mingw we have to specify a slightly different format attribute and ensure
 // that we use the version that knows how to deal with %lld
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) && defined(__GNUC__)
 #define __USE_MINGW_ANSI_STDIO 1
 #define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(__MINGW_PRINTF_FORMAT, 2, 3)))
-#else
+#elif defined(__GNUC__)
 #define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(printf, 2, 3)))
 #endif
 

--- a/c/driver/common/utils.h
+++ b/c/driver/common/utils.h
@@ -30,10 +30,8 @@ extern "C" {
 
 int AdbcStatusCodeToErrno(AdbcStatusCode code);
 
-// On mingw we have to specify a slightly different format attribute and ensure
-// that we use the version that knows how to deal with %lld
-#if defined(__MINGW32__) && defined(__GNUC__)
-#define __USE_MINGW_ANSI_STDIO 1
+// If using mingw's c99-compliant printf, we need a different format-checking attribute
+#if defined(__USE_MINGW_ANSI_STDIO) && defined(__MINGW_PRINTF_FORMAT)
 #define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(__MINGW_PRINTF_FORMAT, 2, 3)))
 #elif defined(__GNUC__)
 #define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(printf, 2, 3)))

--- a/r/adbcpostgresql/src/Makevars.win
+++ b/r/adbcpostgresql/src/Makevars.win
@@ -17,7 +17,7 @@
 
 VERSION = 13.2.0
 RWINLIB = ../windows/libpq-$(VERSION)
-PKG_CPPFLAGS = -I$(RWINLIB)/include -I../src -DADBC_EXPORT=""
+PKG_CPPFLAGS = -I$(RWINLIB)/include -I../src -DADBC_EXPORT="" -D__USE_MINGW_ANSI_STDIO
 PKG_LIBS = -L$(RWINLIB)/lib${R_ARCH}${CRT} \
 	-lpq -lpgport -lpgcommon -lssl -lcrypto -lwsock32 -lsecur32 -lws2_32 -lgdi32 -lcrypt32 -lwldap32
 

--- a/r/adbcsqlite/configure
+++ b/r/adbcsqlite/configure
@@ -52,6 +52,11 @@ else
   PKG_LIBS="$PKG_LIBS -lsqlite3"
 fi
 
+# Add mingw printf flag if on Windows
+if [ ! -z "$R_ADBC_SQLITE_ON_WINDOWS" ]; then
+  PKG_CPPFLAGS="$PKG_CPPFLAGS -D__USE_MINGW_ANSI_STDIO"
+fi
+
 rm -f tools/test.o sqlite_test sqlite_test.log || true
 
 sed \

--- a/r/adbcsqlite/configure
+++ b/r/adbcsqlite/configure
@@ -40,7 +40,7 @@ echo "Testing R CMD SHLIB with $PKG_CPPFLAGS $PKG_LIBS -lsqlite3"
 PKG_CPPFLAGS="$PKG_CPPFLAGS" PKG_LIBS="$PKG_LIBS -lsqlite3" \
   $R_HOME/bin/R CMD SHLIB tools/test.c -o sqlite_test >sqlite_test.log 2>&1
 
-if [ $? -ne 0 ] || [ ! -z "$FORCE_VENDORED_SQLITE3"]; then
+if [ $? -ne 0 ] || [ ! -z "$FORCE_VENDORED_SQLITE3" ]; then
   echo "Forcing vendored sqlite3 or #include <sqlite3.h>/-lsqlite3 failed:"
   cat sqlite_test.log
 

--- a/r/adbcsqlite/configure.win
+++ b/r/adbcsqlite/configure.win
@@ -16,4 +16,4 @@
 # under the License.
 
 # Just call the original configure script
-./configure
+R_ADBC_SQLITE_ON_WINDOWS=1 ./configure

--- a/r/adbcsqlite/src/Makevars.in
+++ b/r/adbcsqlite/src/Makevars.in
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-PKG_CPPFLAGS=-I../src @cppflags@ -DADBC_EXPORT="" -D__USE_MINGW_ANSI_STDIO
+PKG_CPPFLAGS=-I../src @cppflags@ -DADBC_EXPORT=""
 PKG_LIBS=@libs@
 
 OBJECTS = init.o \

--- a/r/adbcsqlite/src/Makevars.in
+++ b/r/adbcsqlite/src/Makevars.in
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-PKG_CPPFLAGS=-I../src @cppflags@ -DADBC_EXPORT=""
+PKG_CPPFLAGS=-I../src @cppflags@ -DADBC_EXPORT="" -D__USE_MINGW_ANSI_STDIO
 PKG_LIBS=@libs@
 
 OBJECTS = init.o \


### PR DESCRIPTION
Closes #1113.

The mingw headers appear to be a little inconsistent with respect to the definitions of `PRId64` and the format check attribute. I think this fix it the least intrusive way to deal with that but I'm open to thoughts!