### PR TITLE
fix(go/adbc/driver/flightsql): take metadata lock for safety

### DIFF
--- a/go/adbc/driver/flightsql/flightsql_database.go
+++ b/go/adbc/driver/flightsql/flightsql_database.go
@@ -382,7 +382,8 @@ func getFlightClient(ctx context.Context, loc string, d *databaseImpl) (*flights
 		}
 
 		if md, ok := metadata.FromOutgoingContext(ctx); ok {
-			// No need to worry about lock here since we are sole owner
+			authMiddle.mutex.Lock()
+			defer authMiddle.mutex.Unlock()
 			authMiddle.hdrs.Set("authorization", md.Get("Authorization")[0])
 		}
 	}


### PR DESCRIPTION
Fixes #1178.