### PR TITLE
feat(go/adbc/drivermgr): Implement Remaining CGO Wrapper Methods that are Supported by SQLite Driver

### DIFF
--- a/go/adbc/drivermgr/wrapper.go
+++ b/go/adbc/drivermgr/wrapper.go
@@ -297,7 +297,15 @@ func (c *cnxn) GetTableSchema(_ context.Context, catalog, dbSchema *string, tabl
 }
 
 func (c *cnxn) GetTableTypes(context.Context) (array.RecordReader, error) {
-	return nil, &adbc.Error{Code: adbc.StatusNotImplemented}
+	var (
+		out C.struct_ArrowArrayStream
+		err C.struct_AdbcError
+	)
+
+	if code := adbc.Status(C.AdbcConnectionGetTableTypes(c.conn, &out, &err)); code != adbc.StatusOK {
+		return nil, toAdbcError(code, &err)
+	}
+	return getRdr(&out)
 }
 
 func (c *cnxn) Commit(context.Context) error {

--- a/go/adbc/drivermgr/wrapper.go
+++ b/go/adbc/drivermgr/wrapper.go
@@ -471,7 +471,16 @@ func (s *stmt) BindStream(_ context.Context, stream array.RecordReader) error {
 }
 
 func (s *stmt) GetParameterSchema() (*arrow.Schema, error) {
-	return nil, &adbc.Error{Code: adbc.StatusNotImplemented}
+	var (
+		schema C.struct_ArrowSchema
+		err    C.struct_AdbcError
+	)
+
+	if code := adbc.Status(C.AdbcStatementGetParameterSchema(s.st, &schema, &err)); code != adbc.StatusOK {
+		return nil, toAdbcError(code, &err)
+	}
+
+	return getSchema(&schema)
 }
 
 func (s *stmt) ExecutePartitions(context.Context) (*arrow.Schema, adbc.Partitions, int64, error) {

--- a/go/adbc/drivermgr/wrapper.go
+++ b/go/adbc/drivermgr/wrapper.go
@@ -309,7 +309,15 @@ func (c *cnxn) GetTableTypes(context.Context) (array.RecordReader, error) {
 }
 
 func (c *cnxn) Commit(context.Context) error {
-	return &adbc.Error{Code: adbc.StatusNotImplemented}
+	var (
+		err C.struct_AdbcError
+	)
+
+	if code := adbc.Status(C.AdbcConnectionCommit(c.conn, &err)); code != adbc.StatusOK {
+		return toAdbcError(code, &err)
+	}
+
+	return nil
 }
 
 func (c *cnxn) Rollback(context.Context) error {

--- a/go/adbc/drivermgr/wrapper.go
+++ b/go/adbc/drivermgr/wrapper.go
@@ -321,7 +321,15 @@ func (c *cnxn) Commit(context.Context) error {
 }
 
 func (c *cnxn) Rollback(context.Context) error {
-	return &adbc.Error{Code: adbc.StatusNotImplemented}
+	var (
+		err C.struct_AdbcError
+	)
+
+	if code := adbc.Status(C.AdbcConnectionRollback(c.conn, &err)); code != adbc.StatusOK {
+		return toAdbcError(code, &err)
+	}
+
+	return nil
 }
 
 func (c *cnxn) NewStatement() (adbc.Statement, error) {

--- a/go/adbc/drivermgr/wrapper.go
+++ b/go/adbc/drivermgr/wrapper.go
@@ -196,11 +196,7 @@ func getSchema(out *C.struct_ArrowSchema) (*arrow.Schema, error) {
 		return nil, nil
 	}
 
-	schema, err := cdata.ImportCArrowSchema((*cdata.CArrowSchema)(unsafe.Pointer(out)))
-	if err != nil {
-		return nil, err
-	}
-	return schema, nil
+	return cdata.ImportCArrowSchema((*cdata.CArrowSchema)(unsafe.Pointer(out)))
 }
 
 type cnxn struct {

--- a/go/adbc/drivermgr/wrapper_sqlite_test.go
+++ b/go/adbc/drivermgr/wrapper_sqlite_test.go
@@ -334,6 +334,37 @@ func (dm *DriverMgrSuite) TestGetObjectsTableType() {
 	dm.False(rdr.Next())
 }
 
+func (dm *DriverMgrSuite) TestGetTableSchema() {
+	schema, err := dm.conn.GetTableSchema(dm.ctx, nil, nil, "test_table")
+	dm.NoError(err)
+
+	expSchema := arrow.NewSchema(
+		[]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
+			{Name: "name", Type: arrow.PrimitiveTypes.Int64, Nullable: true}, // Should be arrow.BinaryTypes.String
+		}, nil)
+	dm.True(expSchema.Equal(schema))
+}
+
+func (dm *DriverMgrSuite) TestGetTableSchemaInvalidTable() {
+	_, err := dm.conn.GetTableSchema(dm.ctx, nil, nil, "unknown_table")
+	dm.Error(err)
+}
+
+func (dm *DriverMgrSuite) TestGetTableSchemaCatalog() {
+	catalog := "does_not_exist"
+	schema, err := dm.conn.GetTableSchema(dm.ctx, &catalog, nil, "test_table")
+	dm.NoError(err)
+	dm.Nil(schema)
+}
+
+func (dm *DriverMgrSuite) TestGetTableSchemaDBSchema() {
+	dbSchema := "does_not_exist"
+	schema, err := dm.conn.GetTableSchema(dm.ctx, nil, &dbSchema, "test_table")
+	dm.NoError(err)
+	dm.Nil(schema)
+}
+
 func (dm *DriverMgrSuite) TestSqlExecute() {
 	query := "SELECT 1"
 	st, err := dm.conn.NewStatement()

--- a/go/adbc/drivermgr/wrapper_sqlite_test.go
+++ b/go/adbc/drivermgr/wrapper_sqlite_test.go
@@ -61,12 +61,17 @@ func (dm *DriverMgrSuite) SetupSuite() {
 	dm.NoError(err)
 	defer stmt.Close()
 
-	err = stmt.SetSqlQuery("CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT)")
-	dm.NoError(err)
+	dm.NoError(stmt.SetSqlQuery("CREATE TABLE test_table (id INTEGER PRIMARY KEY, name TEXT)"))
 
 	nrows, err := stmt.ExecuteUpdate(dm.ctx)
 	dm.NoError(err)
 	dm.Equal(int64(0), nrows)
+
+	dm.NoError(stmt.SetSqlQuery("INSERT INTO test_table (id, name) VALUES (1, 'test')"))
+
+	nrows, err = stmt.ExecuteUpdate(dm.ctx)
+	dm.NoError(err)
+	dm.Equal(int64(1), nrows)
 }
 
 func (dm *DriverMgrSuite) SetupTest() {
@@ -341,7 +346,7 @@ func (dm *DriverMgrSuite) TestGetTableSchema() {
 	expSchema := arrow.NewSchema(
 		[]arrow.Field{
 			{Name: "id", Type: arrow.PrimitiveTypes.Int64, Nullable: true},
-			{Name: "name", Type: arrow.PrimitiveTypes.Int64, Nullable: true}, // Should be arrow.BinaryTypes.String
+			{Name: "name", Type: arrow.BinaryTypes.String, Nullable: true},
 		}, nil)
 	dm.True(expSchema.Equal(schema))
 }

--- a/go/adbc/drivermgr/wrapper_sqlite_test.go
+++ b/go/adbc/drivermgr/wrapper_sqlite_test.go
@@ -365,6 +365,24 @@ func (dm *DriverMgrSuite) TestGetTableSchemaDBSchema() {
 	dm.Nil(schema)
 }
 
+func (dm *DriverMgrSuite) TestGetTableTypes() {
+	rdr, err := dm.conn.GetTableTypes(dm.ctx)
+	dm.NoError(err)
+	defer rdr.Release()
+
+	expSchema := adbc.TableTypesSchema
+	dm.True(expSchema.Equal(rdr.Schema()))
+	dm.True(rdr.Next())
+
+	rec := rdr.Record()
+	dm.Equal(int64(2), rec.NumRows())
+
+	expTableTypes := []string{"table", "view"}
+	dm.Contains(expTableTypes, rec.Column(0).ValueStr(0))
+	dm.Contains(expTableTypes, rec.Column(0).ValueStr(1))
+	dm.False(rdr.Next())
+}
+
 func (dm *DriverMgrSuite) TestSqlExecute() {
 	query := "SELECT 1"
 	st, err := dm.conn.NewStatement()

--- a/go/adbc/drivermgr/wrapper_sqlite_test.go
+++ b/go/adbc/drivermgr/wrapper_sqlite_test.go
@@ -398,6 +398,21 @@ func (dm *DriverMgrSuite) TestCommitAutocommitDisabled() {
 	dm.NoError(err)
 }
 
+func (dm *DriverMgrSuite) TestRollback() {
+	err := dm.conn.Rollback(dm.ctx)
+	dm.Error(err)
+	dm.ErrorContains(err, "No active transaction, cannot rollback")
+}
+
+func (dm *DriverMgrSuite) TestRollbackAutocommitDisabled() {
+	cnxnopt, ok := dm.conn.(adbc.PostInitOptions)
+	dm.True(ok)
+
+	cnxnopt.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled)
+	err := dm.conn.Rollback(dm.ctx)
+	dm.NoError(err)
+}
+
 func (dm *DriverMgrSuite) TestSqlExecute() {
 	query := "SELECT 1"
 	st, err := dm.conn.NewStatement()

--- a/go/adbc/drivermgr/wrapper_sqlite_test.go
+++ b/go/adbc/drivermgr/wrapper_sqlite_test.go
@@ -393,9 +393,8 @@ func (dm *DriverMgrSuite) TestCommitAutocommitDisabled() {
 	cnxnopt, ok := dm.conn.(adbc.PostInitOptions)
 	dm.True(ok)
 
-	cnxnopt.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled)
-	err := dm.conn.Commit(dm.ctx)
-	dm.NoError(err)
+	dm.NoError(cnxnopt.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled))
+	dm.NoError(dm.conn.Commit(dm.ctx))
 }
 
 func (dm *DriverMgrSuite) TestRollback() {
@@ -408,9 +407,8 @@ func (dm *DriverMgrSuite) TestRollbackAutocommitDisabled() {
 	cnxnopt, ok := dm.conn.(adbc.PostInitOptions)
 	dm.True(ok)
 
-	cnxnopt.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled)
-	err := dm.conn.Rollback(dm.ctx)
-	dm.NoError(err)
+	dm.NoError(cnxnopt.SetOption(adbc.OptionKeyAutoCommit, adbc.OptionValueDisabled))
+	dm.NoError(dm.conn.Rollback(dm.ctx))
 }
 
 func (dm *DriverMgrSuite) TestSqlExecute() {
@@ -555,15 +553,15 @@ func (dm *DriverMgrSuite) TestBindStream() {
 
 	recsIn := []arrow.Record{rec1, rec2}
 	rdrIn, err := array.NewRecordReader(schema, recsIn)
-
-	err = st.BindStream(dm.ctx, rdrIn)
 	dm.NoError(err)
+
+	dm.NoError(st.BindStream(dm.ctx, rdrIn))
 
 	rdrOut, _, err := st.ExecuteQuery(dm.ctx)
 	dm.NoError(err)
 	defer rdrOut.Release()
 
-	recsOut := make([]arrow.Record, 0, 0)
+	recsOut := make([]arrow.Record, 0)
 	for rdrOut.Next() {
 		rec := rdrOut.Record()
 		rec.Retain()

--- a/go/adbc/drivermgr/wrapper_sqlite_test.go
+++ b/go/adbc/drivermgr/wrapper_sqlite_test.go
@@ -508,6 +508,24 @@ func (dm *DriverMgrSuite) TestSqlPrepareMultipleParams() {
 	dm.False(rdr.Next())
 }
 
+func (dm *DriverMgrSuite) TestGetParameterSchema() {
+	query := "SELECT ?1, ?2"
+	st, err := dm.conn.NewStatement()
+	dm.Require().NoError(err)
+	dm.Require().NoError(st.SetSqlQuery(query))
+	defer st.Close()
+
+	expSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "?1", Type: arrow.Null, Nullable: true},
+		{Name: "?2", Type: arrow.Null, Nullable: true},
+	}, nil)
+
+	schema, err := st.GetParameterSchema()
+	dm.NoError(err)
+
+	dm.True(expSchema.Equal(schema))
+}
+
 func TestDriverMgr(t *testing.T) {
 	suite.Run(t, new(DriverMgrSuite))
 }


### PR DESCRIPTION
# What?
Implementations for the following methods in the CGO wrapper for `adbc_driver_manager`:
- `GetTableSchema`
- `GetTableTypes`
- `Commit`
- `Rollback`
- `GetParameterSchema`
- `BindStream`

# Why?
Functionality exists in C++ driver manager but not yet accessible via Go driver interface.

# Notes
Three methods in the wrapper remain unimplemented: `ExecutePartitions`, `ReadPartition`,  and `SetSubstraitPlan`. These methods are not currently supported by the SQLite driver, which is the primary test target for these changes. It is still possible to implement them in the drivermgr wrapper without support in specific drivers, but it does make it more difficult to verify correct behavior. The effort to add those methods will likely involve some additional work to ensure we are able to test their behaviors, so they are being left out of this current round of implementations.

Closes part of: #1291