### PR TITLE
feat(rust/driver/snowflake): Snowflake driver based on Go driver

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,13 +56,19 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      - name: Install stable Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "stable"
       - uses: Swatinem/rust-cache@v2
       - name: Check format
         run: cargo fmt -- --check
       - name: Clippy
-        run: cargo clippy --tests
+        run: cargo clippy --workspace --all-targets --all-features -- -Dwarnings
       - name: Test
         shell: bash -l {0}
-        run: cargo test
+        run: |
+          cargo test --workspace --all-targets --all-features
+          cargo test --workspace --doc --all-features
       - name: Check docs
-        run: cargo doc
+        run: cargo doc --workspace --all-features

--- a/rust/driver/snowflake/Cargo.toml
+++ b/rust/driver/snowflake/Cargo.toml
@@ -15,45 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[workspace]
-members = ["driver/snowflake"]
-
-[workspace.package]
-version = "0.9.0-SNAPSHOT"
-edition = "2021"
-rust-version = "1.62"
-homepage = "https://arrow.apache.org/adbc/"
-repository = "https://github.com/apache/arrow-adbc"
-authors = ["Apache Arrow <dev@arrow.apache.org>"]
-license = "Apache-2.0"
-keywords = ["arrow", "database", "sql"]
-
-[workspace.dependencies]
-
 [package]
-name = "arrow-adbc"
+name = "arrow-adbc-snowflake"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-description = "Rust implementation of Arrow Database Connectivity (ADBC)"
+description = "Snowflake driver for Arrow Database Connectivity (ADBC)"
 homepage.workspace = true
 repository.workspace = true
 authors.workspace = true
 license.workspace = true
 keywords.workspace = true
 
-[dependencies]
-arrow-array = { version = "44.0.0", default-features = false}
-arrow-schema = { version = "44.0.0", features = ["ffi"], default-features = false}
-arrow-data = { version = "44.0.0", features = ["ffi"], default-features = false}
-async-trait = "0.1"
-libloading = "0.7"
-num_enum = "0.5"
-once_cell = "1"
-substrait = { version = "0.5", optional = true }
-
-[dev-dependencies]
-itertools = "0.10"
-
-[features]
-substrait = ["dep:substrait"]
+[build-dependencies]
+bindgen = "0.69.1"

--- a/rust/driver/snowflake/build.rs
+++ b/rust/driver/snowflake/build.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use bindgen::Builder;
 use std::{env, error::Error, path::PathBuf, process::Command};
 

--- a/rust/driver/snowflake/build.rs
+++ b/rust/driver/snowflake/build.rs
@@ -1,0 +1,52 @@
+use bindgen::Builder;
+use std::{env, error::Error, path::PathBuf, process::Command};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    let go_dir = manifest_dir.ancestors().nth(3).unwrap().join("go");
+    let go_pkg = go_dir.join("adbc/pkg/snowflake");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+    let archive = out_dir.join("libsnowflake.a");
+    let header = out_dir.join("libsnowflake.h");
+    let bindings = out_dir.join("snowflake.rs");
+
+    // Build the Go driver
+    let status = Command::new("go")
+        .current_dir(go_pkg.as_path())
+        .arg("build")
+        .arg("-tags")
+        .arg("driverlib")
+        .arg("-buildmode=c-archive")
+        .arg("-o")
+        .arg(&archive)
+        .arg(".")
+        .status()?;
+    assert!(status.success(), "Go build failed");
+
+    // Generate the bindings based on the generated header
+    Builder::default()
+        .header(header.to_str().unwrap())
+        .clang_arg(format!("-I{}", go_pkg.display()))
+        .derive_default(true)
+        .allowlist_item("Snowflake.*")
+        .generate()?
+        .write_to_file(bindings)?;
+
+    // Retrigger the build when the Go pkg changes
+    println!("cargo:rerun-if-changed={}", go_pkg.display());
+
+    // Link the driver statically
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=static=snowflake");
+
+    // Link other dependencies
+    println!("cargo:rustc-link-lib=resolv");
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo:rustc-link-lib=framework=CoreFoundation");
+        println!("cargo:rustc-link-lib=framework=Security");
+    }
+
+    Ok(())
+}

--- a/rust/driver/snowflake/src/lib.rs
+++ b/rust/driver/snowflake/src/lib.rs
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[allow(non_camel_case_types, non_snake_case, non_upper_case_globals)]
+#[cfg_attr(
+    doc,
+    allow(rustdoc::broken_intra_doc_links, rustdoc::invalid_html_tags)
+)]
+mod ffi {
+    include!(concat!(env!("OUT_DIR"), "/snowflake.rs"));
+}

--- a/rust/src/info.rs
+++ b/rust/src/info.rs
@@ -176,7 +176,7 @@ pub fn export_info_data(
     let children = union_fields
         .iter()
         .map(|f| (**f.1).clone())
-        .zip(arrays.into_iter())
+        .zip(arrays)
         .collect();
 
     let info_value = UnionArray::try_new(


### PR DESCRIPTION
Adds a Rust Snowflake driver based on the Go Snowflake driver.

Marking as draft, because this is just the binding generation and build + link setup.