### PR TITLE
feat(r/adbcdrivermanager): Add support for setting option as logical

### DIFF
--- a/r/adbcdrivermanager/R/options.R
+++ b/r/adbcdrivermanager/R/options.R
@@ -214,6 +214,8 @@ key_value_options <- function(options) {
       out[[n_out]] <- as.double(item)
     } else if (is.raw(item)) {
       out[[n_out]] <- item
+    } else if (is.logical(item)) {
+      out[[n_out]] <- tolower(as.character(item))
     } else {
       stop(
         sprintf(

--- a/r/adbcdrivermanager/tests/testthat/test-options.R
+++ b/r/adbcdrivermanager/tests/testthat/test-options.R
@@ -321,6 +321,12 @@ test_that("key_value_options works", {
     structure(list("key" = as.raw(c(0x01, 0x05))), class = "adbc_options")
   )
 
+  # Logical becomes "true" or "false"
+  expect_identical(
+    key_value_options(list("key" = TRUE, "key2" = FALSE)),
+    structure(list("key" = "true", "key2" = "false"), class = "adbc_options")
+  )
+
   # S3 objects converted to strings
   expect_identical(
     key_value_options(list("key" = as.Date("2000-01-01"))),


### PR DESCRIPTION
This enables code like `adbc_connection_set_options(con, adbc.connection.autocommit = TRUE)`, which previously failed.