### PR TITLE
feat(python/adbc_driver_manager): export handles through python Arrow Capsule interface

### DIFF
--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pxd
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pxd
@@ -22,10 +22,15 @@ from libc.stdint cimport int32_t, int64_t, uint8_t, uint32_t
 
 cdef extern from "adbc.h" nogil:
     # C ABI
+
+    ctypedef void (*CArrowSchemaRelease)(void*)
+    ctypedef void (*CArrowArrayRelease)(void*)
+
     cdef struct CArrowSchema"ArrowSchema":
-        pass
+        CArrowSchemaRelease release
+
     cdef struct CArrowArray"ArrowArray":
-        pass
+        CArrowArrayRelease release
 
     ctypedef int (*CArrowArrayStreamGetLastError)(void*)
     ctypedef int (*CArrowArrayStreamGetNext)(void*, CArrowArray*)

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -27,7 +27,7 @@ from typing import List, Tuple
 cimport cpython
 import cython
 from cpython.bytes cimport PyBytes_FromStringAndSize
-from cpython.pycapsule cimport PyCapsule_CheckExact, PyCapsule_GetPointer, PyCapsule_New, PyCapsule_IsValid
+from cpython.pycapsule cimport PyCapsule_GetPointer, PyCapsule_New
 from libc.stdint cimport int32_t, int64_t, uint8_t, uint32_t, uintptr_t
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy, memset
@@ -416,7 +416,7 @@ cdef class ArrowArrayStreamHandle:
             <CArrowArrayStream*> malloc(sizeof(CArrowArrayStream))
         allocated.release = NULL
         capsule = PyCapsule_New(
-            <void*>allocated, "arrow_array_stream", pycapsule_stream_deleter,
+            <void*>allocated, "arrow_array_stream", &pycapsule_stream_deleter,
         )
         memcpy(allocated, &self.stream, sizeof(CArrowArrayStream))
         self.stream.release = NULL

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -1072,7 +1072,7 @@ cdef class AdbcStatement(_AdbcHandle):
         cdef CArrowArray* c_array
         cdef CArrowSchema* c_schema
 
-        if hasattr(data, "__arrow_c_array__"):
+        if hasattr(data, "__arrow_c_array__") and not isinstance(data, ArrowArrayHandle):
             if schema is not None:
                 raise ValueError(
                     "Can not provide a schema when passing Arrow-compatible "
@@ -1121,7 +1121,10 @@ cdef class AdbcStatement(_AdbcHandle):
         cdef CAdbcError c_error = empty_error()
         cdef CArrowArrayStream* c_stream
 
-        if hasattr(stream, "__arrow_c_stream__"):
+        if (
+            hasattr(stream, "__arrow_c_stream__")
+            and not isinstance(stream, ArrowArrayStreamHandle)
+        ):
             stream = stream.__arrow_c_stream__()
 
         if PyCapsule_CheckExact(stream):

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -318,15 +318,6 @@ cdef void pycapsule_schema_deleter(object capsule) noexcept:
     free(allocated)
 
 
-cdef void pycapsule_array_deleter(object capsule) noexcept:
-    cdef CArrowArray* allocated = <CArrowArray*> PyCapsule_GetPointer(
-        capsule, "arrow_array"
-    )
-    if allocated.release != NULL:
-        allocated.release(allocated)
-    free(allocated)
-
-
 cdef void pycapsule_stream_deleter(object capsule) noexcept:
     cdef CArrowArrayStream* allocated = <CArrowArrayStream*> PyCapsule_GetPointer(
         capsule, "arrow_array_stream"

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -380,20 +380,6 @@ cdef class ArrowArrayHandle:
         """
         return <uintptr_t> &self.array
 
-    def __arrow_c_array__(self, requested_schema=None) -> object:
-        """Consume this object to get a PyCapsule."""
-        if requested_schema is not None:
-            raise NotImplementedError("requested_schema")
-
-        cdef CArrowArray* allocated = <CArrowArray*> malloc(sizeof(CArrowArray))
-        allocated.release = NULL
-        capsule = PyCapsule_New(
-            <void*>allocated, "arrow_array", pycapsule_array_deleter,
-        )
-        memcpy(allocated, &self.array, sizeof(CArrowArray))
-        self.array.release = NULL
-        return capsule
-
 
 cdef class ArrowArrayStreamHandle:
     """

--- a/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
@@ -668,7 +668,6 @@ class Cursor(_Closeable):
         self._prepare_execute(operation, parameters)
         handle, self._rowcount = self._stmt.execute_query()
         self._results = _RowIterator(
-            # pyarrow.RecordBatchReader._import_from_c(handle.address)
             _reader.AdbcRecordBatchReader._import_from_c(handle.address)
         )
 

--- a/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
@@ -1165,6 +1165,6 @@ def _is_arrow_data(data):
         hasattr(data, "__arrow_c_array__")
         or hasattr(data, "__arrow_c_stream__")
         or isinstance(
-            data, (pyarrow.RecordBatch, pyarrow.Table, pyarrow.RecordBatchReader),
+            data, (pyarrow.RecordBatch, pyarrow.Table, pyarrow.RecordBatchReader)
         )
     )

--- a/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
@@ -613,10 +613,9 @@ class Cursor(_Closeable):
 
     def _bind(self, parameters) -> None:
         if hasattr(parameters, "__arrow_c_array__"):
-            schema_capsule, array_capsule = parameters.__arrow_c_array__()
-            self._stmt.bind(array_capsule, schema_capsule)
+            self._stmt.bind(parameters)
         elif hasattr(parameters, "__arrow_c_stream__"):
-            self._stmt.bind_stream(parameters.__arrow_c_stream__())
+            self._stmt.bind_stream(parameters)
         elif isinstance(parameters, pyarrow.RecordBatch):
             arr_handle = _lib.ArrowArrayHandle()
             sch_handle = _lib.ArrowSchemaHandle()
@@ -881,10 +880,9 @@ class Cursor(_Closeable):
                 pass
 
         if hasattr(data, "__arrow_c_array__"):
-            schema_capsule, array_capsule = data.__arrow_c_array__()
-            self._stmt.bind(array_capsule, schema_capsule)
+            self._stmt.bind(data)
         elif hasattr(data, "__arrow_c_stream__"):
-            self._stmt.bind_stream(data.__arrow_c_stream__())
+            self._stmt.bind_stream(data)
         elif isinstance(data, pyarrow.RecordBatch):
             array = _lib.ArrowArrayHandle()
             schema = _lib.ArrowSchemaHandle()

--- a/python/adbc_driver_manager/pyproject.toml
+++ b/python/adbc_driver_manager/pyproject.toml
@@ -25,8 +25,8 @@ requires-python = ">=3.9"
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dbapi = ["pandas", "pyarrow>=8.0.0"]
-test = ["duckdb", "pandas", "pyarrow>=8.0.0", "pytest"]
+dbapi = ["pandas", "pyarrow>=14.0.1"]
+test = ["duckdb", "pandas", "pyarrow>=14.0.1", "pytest"]
 
 [project.urls]
 homepage = "https://arrow.apache.org/adbc/"

--- a/python/adbc_driver_manager/pyproject.toml
+++ b/python/adbc_driver_manager/pyproject.toml
@@ -25,8 +25,8 @@ requires-python = ">=3.9"
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dbapi = ["pandas", "pyarrow>=14.0.1"]
-test = ["duckdb", "pandas", "pyarrow>=14.0.1", "pytest"]
+dbapi = ["pandas", "pyarrow>=8.0.0"]
+test = ["duckdb", "pandas", "pyarrow>=8.0.0", "pytest"]
 
 [project.urls]
 homepage = "https://arrow.apache.org/adbc/"

--- a/python/adbc_driver_manager/tests/test_lowlevel.py
+++ b/python/adbc_driver_manager/tests/test_lowlevel.py
@@ -390,3 +390,13 @@ def test_child_tracking(sqlite):
                 RuntimeError, match="Cannot close AdbcDatabase with open AdbcConnection"
             ):
                 db.close()
+
+
+@pytest.mark.sqlite
+def test_pycapsule(sqlite):
+    _, conn = sqlite
+    handle = conn.get_table_types()
+    with pyarrow.RecordBatchReader._import_from_c_capsule(handle.__arrow_c_array_stream__()) as reader:
+        reader.read_all()
+
+    # TODO: also need to import from things supporting protocol

--- a/python/adbc_driver_manager/tests/test_lowlevel.py
+++ b/python/adbc_driver_manager/tests/test_lowlevel.py
@@ -396,7 +396,9 @@ def test_child_tracking(sqlite):
 def test_pycapsule(sqlite):
     _, conn = sqlite
     handle = conn.get_table_types()
-    with pyarrow.RecordBatchReader._import_from_c_capsule(handle.__arrow_c_stream__()) as reader:
+    with pyarrow.RecordBatchReader._import_from_c_capsule(
+        handle.__arrow_c_stream__()
+    ) as reader:
         reader.read_all()
 
     # set up some data


### PR DESCRIPTION
Addresses https://github.com/apache/arrow-adbc/issues/70

This PR adds the dunder methods to the Handle classes of the low-level interface (which already enables using the low-level interface without pyarrow and with the capsule protocol). 

And secondly, in the places that accept data (eg ingest/bind), it now also accepts objects that implement the dunders in addition to hardcoded support for pyarrow.