### PR TITLE
fix(go/adbc/sqldriver): Fix nil pointer panics for query parameters

### DIFF
--- a/go/adbc/sqldriver/driver.go
+++ b/go/adbc/sqldriver/driver.go
@@ -475,7 +475,9 @@ func arrFromVal(val any) arrow.Array {
 		panic(fmt.Sprintf("unsupported type %T", val))
 	}
 	for _, b := range buffers {
-		defer b.Release()
+		if b != nil {
+			defer b.Release()
+		}
 	}
 	data := array.NewData(dt, 1, buffers, nil, 0, 0)
 	defer data.Release()

--- a/go/adbc/sqldriver/driver.go
+++ b/go/adbc/sqldriver/driver.go
@@ -22,6 +22,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"strconv"
@@ -470,6 +471,8 @@ func arrFromVal(val any) arrow.Array {
 		var buf = *(*[]byte)(unsafe.Pointer(&v))
 		(*reflect.SliceHeader)(unsafe.Pointer(&buf)).Cap = len(v)
 		buffers[2] = memory.NewBufferBytes(buf)
+	default:
+		panic(fmt.Sprintf("unsupported type %T", val))
 	}
 	for _, b := range buffers {
 		defer b.Release()

--- a/go/adbc/sqldriver/driver.go
+++ b/go/adbc/sqldriver/driver.go
@@ -464,13 +464,13 @@ func arrFromVal(val any) arrow.Array {
 	case []byte:
 		dt = arrow.BinaryTypes.Binary
 		buffers[1] = memory.NewBufferBytes(arrow.Int32Traits.CastToBytes([]int32{0, int32(len(v))}))
-		buffers[2] = memory.NewBufferBytes(v)
+		buffers = append(buffers, memory.NewBufferBytes(v))
 	case string:
 		dt = arrow.BinaryTypes.String
 		buffers[1] = memory.NewBufferBytes(arrow.Int32Traits.CastToBytes([]int32{0, int32(len(v))}))
 		var buf = *(*[]byte)(unsafe.Pointer(&v))
 		(*reflect.SliceHeader)(unsafe.Pointer(&buf)).Cap = len(v)
-		buffers[2] = memory.NewBufferBytes(buf)
+		buffers = append(buffers, memory.NewBufferBytes(buf))
 	default:
 		panic(fmt.Sprintf("unsupported type %T", val))
 	}

--- a/go/adbc/sqldriver/driver_test.go
+++ b/go/adbc/sqldriver/driver_test.go
@@ -38,7 +38,7 @@ func Example() {
 		panic(err)
 	}
 
-	rows, err := db.Query("SELECT 1")
+	rows, err := db.Query("SELECT ?", 1)
 	if err != nil {
 		panic(err)
 	}
@@ -66,8 +66,8 @@ func Example() {
 	}
 
 	// Output:
-	// [1]
-	// 1
+	// [?]
+	// ?
 	// true true
 	// 1
 }


### PR DESCRIPTION
Thought I would contribute some fixes I've been using locally for the issues described in #1341

I have no previous experience with this repository or with the Arrow memory model so I would say it's likely I've gotten something wrong. Feel free to ask me to improve on my contributions or merely take them as inspiration for some other fix.

Resolves #1341

