### PR TITLE
fix(go/adbc/driver/snowflake): Made GetObjects case insensitive

### DIFF
--- a/csharp/test/Drivers/Snowflake/DriverTests.cs
+++ b/csharp/test/Drivers/Snowflake/DriverTests.cs
@@ -40,6 +40,41 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
         readonly AdbcDatabase _database;
         readonly AdbcConnection _connection;
 
+        public static IEnumerable<object[]> GetPatterns(string name)
+        {
+            yield return new object[] { name };
+            yield return new object[] { $"{DriverTests.GetPartialNameForPatternMatch(name)}%" };
+            yield return new object[] { $"{DriverTests.GetPartialNameForPatternMatch(name).ToLower()}%" };
+            yield return new object[] { $"{DriverTests.GetPartialNameForPatternMatch(name).ToUpper()}%" };
+            yield return new object[] { $"_{DriverTests.GetNameWithoutFirstChatacter(name)}%" };
+            yield return new object[] { $"_{DriverTests.GetNameWithoutFirstChatacter(name).ToLower()}%" };
+            yield return new object[] { $"_{DriverTests.GetNameWithoutFirstChatacter(name).ToUpper()}%" };
+        }
+
+        public static IEnumerable<object[]> CatalogNamePatternData()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE));
+            SnowflakeTestConfiguration testConfiguration = Utils.LoadTestConfiguration<SnowflakeTestConfiguration>(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE);
+            string databaseName = testConfiguration.Metadata.Catalog;
+            return GetPatterns(databaseName);
+        }
+
+        public static IEnumerable<object[]> DbSchemasNamePatternData()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE));
+            SnowflakeTestConfiguration testConfiguration = Utils.LoadTestConfiguration<SnowflakeTestConfiguration>(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE);
+            string dbSchemaName = testConfiguration.Metadata.Schema;
+            return GetPatterns(dbSchemaName);
+        }
+
+        public static IEnumerable<object[]> TableNamePatternData()
+        {
+            Skip.IfNot(Utils.CanExecuteTestConfig(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE));
+            SnowflakeTestConfiguration testConfiguration = Utils.LoadTestConfiguration<SnowflakeTestConfiguration>(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE);
+            string tableName = testConfiguration.Metadata.Table;
+            return GetPatterns(tableName);
+        }
+
         public DriverTests()
         {
             Skip.IfNot(Utils.CanExecuteTestConfig(SnowflakeTestingUtils.SNOWFLAKE_TEST_CONFIG_VARIABLE));
@@ -111,45 +146,18 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
         }
 
         /// <summary>
-        /// Validates if the driver can call GetObjects with GetObjectsDepth as Catalogs.
-        /// </summary>
-        [SkippableFact, Order(3)]
-        public void CanGetObjectsCatalogs()
-        {
-            string databaseName = _testConfiguration.Metadata.Catalog;
-
-            using IArrowArrayStream stream = _connection.GetObjects(
-                    depth: AdbcConnection.GetObjectsDepth.Catalogs,
-                    catalogPattern: databaseName,
-                    dbSchemaPattern: null,
-                    tableNamePattern: null,
-                    tableTypes: new List<string> { "BASE TABLE", "VIEW" },
-                    columnNamePattern: null);
-
-            using RecordBatch recordBatch = stream.ReadNextRecordBatchAsync().Result;
-
-            List<AdbcCatalog> catalogs = GetObjectsParser.ParseCatalog(recordBatch, databaseName, null);
-
-            AdbcCatalog catalog = catalogs.FirstOrDefault();
-
-            Assert.True(catalog != null, "catalog should not be null");
-            Assert.Equal(databaseName, catalog.Name);
-        }
-
-        /// <summary>
         /// Validates if the driver can call GetObjects with GetObjectsDepth as Catalogs and CatalogName passed as a pattern.
         /// </summary>
-        [SkippableFact, Order(3)]
-        public void CanGetObjectsCatalogsWithPattern()
+        [SkippableTheory, Order(3)]
+        [MemberData(nameof(CatalogNamePatternData))]
+        public void CanGetObjectsCatalogs(string catalogPattern)
         {
             string databaseName = _testConfiguration.Metadata.Catalog;
             string schemaName = _testConfiguration.Metadata.Schema;
-            string partialDatabaseName = GetPartialNameForPatternMatch(databaseName);
-
 
             using IArrowArrayStream stream = _connection.GetObjects(
                     depth: AdbcConnection.GetObjectsDepth.Catalogs,
-                    catalogPattern: $"{partialDatabaseName}%",
+                    catalogPattern: catalogPattern,
                     dbSchemaPattern: null,
                     tableNamePattern: null,
                     tableTypes: new List<string> { "BASE TABLE", "VIEW" },
@@ -158,59 +166,26 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
             using RecordBatch recordBatch = stream.ReadNextRecordBatchAsync().Result;
 
             List<AdbcCatalog> catalogs = GetObjectsParser.ParseCatalog(recordBatch, databaseName, null);
-
-            AdbcCatalog catalog = catalogs.FirstOrDefault();
+            AdbcCatalog catalog = catalogs.Where((catalog) => string.Equals(catalog.Name, databaseName)).FirstOrDefault();
 
             Assert.True(catalog != null, "catalog should not be null");
-            Assert.StartsWith(databaseName, catalog.Name);
-        }
-
-        /// <summary>
-        /// Validates if the driver can call GetObjects with GetObjectsDepth as DbSchemas.
-        /// </summary>
-        [SkippableFact, Order(3)]
-        public void CanGetObjectsDbSchemas()
-        {
-            // need to add the database
-            string databaseName = _testConfiguration.Metadata.Catalog;
-            string schemaName = _testConfiguration.Metadata.Schema;
-
-            using IArrowArrayStream stream = _connection.GetObjects(
-                    depth: AdbcConnection.GetObjectsDepth.DbSchemas,
-                    catalogPattern: databaseName,
-                    dbSchemaPattern: schemaName,
-                    tableNamePattern: null,
-                    tableTypes: new List<string> { "BASE TABLE", "VIEW" },
-                    columnNamePattern: null);
-
-            using RecordBatch recordBatch = stream.ReadNextRecordBatchAsync().Result;
-
-            List<AdbcCatalog> catalogs = GetObjectsParser.ParseCatalog(recordBatch, databaseName, schemaName);
-
-            List<AdbcDbSchema> dbSchemas = catalogs
-                .Select(s => s.DbSchemas)
-                .FirstOrDefault();
-            AdbcDbSchema dbSchema = dbSchemas.FirstOrDefault();
-
-            Assert.True(dbSchema != null, "dbSchema should not be null");
-            Assert.Equal(schemaName, dbSchema.Name);
         }
 
         /// <summary>
         /// Validates if the driver can call GetObjects with GetObjectsDepth as DbSchemas with DbSchemaName as a pattern.
         /// </summary>
-        [SkippableFact, Order(3)]
-        public void CanGetObjectsDbSchemasWithPattern()
+        [SkippableTheory, Order(3)]
+        [MemberData(nameof(DbSchemasNamePatternData))]
+        public void CanGetObjectsDbSchemas(string dbSchemaPattern)
         {
             // need to add the database
             string databaseName = _testConfiguration.Metadata.Catalog;
             string schemaName = _testConfiguration.Metadata.Schema;
-            string partialSchemaName = GetPartialNameForPatternMatch(schemaName);
 
             using IArrowArrayStream stream = _connection.GetObjects(
                     depth: AdbcConnection.GetObjectsDepth.DbSchemas,
                     catalogPattern: databaseName,
-                    dbSchemaPattern: $"{partialSchemaName}%",
+                    dbSchemaPattern: dbSchemaPattern,
                     tableNamePattern: null,
                     tableTypes: new List<string> { "BASE TABLE", "VIEW" },
                     columnNamePattern: null);
@@ -222,63 +197,28 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
             List<AdbcDbSchema> dbSchemas = catalogs
                 .Select(s => s.DbSchemas)
                 .FirstOrDefault();
-            AdbcDbSchema dbSchema = dbSchemas.FirstOrDefault();
+            AdbcDbSchema dbSchema = dbSchemas.Where((dbSchema) => string.Equals(dbSchema.Name, schemaName)).FirstOrDefault();
 
             Assert.True(dbSchema != null, "dbSchema should not be null");
-            Assert.StartsWith(partialSchemaName, dbSchema.Name);
-        }
-
-        /// <summary>
-        /// Validates if the driver can call GetObjects with GetObjectsDepth as Tables.
-        /// </summary>
-        [SkippableFact, Order(3)]
-        public void CanGetObjectsTables()
-        {
-            // need to add the database
-            string databaseName = _testConfiguration.Metadata.Catalog;
-            string schemaName = _testConfiguration.Metadata.Schema;
-            string tableName = _testConfiguration.Metadata.Table;
-
-            using IArrowArrayStream stream = _connection.GetObjects(
-                    depth: AdbcConnection.GetObjectsDepth.All,
-                    catalogPattern: databaseName,
-                    dbSchemaPattern: schemaName,
-                    tableNamePattern: tableName,
-                    tableTypes: new List<string> { "BASE TABLE", "VIEW" },
-                    columnNamePattern: null);
-
-            using RecordBatch recordBatch = stream.ReadNextRecordBatchAsync().Result;
-
-            List<AdbcCatalog> catalogs = GetObjectsParser.ParseCatalog(recordBatch, databaseName, schemaName);
-
-            List<AdbcTable> tables = catalogs
-                .Select(s => s.DbSchemas)
-                .FirstOrDefault()
-                .Select(t => t.Tables)
-                .FirstOrDefault();
-            AdbcTable table = tables.FirstOrDefault();
-
-            Assert.True(table != null, "table should not be null");
-            Assert.Equal(tableName, table.Name);
         }
 
         /// <summary>
         /// Validates if the driver can call GetObjects with GetObjectsDepth as Tables with TableName as a pattern.
         /// </summary>
-        [SkippableFact, Order(3)]
-        public void CanGetObjectsTablesWithPattern()
+        [SkippableTheory, Order(3)]
+        [MemberData(nameof(TableNamePatternData))]
+        public void CanGetObjectsTables(string tableNamePattern)
         {
             // need to add the database
             string databaseName = _testConfiguration.Metadata.Catalog;
             string schemaName = _testConfiguration.Metadata.Schema;
             string tableName = _testConfiguration.Metadata.Table;
-            string partialTableName = GetPartialNameForPatternMatch(tableName);
 
             using IArrowArrayStream stream = _connection.GetObjects(
                     depth: AdbcConnection.GetObjectsDepth.All,
                     catalogPattern: databaseName,
                     dbSchemaPattern: schemaName,
-                    tableNamePattern: $"{partialTableName}%",
+                    tableNamePattern: tableNamePattern,
                     tableTypes: new List<string> { "BASE TABLE", "VIEW" },
                     columnNamePattern: null);
 
@@ -291,10 +231,9 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
                 .FirstOrDefault()
                 .Select(t => t.Tables)
                 .FirstOrDefault();
-            AdbcTable table = tables.FirstOrDefault();
 
+            AdbcTable table = tables.Where((table) => string.Equals(table.Name, tableName)).FirstOrDefault();
             Assert.True(table != null, "table should not be null");
-            Assert.StartsWith(partialTableName, table.Name);
         }
 
         /// <summary>
@@ -411,11 +350,18 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
             Tests.DriverTests.CanExecuteQuery(queryResult, _testConfiguration.ExpectedResultsCount);
         }
 
-        private string GetPartialNameForPatternMatch(string name)
+        private static string GetPartialNameForPatternMatch(string name)
         {
             if (string.IsNullOrEmpty(name) || name.Length == 1) return name;
 
             return name.Substring(0, name.Length / 2);
+        }
+
+        private static string GetNameWithoutFirstChatacter(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return name;
+
+            return name.Substring(1);
         }
 
         public void Dispose()

--- a/csharp/test/Drivers/Snowflake/DriverTests.cs
+++ b/csharp/test/Drivers/Snowflake/DriverTests.cs
@@ -330,9 +330,9 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
                 .FirstOrDefault();
 
             Assert.True(columns != null, "Columns cannot be null");
-            Assert.Equal(testConfiguration.Metadata.ExpectedColumnCount, columns.Count);
+            Assert.Equal(_testConfiguration.Metadata.ExpectedColumnCount, columns.Count);
 
-            if (testConfiguration.UseHighPrecision)
+            if (_testConfiguration.UseHighPrecision)
             {
                 IEnumerable<AdbcColumn> highPrecisionColumns = columns.Where(c => c.XdbcTypeName == "NUMBER");
 

--- a/go/adbc/driver/snowflake/connection.go
+++ b/go/adbc/driver/snowflake/connection.go
@@ -282,10 +282,10 @@ func (c *cnxn) getObjectsDbSchemas(ctx context.Context, depth adbc.ObjectDepth, 
 
 	conditions := make([]string, 0)
 	if catalog != nil && *catalog != "" {
-		conditions = append(conditions, ` CATALOG_NAME LIKE '`+*catalog+`'`)
+		conditions = append(conditions, ` CATALOG_NAME ILIKE '`+*catalog+`'`)
 	}
 	if dbSchema != nil && *dbSchema != "" {
-		conditions = append(conditions, ` SCHEMA_NAME LIKE '`+*dbSchema+`'`)
+		conditions = append(conditions, ` SCHEMA_NAME ILIKE '`+*dbSchema+`'`)
 	}
 
 	cond := strings.Join(conditions, " AND ")


### PR DESCRIPTION
### Description:
`GetObjects` API was inconsistent case sensitivity for patterns. `getObjectsDbSchemas` driver implementation used `LIKE` whereas `getObjectsTables` used `ILIKE`

### Solution:
Based on discussion here: https://github.com/apache/arrow-adbc/issues/1314 changed `GetObjects` API to use `ILIKE` throughout instead of `LIKE`

### Testing:
Added tests for lowercase, uppercase and `_` wildcard