### PR TITLE
fix(r/adbcsqlite): Allow sqlite driver to link against sqlite3 that does not contain sqlite3_load_extension()

### DIFF
--- a/c/driver/sqlite/sqlite.c
+++ b/c/driver/sqlite/sqlite.c
@@ -325,7 +325,7 @@ AdbcStatusCode SqliteConnectionSetOption(struct AdbcConnection* connection,
     SetError(error,
              "[SQLite] This build of the ADBC SQLite driver does not support extension "
              "loading");
-    return ADBC_STATUS_INTERNAL;
+    return ADBC_STATUS_NOT_IMPLEMENTED;
 #endif
   }
   SetError(error, "[SQLite] Unknown connection option %s=%s", key,

--- a/c/driver/sqlite/sqlite.c
+++ b/c/driver/sqlite/sqlite.c
@@ -282,6 +282,7 @@ AdbcStatusCode SqliteConnectionSetOption(struct AdbcConnection* connection,
     }
     return ADBC_STATUS_OK;
   } else if (strcmp(key, kConnectionOptionLoadExtensionPath) == 0) {
+#if !defined(ADBC_SQLITE_WITH_NO_LOAD_EXTENSION)
     if (!conn->conn) {
       SetError(error, "[SQLite] %s can only be set after AdbcConnectionInit", key);
       return ADBC_STATUS_INVALID_STATE;
@@ -320,6 +321,12 @@ AdbcStatusCode SqliteConnectionSetOption(struct AdbcConnection* connection,
     free(conn->extension_path);
     conn->extension_path = NULL;
     return ADBC_STATUS_OK;
+#else
+    SetError(error,
+             "[SQLite] This build of the ADBC SQLite driver does not support extension "
+             "loading");
+    return ADBC_STATUS_INTERNAL;
+#endif
   }
   SetError(error, "[SQLite] Unknown connection option %s=%s", key,
            value ? value : "(NULL)");

--- a/c/driver/sqlite/sqlite.c
+++ b/c/driver/sqlite/sqlite.c
@@ -282,7 +282,6 @@ AdbcStatusCode SqliteConnectionSetOption(struct AdbcConnection* connection,
     }
     return ADBC_STATUS_OK;
   } else if (strcmp(key, kConnectionOptionLoadExtensionPath) == 0) {
-#if !defined(ADBC_SQLITE_WITH_NO_LOAD_EXTENSION)
     if (!conn->conn) {
       SetError(error, "[SQLite] %s can only be set after AdbcConnectionInit", key);
       return ADBC_STATUS_INVALID_STATE;
@@ -298,6 +297,7 @@ AdbcStatusCode SqliteConnectionSetOption(struct AdbcConnection* connection,
     conn->extension_path = strdup(value);
     return ADBC_STATUS_OK;
   } else if (strcmp(key, kConnectionOptionLoadExtensionEntrypoint) == 0) {
+#if !defined(ADBC_SQLITE_WITH_NO_LOAD_EXTENSION)
     if (!conn->conn) {
       SetError(error, "[SQLite] %s can only be set after AdbcConnectionInit", key);
       return ADBC_STATUS_INVALID_STATE;

--- a/r/adbcsqlite/configure
+++ b/r/adbcsqlite/configure
@@ -50,14 +50,19 @@ if [ $? -ne 0 ] || [ ! -z "$FORCE_VENDORED_SQLITE3" ]; then
 else
   echo "Success!"
   PKG_LIBS="$PKG_LIBS -lsqlite3"
-fi
 
-echo "Testing SQLite for sqlite3_load_extension()"
-PKG_CPPFLAGS="$PKG_CPPFLAGS" PKG_LIBS="$PKG_LIBS -lsqlite3" \
-  $R_HOME/bin/R CMD SHLIB tools/test_extension.c -o sqlite_test >sqlite_test.log 2>&1
+  # Apple -lsqlite3 does not contain sqlite3_load_extension()
+  echo "Testing SQLite for sqlite3_load_extension()"
+  PKG_CPPFLAGS="$PKG_CPPFLAGS" PKG_LIBS="$PKG_LIBS" \
+    $R_HOME/bin/R CMD SHLIB tools/test_extension.c -o sqlite_test >sqlite_test.log 2>&1
 
-if [ $? -ne 0 ]; then
-  PKG_CPPFLAGS="$PKG_CPPFLAGS -DADBC_SQLITE_WITH_NO_LOAD_EXTENSION"
+  if [ $? -ne 0 ]; then
+    echo "Compile of sqlite3_load_extension() test failed"
+    cat sqlite_test.log
+    PKG_CPPFLAGS="$PKG_CPPFLAGS -DADBC_SQLITE_WITH_NO_LOAD_EXTENSION"
+  else
+    echo "Success!"
+  fi
 fi
 
 # Add mingw printf flag if on Windows

--- a/r/adbcsqlite/configure
+++ b/r/adbcsqlite/configure
@@ -52,6 +52,14 @@ else
   PKG_LIBS="$PKG_LIBS -lsqlite3"
 fi
 
+echo "Testing SQLite for sqlite3_load_extension()"
+PKG_CPPFLAGS="$PKG_CPPFLAGS" PKG_LIBS="$PKG_LIBS -lsqlite3" \
+  $R_HOME/bin/R CMD SHLIB tools/test_extension.c -o sqlite_test >sqlite_test.log 2>&1
+
+if [ $? -ne 0 ]; then
+  PKG_CPPFLAGS="$PKG_CPPFLAGS -DADBC_SQLITE_WITH_NO_LOAD_EXTENSION"
+fi
+
 # Add mingw printf flag if on Windows
 if [ ! -z "$R_ADBC_SQLITE_ON_WINDOWS" ]; then
   PKG_CPPFLAGS="$PKG_CPPFLAGS -D__USE_MINGW_ANSI_STDIO"

--- a/r/adbcsqlite/tools/test_extension.c
+++ b/r/adbcsqlite/tools/test_extension.c
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <sqlite3.h>
+
+void try_load_extension() { sqlite3_load_extension(NULL, NULL, NULL, NULL); }

--- a/r/adbcsqlite/tools/test_extension.c
+++ b/r/adbcsqlite/tools/test_extension.c
@@ -16,5 +16,6 @@
 // under the License.
 
 #include <sqlite3.h>
+#include <stddef.h>
 
 void try_load_extension() { sqlite3_load_extension(NULL, NULL, NULL, NULL); }


### PR DESCRIPTION
Closes #1255.