### PR TITLE
ci: fix snowflake integration tests

### DIFF
--- a/c/driver/snowflake/snowflake_test.cc
+++ b/c/driver/snowflake/snowflake_test.cc
@@ -71,15 +71,15 @@ class SnowflakeQuirks : public adbc_validation::DriverQuirks {
     adbc_validation::Handle<struct AdbcStatement> statement;
     CHECK_OK(AdbcStatementNew(connection, &statement.value, error));
 
-    std::string create = "CREATE TABLE ";
+    std::string create = "CREATE TABLE \"";
     create += name;
-    create += " (int64s INT, strings TEXT)";
+    create += "\" (int64s INT, strings TEXT)";
     CHECK_OK(AdbcStatementSetSqlQuery(&statement.value, create.c_str(), error));
     CHECK_OK(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, error));
 
-    std::string insert = "INSERT INTO ";
+    std::string insert = "INSERT INTO \"";
     insert += name;
-    insert += " VALUES (42, 'foo'), (-42, NULL), (NULL, '')";
+    insert += "\" VALUES (42, 'foo'), (-42, NULL), (NULL, '')";
     CHECK_OK(AdbcStatementSetSqlQuery(&statement.value, insert.c_str(), error));
     CHECK_OK(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, error));
 


### PR DESCRIPTION
We use quotes around the table name in the `DropTable` method but we don't use it in `CreateSampleTable`. Without the quotes, the table is created as upper case, but we attempt to drop the table with a forced lower case name. As a result the table doesn't get dropped and we fail on the table creation because the table already exists.

So if we properly put quotes around the table creation, this should fix the snowflake CI integration tests.