### PR TITLE
docs(java): First step into adding Java docs (quickstart, driver manager summary, etc.)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -128,6 +128,7 @@ jobs:
           mamba install -c conda-forge \
             --file ci/conda_env_cpp.txt \
             --file ci/conda_env_python.txt
+          pip install pytest-error-for-skips
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19.13
@@ -176,6 +177,7 @@ jobs:
           ADBC_DREMIO_FLIGHTSQL_USER: "dremio"
           ADBC_DREMIO_FLIGHTSQL_PASS: "dremio123"
           ADBC_TEST_FLIGHTSQL_URI: "grpc+tcp://localhost:41414"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           ./ci/scripts/python_test.sh "$(pwd)" "$(pwd)/build"
       - name: Stop SQLite server and Dremio
@@ -213,6 +215,7 @@ jobs:
           mamba install -c conda-forge \
             --file ci/conda_env_cpp.txt \
             --file ci/conda_env_python.txt
+          pip install pytest-error-for-skips
       - name: Build PostgreSQL Driver
         shell: bash -l {0}
         env:
@@ -237,6 +240,7 @@ jobs:
           ADBC_USE_ASAN: "ON"
           ADBC_USE_UBSAN: "ON"
           ADBC_POSTGRESQL_TEST_URI: "postgresql://localhost:5432/postgres?user=postgres&password=password"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           env POSTGRES_VERSION=11 docker compose up --wait --detach postgres-test
           ./ci/scripts/cpp_test.sh "$(pwd)/build"
@@ -250,6 +254,7 @@ jobs:
           ADBC_USE_ASAN: "ON"
           ADBC_USE_UBSAN: "ON"
           ADBC_POSTGRESQL_TEST_URI: "postgresql://localhost:5432/postgres?user=postgres&password=password"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           env POSTGRES_VERSION=12 docker compose up --wait --detach postgres-test
           ./ci/scripts/cpp_test.sh "$(pwd)/build"
@@ -263,6 +268,7 @@ jobs:
           ADBC_USE_ASAN: "ON"
           ADBC_USE_UBSAN: "ON"
           ADBC_POSTGRESQL_TEST_URI: "postgresql://localhost:5432/postgres?user=postgres&password=password"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           env POSTGRES_VERSION=13 docker compose up --wait --detach postgres-test
           ./ci/scripts/cpp_test.sh "$(pwd)/build"
@@ -276,6 +282,7 @@ jobs:
           ADBC_USE_ASAN: "ON"
           ADBC_USE_UBSAN: "ON"
           ADBC_POSTGRESQL_TEST_URI: "postgresql://localhost:5432/postgres?user=postgres&password=password"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           env POSTGRES_VERSION=14 docker compose up --wait --detach postgres-test
           ./ci/scripts/cpp_test.sh "$(pwd)/build"
@@ -289,6 +296,7 @@ jobs:
           ADBC_USE_ASAN: "ON"
           ADBC_USE_UBSAN: "ON"
           ADBC_POSTGRESQL_TEST_URI: "postgresql://localhost:5432/postgres?user=postgres&password=password"
+          PYTEST_ADDOPTS: "--error-for-skips"
         run: |
           env POSTGRES_VERSION=15 docker compose up --wait --detach postgres-test
           ./ci/scripts/cpp_test.sh "$(pwd)/build"

--- a/c/driver/common/utils.h
+++ b/c/driver/common/utils.h
@@ -30,9 +30,10 @@ extern "C" {
 
 int AdbcStatusCodeToErrno(AdbcStatusCode code);
 
-// The printf checking attribute doesn't work properly on gcc 4.8
-// and results in spurious compiler warnings
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 5)
+// If using mingw's c99-compliant printf, we need a different format-checking attribute
+#if defined(__USE_MINGW_ANSI_STDIO) && defined(__MINGW_PRINTF_FORMAT)
+#define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(__MINGW_PRINTF_FORMAT, 2, 3)))
+#elif defined(__GNUC__)
 #define ADBC_CHECK_PRINTF_ATTRIBUTE __attribute__((format(printf, 2, 3)))
 #else
 #define ADBC_CHECK_PRINTF_ATTRIBUTE

--- a/c/driver/postgresql/postgres_copy_reader.h
+++ b/c/driver/postgresql/postgres_copy_reader.h
@@ -1218,6 +1218,7 @@ static inline ArrowErrorCode MakeCopyFieldWriter(const enum ArrowType arrow_type
     case NANOARROW_TYPE_BOOL:
       *out = new PostgresCopyBooleanFieldWriter();
       return NANOARROW_OK;
+    case NANOARROW_TYPE_INT8:
     case NANOARROW_TYPE_INT16:
       *out = new PostgresCopyNetworkEndianFieldWriter<int16_t>();
       return NANOARROW_OK;

--- a/c/driver/postgresql/postgres_copy_reader.h
+++ b/c/driver/postgresql/postgres_copy_reader.h
@@ -1125,7 +1125,13 @@ class PostgresCopyFieldTupleWriter : public PostgresCopyFieldWriter {
     NANOARROW_RETURN_NOT_OK(WriteChecked<int16_t>(buffer, n_fields, error));
 
     for (int16_t i = 0; i < n_fields; i++) {
-      children_[i]->Write(buffer, index, error);
+      const int8_t is_null = ArrowArrayViewIsNull(array_view_->children[i], index);
+      if (is_null) {
+        constexpr int32_t field_size_bytes = -1;
+        NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
+      } else {
+        children_[i]->Write(buffer, index, error);
+      }
     }
 
     return NANOARROW_OK;
@@ -1138,13 +1144,8 @@ class PostgresCopyFieldTupleWriter : public PostgresCopyFieldWriter {
 class PostgresCopyBooleanFieldWriter : public PostgresCopyFieldWriter {
  public:
   ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
-    const int8_t is_null = ArrowArrayViewIsNull(array_view_, index);
-    const int32_t field_size_bytes = is_null ? -1 : 1;
+    constexpr int32_t field_size_bytes = 1;
     NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
-    if (is_null) {
-      return ADBC_STATUS_OK;
-    }
-
     const int8_t value =
         static_cast<int8_t>(ArrowArrayViewGetIntUnsafe(array_view_, index));
     NANOARROW_RETURN_NOT_OK(WriteChecked<int8_t>(buffer, value, error));
@@ -1157,13 +1158,8 @@ template <typename T, T kOffset = 0>
 class PostgresCopyNetworkEndianFieldWriter : public PostgresCopyFieldWriter {
  public:
   ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
-    const int8_t is_null = ArrowArrayViewIsNull(array_view_, index);
-    const int32_t field_size_bytes = is_null ? -1 : sizeof(T);
+    constexpr int32_t field_size_bytes = sizeof(T);
     NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
-    if (is_null) {
-      return ADBC_STATUS_OK;
-    }
-
     const T value =
         static_cast<T>(ArrowArrayViewGetIntUnsafe(array_view_, index)) - kOffset;
     NANOARROW_RETURN_NOT_OK(WriteChecked<T>(buffer, value, error));
@@ -1175,12 +1171,8 @@ class PostgresCopyNetworkEndianFieldWriter : public PostgresCopyFieldWriter {
 class PostgresCopyFloatFieldWriter : public PostgresCopyFieldWriter {
  public:
   ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
-    const int8_t is_null = ArrowArrayViewIsNull(array_view_, index);
-    const int32_t field_size_bytes = is_null ? -1 : sizeof(uint32_t);
+    constexpr int32_t field_size_bytes = sizeof(uint32_t);
     NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
-    if (is_null) {
-      return ADBC_STATUS_OK;
-    }
 
     uint32_t value;
     float raw_value = ArrowArrayViewGetDoubleUnsafe(array_view_, index);
@@ -1194,12 +1186,8 @@ class PostgresCopyFloatFieldWriter : public PostgresCopyFieldWriter {
 class PostgresCopyDoubleFieldWriter : public PostgresCopyFieldWriter {
  public:
   ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
-    const int8_t is_null = ArrowArrayViewIsNull(array_view_, index);
-    const int32_t field_size_bytes = is_null ? -1 : sizeof(uint64_t);
+    constexpr int32_t field_size_bytes = sizeof(uint64_t);
     NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
-    if (is_null) {
-      return ADBC_STATUS_OK;
-    }
 
     uint64_t value;
     double raw_value = ArrowArrayViewGetDoubleUnsafe(array_view_, index);
@@ -1213,13 +1201,6 @@ class PostgresCopyDoubleFieldWriter : public PostgresCopyFieldWriter {
 class PostgresCopyBinaryFieldWriter : public PostgresCopyFieldWriter {
  public:
   ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
-    const int8_t is_null = ArrowArrayViewIsNull(array_view_, index);
-    if (is_null) {
-      constexpr int32_t field_size_bytes = -1;
-      NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
-      return ADBC_STATUS_OK;
-    }
-
     struct ArrowStringView string_view =
         ArrowArrayViewGetStringUnsafe(array_view_, index);
     NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, string_view.size_bytes, error));

--- a/c/driver/postgresql/postgres_copy_reader.h
+++ b/c/driver/postgresql/postgres_copy_reader.h
@@ -1228,6 +1228,11 @@ static inline ArrowErrorCode MakeCopyFieldWriter(const enum ArrowType arrow_type
     case NANOARROW_TYPE_INT64:
       *out = new PostgresCopyNetworkEndianFieldWriter<int64_t>();
       return NANOARROW_OK;
+    case NANOARROW_TYPE_DATE32: {
+      constexpr int32_t kPostgresDateEpoch = 10957;
+      *out = new PostgresCopyNetworkEndianFieldWriter<int32_t, kPostgresDateEpoch>();
+      return NANOARROW_OK;
+    }
     case NANOARROW_TYPE_FLOAT:
       *out = new PostgresCopyFloatFieldWriter();
       return NANOARROW_OK;

--- a/c/driver/postgresql/postgres_copy_reader_test.cc
+++ b/c/driver/postgresql/postgres_copy_reader_test.cc
@@ -532,6 +532,70 @@ TEST(PostgresCopyUtilsTest, PostgresCopyWriteDoublePrecision) {
   }
 }
 
+static uint8_t kTestPgCopyDate[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff,
+    0x71, 0x54, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x8e, 0xad, 0x00, 0x01,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadDate) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyDate;
+  data.size_bytes = sizeof(kTestPgCopyDate);
+
+  auto col_type = PostgresType(PostgresTypeId::kDate);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyDate, sizeof(kTestPgCopyDate));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 3);
+  ASSERT_EQ(array->n_children, 1);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto data_buffer = reinterpret_cast<const int32_t*>(array->children[0]->buffers[1]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_FALSE(ArrowBitGet(validity, 2));
+
+  ASSERT_EQ(data_buffer[0], -25567);
+  ASSERT_EQ(data_buffer[1], 47482);
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteDate) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_DATE32}}),
+            ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<int32_t>(&schema.value, &array.value, &na_error,
+                                                {-25567, 47482, std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyDate) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyDate[i]);
+  }
+}
+
+
 // For full coverage, ensure that this contains NUMERIC examples that:
 // - Have >= four zeroes to the left of the decimal point
 // - Have >= four zeroes to the right of the decimal point

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -1300,14 +1300,16 @@ AdbcStatusCode PostgresStatement::SetOption(const char* key, const char* value,
     prepared_ = false;
   } else if (std::strcmp(key, ADBC_INGEST_OPTION_TEMPORARY) == 0) {
     if (std::strcmp(value, ADBC_OPTION_VALUE_ENABLED) == 0) {
+      // https://github.com/apache/arrow-adbc/issues/1109: only clear the
+      // schema if enabling since Python always sets the flag explicitly
       ingest_.temporary = true;
+      ingest_.db_schema.clear();
     } else if (std::strcmp(value, ADBC_OPTION_VALUE_DISABLED) == 0) {
       ingest_.temporary = false;
     } else {
       SetError(error, "[libpq] Invalid value '%s' for option '%s'", value, key);
       return ADBC_STATUS_INVALID_ARGUMENT;
     }
-    ingest_.db_schema.clear();
     prepared_ = false;
   } else if (std::strcmp(key, ADBC_POSTGRESQL_OPTION_BATCH_SIZE_HINT_BYTES) == 0) {
     int64_t int_value = std::atol(value);

--- a/c/driver/snowflake/snowflake_test.cc
+++ b/c/driver/snowflake/snowflake_test.cc
@@ -71,15 +71,15 @@ class SnowflakeQuirks : public adbc_validation::DriverQuirks {
     adbc_validation::Handle<struct AdbcStatement> statement;
     CHECK_OK(AdbcStatementNew(connection, &statement.value, error));
 
-    std::string create = "CREATE TABLE ";
+    std::string create = "CREATE TABLE \"";
     create += name;
-    create += " (int64s INT, strings TEXT)";
+    create += "\" (int64s INT, strings TEXT)";
     CHECK_OK(AdbcStatementSetSqlQuery(&statement.value, create.c_str(), error));
     CHECK_OK(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, error));
 
-    std::string insert = "INSERT INTO ";
+    std::string insert = "INSERT INTO \"";
     insert += name;
-    insert += " VALUES (42, 'foo'), (-42, NULL), (NULL, '')";
+    insert += "\" VALUES (42, 'foo'), (-42, NULL), (NULL, '')";
     CHECK_OK(AdbcStatementSetSqlQuery(&statement.value, insert.c_str(), error));
     CHECK_OK(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, error));
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinxcontrib.mermaid",
+    "javasphinx",
 ]
 templates_path = ["_templates"]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,6 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinxcontrib.mermaid",
-    "javasphinx",
 ]
 templates_path = ["_templates"]
 

--- a/docs/source/java/api/adbc_driver_manager.rst
+++ b/docs/source/java/api/adbc_driver_manager.rst
@@ -1,0 +1,79 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+============================
+``Java ADBC Driver Manager``
+============================
+
+Java ADBC Wrapper for JDBC
+==========================
+
+The Java ADBC Driver Manager provides a means to manage ADBC drivers and facilitate connections to databases using the ADBC API. This particular implementation wraps around the JDBC API.
+
+Constants
+---------
+
+.. data:: org.apache.arrow.adbc.driver.jdbc.JdbcDriver.PARAM_DATASOURCE
+
+   A parameter for creating an ``AdbcDatabase`` from a ``DataSource``.
+
+.. data:: org.apache.arrow.adbc.driver.jdbc.JdbcDriver.PARAM_JDBC_QUIRKS
+
+   A parameter for specifying backend-specific configuration.
+
+.. data:: org.apache.arrow.adbc.driver.jdbc.JdbcDriver.PARAM_URI
+
+   A parameter for specifying a URI to connect to, aligning with the C/Go implementations.
+
+Classes
+-------
+
+.. class:: org.apache.arrow.adbc.driver.jdbc.JdbcDriver
+
+   An ADBC driver implementation that wraps around the JDBC API.
+
+   .. method:: open(Map<String, Object> parameters)
+
+      Opens a new database connection using the specified parameters.
+
+.. class:: org.apache.arrow.adbc.driver.jdbc.JdbcDataSourceDatabase
+
+   Represents an ADBC database backed by a JDBC ``DataSource``.
+
+Utilities
+---------
+
+The ``JdbcDriver`` class provides utility methods to fetch and validate parameters from the provided options map.
+
+.. method:: org.apache.arrow.adbc.driver.jdbc.JdbcDriver.getParam(Class<T> klass, Map<String, Object> parameters, String... choices)
+
+   Retrieves a parameter from the provided map, validating its type and ensuring no duplicates.
+
+Usage
+=====
+
+The ``JdbcDriver`` class is registered with the ``AdbcDriverManager`` upon class loading. To utilize this driver:
+
+1. Ensure the necessary dependencies are in place.
+2. Create a ``Map<String, Object>`` containing the connection parameters.
+3. Use the ``AdbcDriverManager`` to obtain an instance of the ``JdbcDriver``.
+4. Open a new database connection using the driver's ``open`` method.
+
+Exceptions
+==========
+
+Any errors during the driver operations throw the ``AdbcException``. This exception provides detailed messages indicating the nature of the problem.

--- a/docs/source/java/api/index.rst
+++ b/docs/source/java/api/index.rst
@@ -1,0 +1,25 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+====================
+Java API Reference
+====================
+
+.. toctree::
+   :maxdepth: 1
+
+   adbc_driver_manager

--- a/docs/source/java/driver_manager.rst
+++ b/docs/source/java/driver_manager.rst
@@ -27,9 +27,9 @@ To include the ADBC Driver Manager in your Maven project, add the following depe
 .. code-block:: xml
 
    <dependency>
-       <groupId>com.adbc</groupId>
-       <artifactId>adbc-driver-manager</artifactId>
-       <version>1.0.0</version>
+      <groupId>org.apache.arrow.adbc</groupId>
+      <artifactId>adbc-driver-manager</artifactId>
+      <version>${adbc.version}</version>
    </dependency>
 
 API Reference

--- a/docs/source/java/driver_manager.rst
+++ b/docs/source/java/driver_manager.rst
@@ -1,0 +1,59 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+==============
+Driver Manager
+==============
+
+The driver manager is a library that provides bindings to the ADBC Java API. It delegates to dynamically-loaded drivers. This allows applications to use multiple drivers simultaneously and decouple themselves from the specific driver.
+
+The Java driver manager provides both low-level bindings that are essentially the same as the C API and high-level bindings that implement the JDBC standard.
+
+Installation
+============
+
+To include the ADBC Driver Manager in your Maven project, add the following dependency:
+
+.. code-block:: xml
+
+   <dependency>
+       <groupId>com.adbc</groupId>
+       <artifactId>adbc-driver-manager</artifactId>
+       <version>1.0.0</version>
+   </dependency>
+
+Usage
+=====
+
+First, load the driver:
+
+.. code-block:: java
+
+   import org.apache.arrow.adbc.core.AdbcDatabase;
+   import org.apache.arrow.adbc.core.AdbcDriver;
+   import org.apache.arrow.adbc.drivermanager.AdbcDriverManager;
+
+Then, create a connection:
+
+.. code-block:: java
+
+   Connection conn = DriverManager.getConnection("jdbc:adbc:sqlite:sample.db");
+
+API Reference
+=============
+
+See the API reference: :doc:`./api/adbc_driver_manager`.

--- a/docs/source/java/driver_manager.rst
+++ b/docs/source/java/driver_manager.rst
@@ -19,10 +19,6 @@
 Driver Manager
 ==============
 
-The driver manager is a library that provides bindings to the ADBC Java API. It delegates to dynamically-loaded drivers. This allows applications to use multiple drivers simultaneously and decouple themselves from the specific driver.
-
-The Java driver manager provides both low-level bindings that are essentially the same as the C API and high-level bindings that implement the JDBC standard.
-
 Installation
 ============
 
@@ -35,23 +31,6 @@ To include the ADBC Driver Manager in your Maven project, add the following depe
        <artifactId>adbc-driver-manager</artifactId>
        <version>1.0.0</version>
    </dependency>
-
-Usage
-=====
-
-First, load the driver:
-
-.. code-block:: java
-
-   import org.apache.arrow.adbc.core.AdbcDatabase;
-   import org.apache.arrow.adbc.core.AdbcDriver;
-   import org.apache.arrow.adbc.drivermanager.AdbcDriverManager;
-
-Then, create a connection:
-
-.. code-block:: java
-
-   Connection conn = DriverManager.getConnection("jdbc:adbc:sqlite:sample.db");
 
 API Reference
 =============

--- a/docs/source/java/index.rst
+++ b/docs/source/java/index.rst
@@ -15,11 +15,14 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-====
+======
 Java
-====
+======
 
 .. toctree::
    :maxdepth: 2
 
-.. note:: Under construction
+   quickstart
+   driver_manager
+   api/index
+   recipe/index

--- a/docs/source/java/index.rst
+++ b/docs/source/java/index.rst
@@ -25,4 +25,3 @@ Java
    quickstart
    driver_manager
    api/index
-   recipe/index

--- a/docs/source/java/index.rst
+++ b/docs/source/java/index.rst
@@ -15,9 +15,9 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-======
+====
 Java
-======
+====
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/java/quickstart.rst
+++ b/docs/source/java/quickstart.rst
@@ -49,8 +49,8 @@ JDBC-style API
 
 ADBC provides a high-level API in the style of the JDBC standard.
 
-Creating a Connection
----------------------
+Usage
+-----
 
 .. code-block:: java
 
@@ -60,32 +60,23 @@ Creating a Connection
        BufferAllocator allocator = new RootAllocator();
        AdbcDatabase db = new JdbcDriver(allocator).open(parameters);
        AdbcConnection adbcConnection = db.connect();
+       AdbcStatement stmt = adbcConnection.createStatement()
 
    ) {
-       // run queries, etc.
+       stmt.setSqlQuery("select * from foo");
+       AdbcStatement.QueryResult queryResult = stmt.executeQuery();
+       while (queryResult.getReader().loadNextBatch()) {
+           // process batch
+       }
    }  catch (AdbcException e) {
        // throw
    }
 
 In application code, the connection must be closed after usage or memory may leak.
-It is recommended to wrap the connection in a try-resource block for automatic
+It is recommended to wrap the connection in a try-with-resources block for automatic
 resource management.  In this example, we are connecting to a PostgreSQL database,
 specifically the default database "postgres".
 
-Creating a Statement
---------------------
-
-.. code-block:: java
-
-   AdbcStatement stmt = adbcConnection.createStatement();
-
-Executing a Query
------------------
-
-.. code-block:: java
-
-   stmt.setSqlQuery("select * from foo");
-   AdbcStatement.QueryResult queryResult = stmt.executeQuery();
-   while (queryResult.getReader().loadNextBatch()) {
-       // process batch
-   }
+Note that creating a statement is also wrapped in the try-with-resources block.
+Assuming we have a table "foo" in the database, an example for setting and executing the
+query is also provided.

--- a/docs/source/java/quickstart.rst
+++ b/docs/source/java/quickstart.rst
@@ -1,0 +1,91 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+==========
+Quickstart
+==========
+
+Here we'll briefly tour basic features of ADBC with the PostgreSQL driver for Java.
+
+Installation
+============
+
+To include ADBC in your Maven project, add the following dependency:
+
+.. code-block:: xml
+
+   <dependency>
+       <groupId>org.apache.arrow.adbc</groupId>
+       <artifactId>adbc-driver-jdbc</artifactId>
+       <version>0.7.0</version>
+   </dependency>
+
+For the examples in this section, the following imports are required:
+
+.. code-block:: java
+
+   import org.apache.arrow.adbc.core.AdbcConnection;
+   import org.apache.arrow.adbc.core.AdbcDatabase;
+   import org.apache.arrow.adbc.core.AdbcDriver;
+   import org.apache.arrow.adbc.core.AdbcException;
+   import org.apache.arrow.adbc.core.AdbcStatement;
+
+JDBC-style API
+==============
+
+ADBC provides a high-level API in the style of the JDBC standard.
+
+Creating a Connection
+---------------------
+
+.. code-block:: java
+
+   final Map<String, Object> parameters = new HashMap<>();
+   parameters.put(AdbcDriver.PARAM_URL, "jdbc:postgresql://localhost:5432/postgres");
+   try (
+       BufferAllocator allocator = new RootAllocator();
+       AdbcDatabase db = new JdbcDriver(allocator).open(parameters);
+       AdbcConnection adbcConnection = db.connect();
+
+   ) {
+       // run queries, etc.
+   }  catch (AdbcException e) {
+       // throw
+   }
+
+In application code, the connection must be closed after usage or memory may leak.
+It is recommended to wrap the connection in a try-resource block for automatic
+resource management.  In this example, we are connecting to a PostgreSQL database,
+specifically the default database "postgres".
+
+Creating a Statement
+--------------------
+
+.. code-block:: java
+
+   AdbcStatement stmt = adbcConnection.createStatement();
+
+Executing a Query
+-----------------
+
+.. code-block:: java
+
+   stmt.setSqlQuery("select * from foo");
+   AdbcStatement.QueryResult queryResult = stmt.executeQuery();
+   while (queryResult.getReader().loadNextBatch()) {
+       // process batch
+   }

--- a/docs/source/java/quickstart.rst
+++ b/docs/source/java/quickstart.rst
@@ -31,7 +31,7 @@ To include ADBC in your Maven project, add the following dependency:
    <dependency>
        <groupId>org.apache.arrow.adbc</groupId>
        <artifactId>adbc-driver-jdbc</artifactId>
-       <version>0.7.0</version>
+       <version>${adbc.version}</version>
    </dependency>
 
 For the examples in this section, the following imports are required:

--- a/r/adbcpostgresql/src/Makevars.win
+++ b/r/adbcpostgresql/src/Makevars.win
@@ -17,7 +17,7 @@
 
 VERSION = 13.2.0
 RWINLIB = ../windows/libpq-$(VERSION)
-PKG_CPPFLAGS = -I$(RWINLIB)/include -I../src -DADBC_EXPORT=""
+PKG_CPPFLAGS = -I$(RWINLIB)/include -I../src -DADBC_EXPORT="" -D__USE_MINGW_ANSI_STDIO
 PKG_LIBS = -L$(RWINLIB)/lib${R_ARCH}${CRT} \
 	-lpq -lpgport -lpgcommon -lssl -lcrypto -lwsock32 -lsecur32 -lws2_32 -lgdi32 -lcrypt32 -lwldap32
 

--- a/r/adbcsqlite/configure
+++ b/r/adbcsqlite/configure
@@ -40,7 +40,7 @@ echo "Testing R CMD SHLIB with $PKG_CPPFLAGS $PKG_LIBS -lsqlite3"
 PKG_CPPFLAGS="$PKG_CPPFLAGS" PKG_LIBS="$PKG_LIBS -lsqlite3" \
   $R_HOME/bin/R CMD SHLIB tools/test.c -o sqlite_test >sqlite_test.log 2>&1
 
-if [ $? -ne 0 ] || [ ! -z "$FORCE_VENDORED_SQLITE3"]; then
+if [ $? -ne 0 ] || [ ! -z "$FORCE_VENDORED_SQLITE3" ]; then
   echo "Forcing vendored sqlite3 or #include <sqlite3.h>/-lsqlite3 failed:"
   cat sqlite_test.log
 
@@ -50,6 +50,11 @@ if [ $? -ne 0 ] || [ ! -z "$FORCE_VENDORED_SQLITE3"]; then
 else
   echo "Success!"
   PKG_LIBS="$PKG_LIBS -lsqlite3"
+fi
+
+# Add mingw printf flag if on Windows
+if [ ! -z "$R_ADBC_SQLITE_ON_WINDOWS" ]; then
+  PKG_CPPFLAGS="$PKG_CPPFLAGS -D__USE_MINGW_ANSI_STDIO"
 fi
 
 rm -f tools/test.o sqlite_test sqlite_test.log || true

--- a/r/adbcsqlite/configure.win
+++ b/r/adbcsqlite/configure.win
@@ -16,4 +16,4 @@
 # under the License.
 
 # Just call the original configure script
-./configure
+R_ADBC_SQLITE_ON_WINDOWS=1 ./configure


### PR DESCRIPTION
Initially I wanted to use `javasphinx` to use `.. java:`, but ran into several build issues that mostly stem from it not being updated in over 5 years (one of several issues I ran into trying to `make html`: https://github.com/readthedocs/readthedocs.org/issues/7649).  So I decided to just use more generic directives like `.. method::` and `.. class::` in some places.

Tested by running `make html` and checking out the `build` html output.