### PR TITLE
fix(r/adbcsqlite): Fix incomplete cleanup in adbcsqlite tests

### DIFF
--- a/r/adbcsqlite/tests/testthat/test-adbcsqlite-package.R
+++ b/r/adbcsqlite/tests/testthat/test-adbcsqlite-package.R
@@ -93,7 +93,10 @@ test_that("read/write/execute SQL work with sqlite connections", {
 
   stream <- adbcdrivermanager::read_adbc(con, "SELECT * from df")
   expect_identical(as.data.frame(stream), data.frame(x = as.double(3:12)))
+
   stream$release()
+  adbcdrivermanager::adbc_connection_release(con)
+  adbcdrivermanager::adbc_database_release(db)
 })
 
 test_that("write_adbc() with temporary = TRUE works with sqlite databases", {
@@ -118,4 +121,7 @@ test_that("write_adbc() with temporary = TRUE works with sqlite databases", {
     adbcdrivermanager::read_adbc(con, "SELECT * from df"),
     class = "adbc_status_invalid_argument"
   )
+
+  adbcdrivermanager::adbc_connection_release(con)
+  adbcdrivermanager::adbc_database_release(db)
 })


### PR DESCRIPTION
Closes #1211.

It wasn't an external pointer issue, it was just not cleaning up properly in some tests. These tests were written before `with_adbc()` and `local_adbc()`...the tests for all the drivers could be refactored to use them (but perhaps not today).