### PR TITLE
Statement add new API for execute to clean Vala/GObject API

### DIFF
--- a/glib/adbc-glib/meson.build
+++ b/glib/adbc-glib/meson.build
@@ -63,6 +63,7 @@ install_headers(headers, subdir: project_include_sub_dir)
 gobject = dependency('gobject-2.0')
 dependencies = [
   adbc_driver_manager,
+  arrow_glib,
   gobject,
 ]
 libadbc_glib = library('adbc-glib',

--- a/glib/adbc-glib/meson.build
+++ b/glib/adbc-glib/meson.build
@@ -95,10 +95,16 @@ adbc_glib_gir = gnome.generate_gir(libadbc_glib,
                                    header: 'adbc-glib/adbc-glib.h',
                                    identifier_prefix: 'GADBC',
                                    includes: [
-                                     'GObject-2.0',
+                                     'GObject-2.0', 'Arrow-1.0'
                                    ],
                                    install: true,
                                    namespace: 'ADBC',
                                    nsversion: api_version,
                                    sources: sources + definition_headers + enums,
                                    symbol_prefix: 'gadbc')
+if generate_vapi
+  adbc_glib_vapi = gnome.generate_vapi('adbc-glib',
+                                  install: true,
+                                  packages: ['gobject-2.0', 'arrow-glib'],
+                                  sources: [adbc_glib_gir[0]])
+endif

--- a/glib/adbc-glib/statement.c
+++ b/glib/adbc-glib/statement.c
@@ -268,10 +268,10 @@ gboolean gadbc_statement_prepare(GADBCStatement* statement, GError** error) {
 /**
  * gadbc_statement_bind:
  * @statement: A #GADBCStatement.
- * @c_abi_array: A `struct ArrowArray *` of a record batch to
+ * @c_abi_array: (out) (type Arrow.Array): A `struct ArrowArray *` of a record batch to
  *   bind. The driver will call the release callback itself, although
  *   it may not do this until the statement is released.
- * @c_abi_schema: A `struct ArrowSchema *` of @c_abi_array.
+ * @c_abi_schema: (out) (type Arrow.Schema): A `struct ArrowSchema *` of @c_abi_array.
  * @error: (out) (optional): Return location for a #GError or %NULL.
  *
  * Bind Arrow data. This can be used for bulk inserts or prepared
@@ -299,7 +299,7 @@ gboolean gadbc_statement_bind(GADBCStatement* statement, gpointer c_abi_array,
 /**
  * gadbc_statement_bind_stream:
  * @statement: A #GADBCStatement.
- * @c_abi_array_stream: A `struct ArrowArrayStream *` of record batches stream
+ * @c_abi_array_stream: (out) (type Arrow.InputStream): A `struct ArrowArrayStream *` of record batches stream
  *   to bind. The driver will call the release callback itself, although
  *   it may not do this until the statement is released.
  * @error: (out) (optional): Return location for a #GError or %NULL.
@@ -331,7 +331,7 @@ gboolean gadbc_statement_bind_stream(GADBCStatement* statement,
  * @statement: A #GADBCStatement.
  * @need_result: Whether the results are received by @c_abi_arrray_stream or
  *   not.
- * @c_abi_array_stream: (out) (optional): Return location for the execution as
+ * @c_abi_array_stream: (out) (optional) (type Arrow.InputStream): Return location for the execution as
  *   `struct ArrowArrayStream *`. It should be freed with the
  *   `ArrowArrayStream::release` callback then g_free() when no longer needed.
  * @n_rows_affected: (out) (optional): Return location for the number of rows

--- a/glib/adbc-glib/statement.h
+++ b/glib/adbc-glib/statement.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <adbc-glib/connection.h>
+#include <arrow-glib/arrow-glib.h>
 
 G_BEGIN_DECLS
 
@@ -74,6 +75,13 @@ gboolean gadbc_statement_bind_stream(GADBCStatement* statement,
 GADBC_AVAILABLE_IN_0_1
 gboolean gadbc_statement_execute(GADBCStatement* statement, gboolean need_result,
                                  gpointer* c_abi_array_stream, gint64* n_rows_affected,
+                                 GError** error);
+// GADBC_AVAILABLE_IN_0_8
+gboolean gadbc_statement_execute_query(GADBCStatement* statement, gint64* n_rows_affected,
+                                 GError** error);
+// GADBC_AVAILABLE_IN_0_8
+GArrowRecordBatchReader*
+gadbc_statement_execute_reader(GADBCStatement* statement,
                                  GError** error);
 
 G_END_DECLS

--- a/glib/example/README.md
+++ b/glib/example/README.md
@@ -1,0 +1,32 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# ADBC GLib example
+
+There are example codes in this directory.
+
+C example codes exist in this directory. Language bindings example
+codes exists in sub directories. For example, Vala example codes exists
+in `vala/` sub directory.
+
+## C example codes
+
+Here are example codes in this directory:
+
+  * `sqlite.c`: It shows how to connect to a database using SQLite.

--- a/glib/example/meson.build
+++ b/glib/example/meson.build
@@ -17,12 +17,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option('adbc_build_dir',
-       type: 'string',
-       value: '',
-       description: 'Use this option to build with not installed ADBC')
+arrow_glib = dependency('arrow-glib')
 
-option('vapi',
-       type: 'boolean',
-       value: false,
-       description: 'Build Vala API')
+executable('sqlite', 'sqlite.c',
+           dependencies: [adbc_glib, arrow_glib],
+           link_language: 'c')
+
+install_data('README.md',
+             install_dir: join_paths(data_dir, meson.project_name(), 'example'))
+
+subdir('vala')

--- a/glib/example/meson.build
+++ b/glib/example/meson.build
@@ -17,8 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-arrow_glib = dependency('arrow-glib')
-
 executable('sqlite', 'sqlite.c',
            dependencies: [adbc_glib, arrow_glib],
            link_language: 'c')

--- a/glib/example/sqlite.c
+++ b/glib/example/sqlite.c
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdlib.h>
+
+#include <adbc-glib/adbc-glib.h>
+#include <arrow-glib/arrow-glib.h>
+
+int main(int argc, char** argv) {
+  GADBCDatabase* database;
+  GADBCConnection* conn;
+  GError* error = NULL;
+  database = gadbc_database_new(&error);
+  if (!database) {
+    g_print("Error creating a Database: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+
+  if (!gadbc_database_set_option(database, "driver", "adbc_driver_sqlite", &error)) {
+    g_print("Error initializing the database: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+  if (!gadbc_database_set_option(database, "uri", "test.db", &error)) {
+    g_print("Error initializing the database: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+  if (!gadbc_database_init(database, &error)) {
+    g_print("Error initializing the database: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+
+  conn = gadbc_connection_new(&error);
+  if (!conn) {
+    g_print("Error creating a Connection: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    g_object_unref(conn);
+    return EXIT_FAILURE;
+  }
+  if (!gadbc_connection_init(conn, database, &error)) {
+    g_print("Error initializing a Connection: %s", error->message);
+    g_error_free(error);
+    g_object_unref(database);
+    g_object_unref(conn);
+    return EXIT_FAILURE;
+  }
+
+  GADBCStatement* statement = gadbc_statement_new(conn, &error);
+  if (!statement) {
+    g_print("Error initializing a statement: %s", error->message);
+    g_error_free(error);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+  if (!gadbc_statement_set_sql_query(statement, "select sqlite_version() as version",
+                                     &error)) {
+    g_print("Error setting a query: %s", error->message);
+    g_error_free(error);
+    g_object_unref(statement);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+
+  gpointer c_abi_array_stream;
+  gint64 n_rows_affected;
+  if (!gadbc_statement_execute(statement, TRUE, &c_abi_array_stream, &n_rows_affected,
+                               &error)) {
+    g_print("Error executing a query: %s", error->message);
+    g_error_free(error);
+    g_object_unref(statement);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+
+  GArrowRecordBatchReader* reader =
+      garrow_record_batch_reader_import(c_abi_array_stream, &error);
+  g_free(c_abi_array_stream);
+  if (!reader) {
+    g_print("Error importing a result: %s", error->message);
+    g_error_free(error);
+    g_object_unref(statement);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+
+  GArrowTable* table = garrow_record_batch_reader_read_all(reader, &error);
+  g_object_unref(reader);
+  if (!table) {
+    g_print("Error reading a result: %s", error->message);
+    g_error_free(error);
+    g_object_unref(statement);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+  gchar* table_content = garrow_table_to_string(table, &error);
+  g_object_unref(table);
+  if (!table_content) {
+    g_print("Error stringify a result: %s", error->message);
+    g_error_free(error);
+    g_object_unref(statement);
+    g_object_unref(conn);
+    g_object_unref(database);
+    return EXIT_FAILURE;
+  }
+  g_print("Result:\n%s\n", table_content);
+  g_free(table_content);
+  gadbc_statement_release(statement, &error);
+  if (error) {
+    g_print("Error releasing a statement: %s", error->message);
+    g_error_free(error);
+    error = NULL;
+  }
+  g_object_unref(statement);
+  g_object_unref(conn);
+  g_object_unref(database);
+
+  return EXIT_SUCCESS;
+}

--- a/glib/example/sqlite.c
+++ b/glib/example/sqlite.c
@@ -87,11 +87,10 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  gpointer c_abi_array_stream;
   gint64 n_rows_affected;
-  if (!gadbc_statement_execute(statement, TRUE, &c_abi_array_stream, &n_rows_affected,
+  if (!gadbc_statement_execute_query(statement, &n_rows_affected,
                                &error)) {
-    g_print("Error executing a query: %s", error->message);
+    g_print("Error executing a query ingnoring results: %s", error->message);
     g_error_free(error);
     g_object_unref(statement);
     g_object_unref(conn);
@@ -99,9 +98,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  GArrowRecordBatchReader* reader =
-      garrow_record_batch_reader_import(c_abi_array_stream, &error);
-  g_free(c_abi_array_stream);
+  GArrowRecordBatchReader* reader = gadbc_statement_execute_reader(statement, &error);
   if (!reader) {
     g_print("Error importing a result: %s", error->message);
     g_error_free(error);

--- a/glib/example/vala/README.md
+++ b/glib/example/vala/README.md
@@ -1,0 +1,36 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# ADBC GLib Vala example
+
+There are Vala example codes in this directory.
+
+## How to build
+
+Here is a command line to build an example in this directory:
+
+```console
+$ valac --pkg adbc-glib --pkg posix XXX.vala
+```
+
+## GLib Vala example codes
+
+Here are example codes in this directory:
+
+  * `sqlite.vala`: It shows how to connect to a SQLite database.

--- a/glib/example/vala/meson.build
+++ b/glib/example/vala/meson.build
@@ -29,7 +29,7 @@ if generate_vapi
       dependency('gobject-2.0'),
     ],
     'vala_args': [
-      '--pkg', 'posix',
+      '--pkg', 'posix', '--disable-since-check'
     ],
   }
   executable('sqlite', 'sqlite.vala',

--- a/glib/example/vala/meson.build
+++ b/glib/example/vala/meson.build
@@ -17,12 +17,27 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option('adbc_build_dir',
-       type: 'string',
-       value: '',
-       description: 'Use this option to build with not installed ADBC')
+if generate_vapi
+  vala_example_executable_kwargs = {
+    'c_args': [
+      '-I' + meson.build_root(),
+      '-I' + meson.source_root(),
+    ],
+    'dependencies': [
+      adbc_glib_vapi,
+      arrow_glib,
+      dependency('gobject-2.0'),
+    ],
+    'vala_args': [
+      '--pkg', 'posix',
+    ],
+  }
+  executable('sqlite', 'sqlite.vala',
+             kwargs: vala_example_executable_kwargs)
+endif
 
-option('vapi',
-       type: 'boolean',
-       value: false,
-       description: 'Build Vala API')
+install_data('README.md',
+             install_dir: join_paths(data_dir,
+                                     meson.project_name(),
+                                     'example',
+                                     'vala'))

--- a/glib/example/vala/sqlite.vala
+++ b/glib/example/vala/sqlite.vala
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+int main (string[] args) {
+  try {
+    var database = new GADBC.Database ();
+    database.set_option ("driver", "adbc_driver_sqlite");
+    database.set_option ("uri", "test.sqlite");
+    database.init ();
+    GLib.message ("Database initialization done...");
+    try {
+      var conn = new GADBC.Connection ();
+      conn.init (database);
+      GLib.message ("Connection to database initialized...");
+      try {
+        var stm = new GADBC.Statement (conn);
+        string sql = "SELECT sqlite_version() AS version";
+        stm.set_sql_query (sql);
+        void *c_abi_array_stream = null;
+        stm.execute (true, out c_abi_array_stream, null);
+        try {
+            GLib.message ("Statement executed: %s", sql);
+            var reader = GArrow.RecordBatchReader.import (c_abi_array_stream);
+            var table = reader.read_all ();
+            GLib.message ("Executed result: %s", table.to_string ());
+        } finally {
+            GLib.free (c_abi_array_stream);
+        }
+      GLib.message ("Statement executed: %s", sql);
+      }
+      catch (GLib.Error e) {
+        GLib.message ("Error executing statement: %s", e.message);
+      }
+    }
+    catch (GLib.Error e) {
+      GLib.message ("Error initializing the connection: %s", e.message);
+    }
+  }
+  catch (GLib.Error e) {
+    GLib.message ("Error initializing the database: %s", e.message);
+  }
+
+  return Posix.EXIT_SUCCESS;
+}

--- a/glib/example/vala/sqlite.vala
+++ b/glib/example/vala/sqlite.vala
@@ -31,17 +31,10 @@ int main (string[] args) {
         var stm = new GADBC.Statement (conn);
         string sql = "SELECT sqlite_version() AS version";
         stm.set_sql_query (sql);
-        void *c_abi_array_stream = null;
-        stm.execute (true, out c_abi_array_stream, null);
-        try {
-            GLib.message ("Statement executed: %s", sql);
-            var reader = GArrow.RecordBatchReader.import (c_abi_array_stream);
-            var table = reader.read_all ();
-            GLib.message ("Executed result: %s", table.to_string ());
-        } finally {
-            GLib.free (c_abi_array_stream);
-        }
-      GLib.message ("Statement executed: %s", sql);
+        GArrow.RecordBatchReader reader = stm.execute_reader ();
+        GLib.message ("Statement executed: %s", sql);
+        var table = reader.read_all ();
+        GLib.message ("Read result: %s", table.to_string ());
       }
       catch (GLib.Error e) {
         GLib.message ("Error executing statement: %s", e.message);

--- a/glib/meson.build
+++ b/glib/meson.build
@@ -30,7 +30,7 @@ version_major = version_numbers[0].to_int()
 version_minor = version_numbers[1].to_int()
 version_micro = version_numbers[2].to_int()
 
-api_version = '@0@.0'.format(version_major)
+api_version = '1.0'
 so_version = version_major
 library_version = '.'.join(version_numbers)
 
@@ -39,6 +39,7 @@ include_dir = get_option('includedir')
 project_include_sub_dir = meson.project_name()
 data_dir = get_option('datadir')
 gir_dir = prefix / data_dir / 'gir-1.0'
+vapi_dir = data_dir / 'vala' / 'vapi'
 
 gnome = import('gnome')
 pkgconfig = import('pkgconfig')
@@ -67,7 +68,15 @@ else
                                                 dirs: [adbc_build_dir])
 endif
 
+dependency('gobject-introspection-1.0', required: false).found()
+generate_vapi = get_option('vapi')
+if generate_vapi
+  pkgconfig_variables += ['vapidir=@0@'.format(vapi_dir)]
+  add_languages('vala')
+endif
+
 subdir('adbc-glib')
+subdir('example')
 
 install_data('../LICENSE.txt',
              'README.md',

--- a/glib/meson.build
+++ b/glib/meson.build
@@ -68,6 +68,8 @@ else
                                                 dirs: [adbc_build_dir])
 endif
 
+arrow_glib = dependency('arrow-glib')
+
 dependency('gobject-introspection-1.0', required: false).found()
 generate_vapi = get_option('vapi')
 if generate_vapi


### PR DESCRIPTION
Currently `Statement.execute()` use `void *` to pass a `ArrowArrayStream`, which in turn is not defined in GLib Arrow, also this force manual memory management when using Vala, so this new methods, clean up the way to better use on Vala and GLib/GObject

This is depends on #1152 