### PR TITLE
feat(go/adbc/drivermgr): Implement GetObjects for CGO Wrapper

### DIFF
--- a/go/adbc/drivermgr/wrapper_sqlite_test.go
+++ b/go/adbc/drivermgr/wrapper_sqlite_test.go
@@ -52,12 +52,17 @@ func (dm *DriverMgrSuite) SetupSuite() {
 		"driver": "adbc_driver_sqlite",
 	})
 	dm.NoError(err)
+
 	db, err := dm.db.Open(dm.ctx)
 	dm.NoError(err)
+	defer db.Close()
+
 	stmt, err := db.NewStatement()
 	dm.NoError(err)
+
 	err = stmt.SetSqlQuery("CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT)")
 	dm.NoError(err)
+
 	nrows, err := stmt.ExecuteUpdate(dm.ctx)
 	dm.NoError(err)
 	dm.Equal(int64(0), nrows)
@@ -159,6 +164,7 @@ func (dm *DriverMgrSuite) TestGetObjects() {
 					]
 				}
 			]`))
+	dm.NoError(err)
 	dm.Truef(array.RecordEqual(expRec, rec), "expected: %s\ngot: %s", expRec, rec)
 	dm.False(rdr.Next())
 }
@@ -203,6 +209,7 @@ func (dm *DriverMgrSuite) TestGetObjectsTableType() {
 					]
 				}
 			]`))
+	dm.NoError(err)
 	dm.Truef(array.RecordEqual(expRec, rec), "expected: %s\ngot: %s", expRec, rec)
 	dm.False(rdr.Next())
 }

--- a/go/adbc/drivermgr/wrapper_sqlite_test.go
+++ b/go/adbc/drivermgr/wrapper_sqlite_test.go
@@ -59,6 +59,7 @@ func (dm *DriverMgrSuite) SetupSuite() {
 
 	stmt, err := db.NewStatement()
 	dm.NoError(err)
+	defer stmt.Close()
 
 	err = stmt.SetSqlQuery("CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT)")
 	dm.NoError(err)

--- a/go/adbc/drivermgr/wrapper_sqlite_test.go
+++ b/go/adbc/drivermgr/wrapper_sqlite_test.go
@@ -166,6 +166,8 @@ func (dm *DriverMgrSuite) TestGetObjects() {
 				}
 			]`))
 	dm.NoError(err)
+	defer expRec.Release()
+
 	dm.Truef(array.RecordEqual(expRec, rec), "expected: %s\ngot: %s", expRec, rec)
 	dm.False(rdr.Next())
 }
@@ -211,6 +213,8 @@ func (dm *DriverMgrSuite) TestGetObjectsTableType() {
 				}
 			]`))
 	dm.NoError(err)
+	defer expRec.Release()
+
 	dm.Truef(array.RecordEqual(expRec, rec), "expected: %s\ngot: %s", expRec, rec)
 	dm.False(rdr.Next())
 }


### PR DESCRIPTION
# What?
Add implementation for `GetObjects` in CGO wrapper for `adbc_driver_manager`

# Why?
Functionality exists in C++ driver manager but not yet accessible via Go driver interface.

# Notes
I haven't worked with CGO before so I wanted to limit the scope of this PR to just one of the unimplemented methods in the wrapper. I would like to continue implementing the other methods once I know I'm going about this correctly.

Closes part of #1291