### PR TITLE
test(csharp/test/Drivers/Snowflake): Correct FLOAT min/max tests in .NET 4.7.2

### DIFF
--- a/csharp/test/Drivers/Snowflake/ValueTests.cs
+++ b/csharp/test/Drivers/Snowflake/ValueTests.cs
@@ -238,6 +238,13 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
                     return "'-inf'";
                 case double.NaN:
                     return "'NaN'";
+#if NET472
+                // Double.ToString() rounds max/min values, causing Snowflake to store +/- infinity
+                case double.MaxValue:
+                    return "1.7976931348623157E+308";
+                case double.MinValue:
+                    return "-1.7976931348623157E+308";
+#endif
                 default:
                     return value.ToString();
             }


### PR DESCRIPTION
.NET 4.7.2 will round up Double.MaxValue / round down Double.MinValue when using Double.ToString(), resulting in infinity / -infinity stored in Snowflake when passed into the INSERT query statement. This rounding does not occur in .NET 6.0.

This PR corrects that behavior and sends a properly accepted MaxValue/MinValue string when using .NET 4.7.2.

Notable that when the tests can use prepared statements, issues like this should cease to happen.

Near identical to #1312, with some minor changes to comment wording. Adding it back because it was accidentally removed in https://github.com/apache/arrow-adbc/pull/1311/commits/4aba0400610f3bd2a4344caa7dd8ea1071f6d532.