### PR TITLE
fix(r/adbcsnowflake): Add arrow as check dependency for adbcsnowflake

### DIFF
--- a/r/adbcsnowflake/DESCRIPTION
+++ b/r/adbcsnowflake/DESCRIPTION
@@ -21,6 +21,7 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
+Config/Needs/check: arrow
 URL: https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports: adbcdrivermanager


### PR DESCRIPTION
The CI for adbcsnowflake is failing because apparently REGIONKEY gets returned as a decimal, which needs the arrow R package to inspect. The previous attempt at fixing this assumed that it was another column causing the problem.