### PR TITLE
chore(dev/release): default to python 3.11 for now

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -319,7 +319,9 @@ install_conda() {
 maybe_setup_conda() {
   # Optionally setup conda environment with the passed dependencies
   local env="conda-${CONDA_ENV:-source}"
-  local pyver=${PYTHON_VERSION:-3}
+  # XXX(https://github.com/apache/arrow-adbc/issues/1247): no duckdb for
+  # python 3.12 on conda-forge right now
+  local pyver=${PYTHON_VERSION:-3.11}
 
   if [ "${USE_CONDA}" -gt 0 ]; then
     show_info "Configuring Conda environment..."


### PR DESCRIPTION
Fixes #1247.