### PR TITLE
fix(r/adbcpostgresql): Use libpq provided by Rtools for R 4.2 and R 4.3

### DIFF
--- a/r/adbcpostgresql/src/Makevars.ucrt
+++ b/r/adbcpostgresql/src/Makevars.ucrt
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-CRT=-ucrt
-include Makevars.win
+PKG_CPPFLAGS = -I../src -DADBC_EXPORT="" -D__USE_MINGW_ANSI_STDIO
+
+PKG_LIBS = -lpq -lpgcommon -lpgport -lssl -lcrypto -lz -lsecur32 -lws2_32 -lwldap32
 
 OBJECTS = init.o \
     error.o \


### PR DESCRIPTION
This PR updates adbcpostgresql to use the version of libpq distributed with RTools (i.e., the Windows build system for R). Tomas Kalibera kindly checked to make sure this change worked, and indicated that falling back to downloading static libraries on older versions of R would be tolerated by CRAN:

> since you have Makevars.ucrt for R >= 4.2 (and hence Rtools >= 42), it is ok to use Makevars.win as a fallback for older versions. CRAN tolerates downloading with Rtools40 (when many libraries were not part of the default installation) and older and CRAN doesn't really care about versions older than "oldrelease" anyway.

Tomas provided a patch if we want to use pkg-config; however, noted that the version here would work on both RTools42 and RTools43, and using pkg-config could be revisited if a future version of R required an update to the linking order.

```patch
diff -Nru orig/adbcpostgresql/src/Makevars.ucrt patched/adbcpostgresql/src/Makevars.ucrt
--- orig/adbcpostgresql/src/Makevars.ucrt	2023-10-23 18:49:19.000000000 +0200
+++ patched/adbcpostgresql/src/Makevars.ucrt	2023-10-24 11:06:06.022535400 +0200
@@ -15,9 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-PKG_CPPFLAGS = -I../src -DADBC_EXPORT="" -D__USE_MINGW_ANSI_STDIO
+PKG_CPPFLAGS = -I../src -DADBC_EXPORT="" 
 
-PKG_LIBS = -lpq -lpgcommon -lpgport -lssl -lcrypto -lz -lsecur32 -lws2_32 -lwldap32
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+   PKG_LIBS = -lpq -lpgcommon -lpgport -lssl -lcrypto -lz -lsecur32 -lws2_32 -lwldap32
+else
+   PKG_LIBS = $(shell pkg-config --libs libpq)
+   PKG_CPPFLAGS += $(shell pkg-config --cflags libpq)
+endif 
 
 OBJECTS = init.o \
     error.o \
```

