### PR TITLE
fix(glib): Vala's vapi's name should be same as pkg-config package

### DIFF
--- a/glib/adbc-glib/meson.build
+++ b/glib/adbc-glib/meson.build
@@ -103,7 +103,7 @@ adbc_glib_gir = gnome.generate_gir(libadbc_glib,
                                    sources: sources + definition_headers + enums,
                                    symbol_prefix: 'gadbc')
 if generate_vapi
-  adbc_glib_vapi = gnome.generate_vapi('gadbc-1.0',
+  adbc_glib_vapi = gnome.generate_vapi('adbc-glib',
                                        install: true,
                                        packages: ['gobject-2.0'],
                                        sources: [adbc_glib_gir[0]])


### PR DESCRIPTION
In sync with arrow-glib, GADBC should name its Vala's VAPI file's name to adbc-glib and is the same as the pkg-config adbc-glib.pc file's name