### PR TITLE
fix(csharp): fix timestamp case in AdbcStatement.GetValue

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/AdbcStatement.cs
+++ b/csharp/src/Apache.Arrow.Adbc/AdbcStatement.cs
@@ -186,8 +186,7 @@ namespace Apache.Arrow.Adbc
                 case Time64Array time64Array:
                     return time64Array.GetValue(index);
                 case TimestampArray timestampArray:
-                    DateTimeOffset dateTimeOffset = timestampArray.GetTimestamp(index).Value;
-                    return dateTimeOffset;
+                    return timestampArray.GetTimestamp(index);
                 case UInt8Array uInt8Array:
                     return uInt8Array.GetValue(index);
                 case UInt16Array uInt16Array:


### PR DESCRIPTION
Fixes #1278