### PR TITLE
test(csharp): add more tests for verifying GetObjects (Depths and Patterns)

### DIFF
--- a/csharp/test/Apache.Arrow.Adbc.Tests/Metadata/GetObjectsParser.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/Metadata/GetObjectsParser.cs
@@ -52,6 +52,8 @@ namespace Apache.Arrow.Adbc.Tests.Metadata
 
         private static List<AdbcDbSchema> ParseDbSchema(StructArray dbSchemaArray, string schemaName)
         {
+            if (dbSchemaArray == null) return null;
+
             StringArray schemaNameArray = (StringArray)dbSchemaArray.Fields[0]; // db_schema_name
             ListArray tablesArray = (ListArray)dbSchemaArray.Fields[1]; // db_schema_tables
 
@@ -71,6 +73,8 @@ namespace Apache.Arrow.Adbc.Tests.Metadata
 
         private static List<AdbcTable> ParseTables(StructArray tablesArray)
         {
+            if (tablesArray == null) return null;
+
             StringArray tableNameArray = (StringArray)tablesArray.Fields[0]; // table_name
             StringArray tableTypeArray = (StringArray)tablesArray.Fields[1]; // table_type
             ListArray columnsArray = (ListArray)tablesArray.Fields[2]; // table_columns
@@ -93,6 +97,8 @@ namespace Apache.Arrow.Adbc.Tests.Metadata
 
         private static List<AdbcColumn> ParseColumns(StructArray columnsArray)
         {
+            if (columnsArray == null) return null;
+
             List<AdbcColumn> columns = new List<AdbcColumn>();
 
             StringArray column_name = (StringArray)columnsArray.Fields[StandardSchemas.ColumnSchema.FindIndex(f => f.Name == "column_name")]; // column_name | utf8 not null

--- a/csharp/test/Drivers/Snowflake/DriverTests.cs
+++ b/csharp/test/Drivers/Snowflake/DriverTests.cs
@@ -112,10 +112,266 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
         }
 
         /// <summary>
-        /// Validates if the driver can call GetObjects.
+        /// Validates if the driver can call GetObjects with GetObjectsDepth as Catalogs.
         /// </summary>
         [SkippableFact, Order(3)]
-        public void CanGetObjects()
+        public void CanGetObjectsCatalogs()
+        {
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+
+            SnowflakeTestConfiguration testConfiguration = Utils.LoadTestConfiguration<SnowflakeTestConfiguration>(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE);
+
+            AdbcDriver driver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(testConfiguration, out parameters);
+
+            string databaseName = testConfiguration.Metadata.Catalog;
+            string schemaName = testConfiguration.Metadata.Schema;
+
+            parameters[SnowflakeParameters.DATABASE] = databaseName;
+            parameters[SnowflakeParameters.SCHEMA] = schemaName;
+
+            AdbcDatabase adbcDatabase = driver.Open(parameters);
+            AdbcConnection adbcConnection = adbcDatabase.Connect(new Dictionary<string, string>());
+
+            IArrowArrayStream stream = adbcConnection.GetObjects(
+                    depth: AdbcConnection.GetObjectsDepth.Catalogs,
+                    catalogPattern: databaseName,
+                    dbSchemaPattern: null,
+                    tableNamePattern: null,
+                    tableTypes: new List<string> { "BASE TABLE", "VIEW" },
+                    columnNamePattern: null);
+
+            RecordBatch recordBatch = stream.ReadNextRecordBatchAsync().Result;
+
+            List<AdbcCatalog> catalogs = GetObjectsParser.ParseCatalog(recordBatch, databaseName, null);
+
+            AdbcCatalog catalog = catalogs.FirstOrDefault();
+
+            Assert.True(catalog != null, "catalog should not be null");
+            Assert.Equal(databaseName, catalog.Name);
+        }
+
+        /// <summary>
+        /// Validates if the driver can call GetObjects with GetObjectsDepth as Catalogs and CatalogName passed as a pattern.
+        /// </summary>
+        [SkippableFact, Order(3)]
+        public void CanGetObjectsCatalogsWithPattern()
+        {
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+
+            SnowflakeTestConfiguration testConfiguration = Utils.LoadTestConfiguration<SnowflakeTestConfiguration>(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE);
+
+            AdbcDriver driver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(testConfiguration, out parameters);
+
+            string databaseName = testConfiguration.Metadata.Catalog;
+            string schemaName = testConfiguration.Metadata.Schema;
+            string partialDatabaseName = $"{GetPartialNameForPatternMatch(databaseName)}%";
+
+            parameters[SnowflakeParameters.DATABASE] = databaseName;
+            parameters[SnowflakeParameters.SCHEMA] = schemaName;
+
+            AdbcDatabase adbcDatabase = driver.Open(parameters);
+            AdbcConnection adbcConnection = adbcDatabase.Connect(new Dictionary<string, string>());
+
+            IArrowArrayStream stream = adbcConnection.GetObjects(
+                    depth: AdbcConnection.GetObjectsDepth.Catalogs,
+                    catalogPattern: partialDatabaseName,
+                    dbSchemaPattern: null,
+                    tableNamePattern: null,
+                    tableTypes: new List<string> { "BASE TABLE", "VIEW" },
+                    columnNamePattern: null);
+
+            RecordBatch recordBatch = stream.ReadNextRecordBatchAsync().Result;
+
+            List<AdbcCatalog> catalogs = GetObjectsParser.ParseCatalog(recordBatch, databaseName, null);
+
+            AdbcCatalog catalog = catalogs.FirstOrDefault();
+
+            Assert.True(catalog != null, "catalog should not be null");
+        }
+
+        /// <summary>
+        /// Validates if the driver can call GetObjects with GetObjectsDepth as DbSchemas.
+        /// </summary>
+        [SkippableFact, Order(3)]
+        public void CanGetObjectsDbSchemas()
+        {
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+
+            SnowflakeTestConfiguration testConfiguration = Utils.LoadTestConfiguration<SnowflakeTestConfiguration>(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE);
+
+            AdbcDriver driver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(testConfiguration, out parameters);
+
+            // need to add the database
+            string databaseName = testConfiguration.Metadata.Catalog;
+            string schemaName = testConfiguration.Metadata.Schema;
+
+            parameters[SnowflakeParameters.DATABASE] = databaseName;
+            parameters[SnowflakeParameters.SCHEMA] = schemaName;
+
+            AdbcDatabase adbcDatabase = driver.Open(parameters);
+            AdbcConnection adbcConnection = adbcDatabase.Connect(new Dictionary<string, string>());
+
+            IArrowArrayStream stream = adbcConnection.GetObjects(
+                    depth: AdbcConnection.GetObjectsDepth.DbSchemas,
+                    catalogPattern: databaseName,
+                    dbSchemaPattern: schemaName,
+                    tableNamePattern: null,
+                    tableTypes: new List<string> { "BASE TABLE", "VIEW" },
+                    columnNamePattern: null);
+
+            RecordBatch recordBatch = stream.ReadNextRecordBatchAsync().Result;
+
+            List<AdbcCatalog> catalogs = GetObjectsParser.ParseCatalog(recordBatch, databaseName, schemaName);
+
+            List<AdbcDbSchema> dbSchemas = catalogs
+                .Select(s => s.DbSchemas)
+                .FirstOrDefault();
+            AdbcDbSchema dbSchema = dbSchemas.FirstOrDefault();
+
+            Assert.True(dbSchema != null, "dbSchema should not be null");
+            Assert.Equal(schemaName, dbSchema.Name);
+        }
+
+        /// <summary>
+        /// Validates if the driver can call GetObjects with GetObjectsDepth as DbSchemas with DbSchemaName as a pattern.
+        /// </summary>
+        [SkippableFact, Order(3)]
+        public void CanGetObjectsDbSchemasWithPattern()
+        {
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+
+            SnowflakeTestConfiguration testConfiguration = Utils.LoadTestConfiguration<SnowflakeTestConfiguration>(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE);
+
+            AdbcDriver driver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(testConfiguration, out parameters);
+
+            // need to add the database
+            string databaseName = testConfiguration.Metadata.Catalog;
+            string schemaName = testConfiguration.Metadata.Schema;
+            string partialSchemaName = $"{GetPartialNameForPatternMatch(schemaName)}%";
+
+            parameters[SnowflakeParameters.DATABASE] = databaseName;
+            parameters[SnowflakeParameters.SCHEMA] = schemaName;
+
+            AdbcDatabase adbcDatabase = driver.Open(parameters);
+            AdbcConnection adbcConnection = adbcDatabase.Connect(new Dictionary<string, string>());
+
+            IArrowArrayStream stream = adbcConnection.GetObjects(
+                    depth: AdbcConnection.GetObjectsDepth.DbSchemas,
+                    catalogPattern: databaseName,
+                    dbSchemaPattern: partialSchemaName,
+                    tableNamePattern: null,
+                    tableTypes: new List<string> { "BASE TABLE", "VIEW" },
+                    columnNamePattern: null);
+
+            RecordBatch recordBatch = stream.ReadNextRecordBatchAsync().Result;
+
+            List<AdbcCatalog> catalogs = GetObjectsParser.ParseCatalog(recordBatch, databaseName, schemaName);
+
+            List<AdbcDbSchema> dbSchemas = catalogs
+                .Select(s => s.DbSchemas)
+                .FirstOrDefault();
+            AdbcDbSchema dbSchema = dbSchemas.FirstOrDefault();
+
+            Assert.True(dbSchema != null, "dbSchema should not be null");
+        }
+
+        /// <summary>
+        /// Validates if the driver can call GetObjects with GetObjectsDepth as Tables.
+        /// </summary>
+        [SkippableFact, Order(3)]
+        public void CanGetObjectsTables()
+        {
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+
+            SnowflakeTestConfiguration testConfiguration = Utils.LoadTestConfiguration<SnowflakeTestConfiguration>(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE);
+
+            AdbcDriver driver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(testConfiguration, out parameters);
+
+            // need to add the database
+            string databaseName = testConfiguration.Metadata.Catalog;
+            string schemaName = testConfiguration.Metadata.Schema;
+            string tableName = testConfiguration.Metadata.Table;
+
+            parameters[SnowflakeParameters.DATABASE] = databaseName;
+            parameters[SnowflakeParameters.SCHEMA] = schemaName;
+
+            AdbcDatabase adbcDatabase = driver.Open(parameters);
+            AdbcConnection adbcConnection = adbcDatabase.Connect(new Dictionary<string, string>());
+
+            IArrowArrayStream stream = adbcConnection.GetObjects(
+                    depth: AdbcConnection.GetObjectsDepth.All,
+                    catalogPattern: databaseName,
+                    dbSchemaPattern: schemaName,
+                    tableNamePattern: tableName,
+                    tableTypes: new List<string> { "BASE TABLE", "VIEW" },
+                    columnNamePattern: null);
+
+            RecordBatch recordBatch = stream.ReadNextRecordBatchAsync().Result;
+
+            List<AdbcCatalog> catalogs = GetObjectsParser.ParseCatalog(recordBatch, databaseName, schemaName);
+
+            List<AdbcTable> tables = catalogs
+                .Select(s => s.DbSchemas)
+                .FirstOrDefault()
+                .Select(t => t.Tables)
+                .FirstOrDefault();
+            AdbcTable table = tables.FirstOrDefault();
+
+            Assert.True(table != null, "table should not be null");
+            Assert.Equal(tableName, table.Name);
+        }
+
+        /// <summary>
+        /// Validates if the driver can call GetObjects with GetObjectsDepth as Tables with TableName as a pattern.
+        /// </summary>
+        [SkippableFact, Order(3)]
+        public void CanGetObjectsTablesWithPattern()
+        {
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+
+            SnowflakeTestConfiguration testConfiguration = Utils.LoadTestConfiguration<SnowflakeTestConfiguration>(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE);
+
+            AdbcDriver driver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(testConfiguration, out parameters);
+
+            // need to add the database
+            string databaseName = testConfiguration.Metadata.Catalog;
+            string schemaName = testConfiguration.Metadata.Schema;
+            string tableName = testConfiguration.Metadata.Table;
+            string partialTableName = $"{GetPartialNameForPatternMatch(tableName)}%";
+
+            parameters[SnowflakeParameters.DATABASE] = databaseName;
+            parameters[SnowflakeParameters.SCHEMA] = schemaName;
+
+            AdbcDatabase adbcDatabase = driver.Open(parameters);
+            AdbcConnection adbcConnection = adbcDatabase.Connect(new Dictionary<string, string>());
+
+            IArrowArrayStream stream = adbcConnection.GetObjects(
+                    depth: AdbcConnection.GetObjectsDepth.All,
+                    catalogPattern: databaseName,
+                    dbSchemaPattern: schemaName,
+                    tableNamePattern: partialTableName,
+                    tableTypes: new List<string> { "BASE TABLE", "VIEW" },
+                    columnNamePattern: null);
+
+            RecordBatch recordBatch = stream.ReadNextRecordBatchAsync().Result;
+
+            List<AdbcCatalog> catalogs = GetObjectsParser.ParseCatalog(recordBatch, databaseName, schemaName);
+
+            List<AdbcTable> tables = catalogs
+                .Select(s => s.DbSchemas)
+                .FirstOrDefault()
+                .Select(t => t.Tables)
+                .FirstOrDefault();
+            AdbcTable table = tables.FirstOrDefault();
+
+            Assert.True(table != null, "table should not be null");
+        }
+
+        /// <summary>
+        /// Validates if the driver can call GetObjects for GetObjectsDepth as All.
+        /// </summary>
+        [SkippableFact, Order(3)]
+        public void CanGetObjectsAll()
         {
             Dictionary<string, string> parameters = new Dictionary<string, string>();
 
@@ -252,6 +508,13 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
             QueryResult queryResult = statement.ExecuteQuery();
 
             Tests.DriverTests.CanExecuteQuery(queryResult, testConfiguration.ExpectedResultsCount);
+        }
+
+        private string GetPartialNameForPatternMatch(string name)
+        {
+            if (string.IsNullOrEmpty(name) || name.Length == 1) return name;
+
+            return name.Substring(0, name.Length / 2);
         }
     }
 }


### PR DESCRIPTION
Added tests to verify GetObjects for different depths like: Catalogs
DbSchemas
Tables
All

Also added tests to verify GetObjects with catalog, schema, and table names passed as patterns