### PR TITLE
build(csharp): add Arrow as submodule proper for CSharp project

### DIFF
--- a/csharp/.gitignore
+++ b/csharp/.gitignore
@@ -27,6 +27,5 @@ x64
 *.csproj.user
 *.pass
 
-src/arrow
 artifacts/
 TestResults/


### PR DESCRIPTION
Can't build the C# project checking out from main directly at the moment.

README mentioned the submodule for Arrow and it's included in .gitmodules, but none of it works unless the csharp's .gitignore has src/arrow removed so that it isn't ignored, and the repo can actually pull the submodule into the expected directory path.