### PR TITLE
fix(go/adbc/driver/snowflake): fix XDBC support when using high precision

### DIFF
--- a/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
@@ -87,6 +87,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             return new Field(field.Name, TranslateType(field), field.Mode == "NULLABLE");
         }
 
+<<<<<<< HEAD
         public override object GetValue(IArrowArray arrowArray, Field field, int index)
         {
             switch(arrowArray)
@@ -100,6 +101,21 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             }
         }
 
+=======
+        public override object GetValue(IArrowArray arrowArray, Field field, int index)
+        {
+            switch(arrowArray)
+            {
+                case StructArray structArray:
+                    return SerializeToJson(structArray, index);
+                case ListArray listArray:
+                    return listArray.GetSlicedValues(index);
+                default:
+                    return base.GetValue(arrowArray, field, index);
+            }
+        }
+
+>>>>>>> be35986c (add back support for List, Struct types)
         private IArrowType TranslateType(TableFieldSchema field)
         {
             // per https://developers.google.com/resources/api-libraries/documentation/bigquery/v2/java/latest/com/google/api/services/bigquery/model/TableFieldSchema.html#getType--

--- a/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
@@ -88,6 +88,9 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
         }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 641a6fe4 (fix line endings)
         public override object GetValue(IArrowArray arrowArray, Field field, int index)
         {
             switch(arrowArray)
@@ -101,6 +104,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             }
         }
 
+<<<<<<< HEAD
 =======
         public override object GetValue(IArrowArray arrowArray, Field field, int index)
         {
@@ -116,6 +120,8 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
         }
 
 >>>>>>> be35986c (add back support for List, Struct types)
+=======
+>>>>>>> 641a6fe4 (fix line endings)
         private IArrowType TranslateType(TableFieldSchema field)
         {
             // per https://developers.google.com/resources/api-libraries/documentation/bigquery/v2/java/latest/com/google/api/services/bigquery/model/TableFieldSchema.html#getType--

--- a/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
@@ -87,10 +87,6 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             return new Field(field.Name, TranslateType(field), field.Mode == "NULLABLE");
         }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 641a6fe4 (fix line endings)
         public override object GetValue(IArrowArray arrowArray, Field field, int index)
         {
             switch(arrowArray)
@@ -104,24 +100,6 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             }
         }
 
-<<<<<<< HEAD
-=======
-        public override object GetValue(IArrowArray arrowArray, Field field, int index)
-        {
-            switch(arrowArray)
-            {
-                case StructArray structArray:
-                    return SerializeToJson(structArray, index);
-                case ListArray listArray:
-                    return listArray.GetSlicedValues(index);
-                default:
-                    return base.GetValue(arrowArray, field, index);
-            }
-        }
-
->>>>>>> be35986c (add back support for List, Struct types)
-=======
->>>>>>> 641a6fe4 (fix line endings)
         private IArrowType TranslateType(TableFieldSchema field)
         {
             // per https://developers.google.com/resources/api-libraries/documentation/bigquery/v2/java/latest/com/google/api/services/bigquery/model/TableFieldSchema.html#getType--

--- a/csharp/test/Drivers/Snowflake/DriverTests.cs
+++ b/csharp/test/Drivers/Snowflake/DriverTests.cs
@@ -156,8 +156,21 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
                 .FirstOrDefault();
 
             Assert.True(columns != null, "Columns cannot be null");
-
             Assert.Equal(testConfiguration.Metadata.ExpectedColumnCount, columns.Count);
+
+            if (testConfiguration.UseHighPrecision)
+            {
+                IEnumerable<AdbcColumn> highPrecisionColumns = columns.Where(c => c.XdbcTypeName == "NUMBER");
+
+                if(highPrecisionColumns.Count() > 0)
+                {
+                    // ensure they all are coming back as XdbcDataType_XDBC_DECIMAL because they are Decimal128
+                    short XdbcDataType_XDBC_DECIMAL = 3;
+                    IEnumerable<AdbcColumn> invalidHighPrecisionColumns  = highPrecisionColumns.Where(c => c.XdbcSqlDataType != XdbcDataType_XDBC_DECIMAL);
+                    int count = invalidHighPrecisionColumns.Count();
+                    Assert.True(count == 0, $"There are {count} columns that do not map to the correct XdbcSqlDataType when UseHighPrecision=true");
+                }
+            }
         }
 
         /// <summary>

--- a/csharp/test/Drivers/Snowflake/ValueTests.cs
+++ b/csharp/test/Drivers/Snowflake/ValueTests.cs
@@ -18,12 +18,11 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SqlTypes;
-using Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake;
 using Apache.Arrow.Ipc;
 using Apache.Arrow.Types;
 using Xunit;
 
-namespace Apache.Arrow.Adbc.Tests
+namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
 {
     // TODO: When supported, use prepared statements instead of SQL string literals
     //      Which will better test how the driver handles values sent/received


### PR DESCRIPTION
- Fixes https://github.com/apache/arrow-adbc/issues/1309
- Fixes a namespace  
- Adds a test for Xdbc in the C# code
- hanging merge fix from rebase