### PR TITLE
feat(c/driver/postgresql): Accept bulk ingest of dictionary-encoded strings/binary

### DIFF
--- a/c/driver/postgresql/postgres_type.h
+++ b/c/driver/postgresql/postgres_type.h
@@ -521,6 +521,9 @@ inline ArrowErrorCode PostgresType::FromSchema(const PostgresTypeResolver& resol
           PostgresType::FromSchema(resolver, schema->children[0], &child, error));
       return resolver.FindArray(child.oid(), out, error);
     }
+    case NANOARROW_TYPE_DICTIONARY:
+      // Dictionary arrays always resolve to the dictionary type when binding or ingesting
+      return PostgresType::FromSchema(resolver, schema->dictionary, out, error);
 
     default:
       ArrowErrorSet(error, "Can't map Arrow type '%s' to Postgres type",

--- a/c/driver/postgresql/postgres_type_test.cc
+++ b/c/driver/postgresql/postgres_type_test.cc
@@ -279,6 +279,15 @@ TEST(PostgresTypeTest, PostgresTypeFromSchema) {
   EXPECT_EQ(type.child(0).type_id(), PostgresTypeId::kBool);
   schema.reset();
 
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_INT64), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaAllocateDictionary(schema.get()), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInitFromType(schema->dictionary, NANOARROW_TYPE_STRING),
+            NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kText);
+  schema.reset();
+
   ArrowError error;
   ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO),
             NANOARROW_OK);

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -820,7 +820,6 @@ class PostgresStatementTest : public ::testing::Test,
   void TestSqlIngestUInt16() { GTEST_SKIP() << "Not implemented"; }
   void TestSqlIngestUInt32() { GTEST_SKIP() << "Not implemented"; }
   void TestSqlIngestUInt64() { GTEST_SKIP() << "Not implemented"; }
-  void TestSqlIngestStringDictionary() { GTEST_SKIP() << "Not implemented"; }
 
   void TestSqlPrepareErrorParamCountMismatch() { GTEST_SKIP() << "Not yet implemented"; }
   void TestSqlPrepareGetParameterSchema() { GTEST_SKIP() << "Not yet implemented"; }


### PR DESCRIPTION
This PR adds the ability for the Postgres driver to ingest dictionary-encoded arrays. This shows up in R because factors are relatively common and encode by default in Arrow to dictionary-encoded string for performance reasons.

Reprex in R:

``` r
library(adbcdrivermanager)

con <- adbcpostgresql::adbcpostgresql() |> 
  adbc_database_init(uri = Sys.getenv("ADBC_POSTGRESQL_TEST_URI")) |> 
  adbc_connection_init()

df <- data.frame(x = letters, y = factor(letters))
write_adbc(df, con, "some_table")
#> Error in adbc_statement_execute_query(stmt): [libpq] Failed to create table: ERROR:  relation "some_table" already exists
#> 
#> Query was: CREATE TABLE "public" . "some_table" ("x" TEXT, "y" TEXT)
read_adbc(con, "SELECT * from some_table") |> 
  as.data.frame() |> 
  str()
#> 'data.frame':    26 obs. of  2 variables:
#>  $ x: chr  "a" "b" "c" "d" ...
#>  $ y: chr  "a" "b" "c" "d" ...
```

<sup>Created on 2023-11-09 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

There is probably some opportunity to consolidate some of the code that currently lives in the `BindStream` into the `PostgresType` and/or `PostgresTypeResolver`...I'm happy to poke away at that at some point but in the meantime it seemed like it wasn't too onerous to tack on dictionary support here.