### PR TITLE
ci: Temporary fix for Python version

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -229,6 +229,7 @@ jobs:
           BUILD_ALL: "0"
           BUILD_DRIVER_MANAGER: "1"
           BUILD_DRIVER_POSTGRESQL: "1"
+          SETUPTOOLS_SCM_PRETEND_VERSION: "0.9.0"
         run: |
           ./ci/scripts/python_build.sh "$(pwd)" "$(pwd)/build"
 


### PR DESCRIPTION
I don't think this is the better long term option of what is described in https://github.com/apache/arrow-adbc/issues/1333#issuecomment-1836083476 but should get CI green for now