### PR TITLE
test(csharp/snowflake): Correct catalog field name in README, generify expected table name in CanClientExecuteUpdateUsingExecuteReader test

### DIFF
--- a/csharp/test/Drivers/Snowflake/ClientTests.cs
+++ b/csharp/test/Drivers/Snowflake/ClientTests.cs
@@ -84,7 +84,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
 
                     string[] queries = SnowflakeTestingUtils.GetQueries(testConfiguration);
 
-                    List<object> expectedResults = new List<object>() { "Table ADBC_ALLTYPES successfully created.", 1L, 1L };
+                    List<object> expectedResults = new List<object>() { string.Format("Table {0} successfully created.",testConfiguration.Metadata.Table), 1L, 1L };
 
                     for (int i = 0; i < queries.Length; i++)
                     {

--- a/csharp/test/Drivers/Snowflake/readme.md
+++ b/csharp/test/Drivers/Snowflake/readme.md
@@ -23,11 +23,11 @@ The Snowflake tests leverage the interop nature of the C# ADBC library. These re
 To compile, navigate to the `go/adbc/pkg` directory of the cloned [arrow-adbc](https://github.com/apache/arrow-adbc) repository then run the `make` command.  If you encounter compilation errors, please ensure that Go, [GCC and C++](https://code.visualstudio.com/docs/cpp/config-mingw) tools are installed. And following [Contributing to ADBC](https://github.com/apache/arrow-adbc/blob/main/CONTRIBUTING.md#environment-setup).
 
 ## Setup
-The environment variable `SNOWFLAKE_TEST_CONFIG_FILE` must be set to a configuration file for the tests to execute. If it is not, the tests will show as passed with an output message that they are skipped.
+The environment variable `SNOWFLAKE_TEST_CONFIG_FILE` must be set to a configuration JSON file for the tests to execute. If it is not, the tests will show as passed with an output message that they are skipped. A template configuration file can be found in the Resources directory.
 
 ## Configuration
 
-The following values can be setup in the configuration
+The following values can be setup in the configuration:
 
 - **driverPath** - The path for the Go library. Can be a relative path if using .NET 5.0 or greater, otherwise, it is an absolute path.
 - **driverEntryPoint** - The driver entry point. For Snowflake, this is `SnowflakeDriverInit`.
@@ -38,7 +38,7 @@ The following values can be setup in the configuration
 - **authenticationType** - The `adbc.snowflake.sql.auth_type` value from the [Snowflake Client Options](https://arrow.apache.org/adbc/0.5.1/driver/snowflake.html#client-options).
 - **authenticationTokenPath** - The path to the authentication token file, if using `auth_jwt` for the auth type.
 - metadata
-  - **database** - Used by metadata tests for which database to target.
+  - **catalog** - Used by metadata tests for which database to target.
   - **schema** - Used by metadata tests for which schema to target.
   - **table** - Used by metadata tests for which table to target.
   - **expectedColumnCount** - Used by metadata tests to validate the number of columns that are returned.


### PR DESCRIPTION
README currently lists the field name as "database", when it should be "catalog". Also add a few small notes that the config file is JSON and there's a template in resources to use.

CanClientExecuteUpdateUsingExecuteReader() currently has the table name ADBC_ALLTYPES hardcoded, ignoring the table value set in the configuration. It can be made to use the config table name instead.