### PR TITLE
feat(c/driver/sqlite): Support BLOB in result sets for SQLite

### DIFF
--- a/c/driver/sqlite/sqlite_test.cc
+++ b/c/driver/sqlite/sqlite_test.cc
@@ -249,7 +249,6 @@ class SqliteStatementTest : public ::testing::Test,
     return TestSqlIngestType(NANOARROW_TYPE_UINT64, values);
   }
 
-  void TestSqlIngestBinary() { GTEST_SKIP() << "Cannot ingest BINARY (not implemented)"; }
   void TestSqlIngestDuration() {
     GTEST_SKIP() << "Cannot ingest DURATION (not implemented)";
   }


### PR DESCRIPTION
It looks like the binding + ingest was supported already, it was just the result sets that were not supported.

From the R bindings:

``` r
library(adbcdrivermanager)

db <- adbc_database_init(adbcsqlite::adbcsqlite(), uri = ":memory:")
con <- adbc_connection_init(db)

read_adbc(con, "SELECT X'00' as a") |> 
  as.data.frame()
#>           a
#> 1 blob[1 B]
```

<sup>Created on 2023-10-25 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>