### PR TITLE
Reduced SQL calls in GetObjects to one and added prefixing DbNam…

### DIFF
--- a/csharp/test/Drivers/Snowflake/DriverTests.cs
+++ b/csharp/test/Drivers/Snowflake/DriverTests.cs
@@ -82,12 +82,6 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
             Dictionary<string, string> options = new Dictionary<string, string>();
             _snowflakeDriver = SnowflakeTestingUtils.GetSnowflakeAdbcDriver(_testConfiguration, out parameters);
 
-            string databaseName = _testConfiguration.Metadata.Catalog;
-            string schemaName = _testConfiguration.Metadata.Schema;
-
-            parameters[SnowflakeParameters.DATABASE] = databaseName;
-            parameters[SnowflakeParameters.SCHEMA] = schemaName;
-
             _database = _snowflakeDriver.Open(parameters);
             _connection = _database.Connect(options);
         }
@@ -214,7 +208,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
             string tableName = _testConfiguration.Metadata.Table;
 
             using IArrowArrayStream stream = _connection.GetObjects(
-                    depth: AdbcConnection.GetObjectsDepth.All,
+                    depth: AdbcConnection.GetObjectsDepth.Tables,
                     catalogPattern: databaseName,
                     dbSchemaPattern: schemaName,
                     tableNamePattern: tableNamePattern,
@@ -235,6 +229,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
 
             AdbcTable table = tables.Where((table) => string.Equals(table.Name, tableName)).FirstOrDefault();
             Assert.True(table != null, "table should not be null");
+            Assert.Equal("BASE TABLE", table.Type);
         }
 
         /// <summary>
@@ -260,8 +255,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
             using RecordBatch recordBatch = stream.ReadNextRecordBatchAsync().Result;
 
             List<AdbcCatalog> catalogs = GetObjectsParser.ParseCatalog(recordBatch, databaseName, schemaName);
-
-            List<AdbcColumn> columns = catalogs
+            AdbcTable table = catalogs
                 .Where(c => string.Equals(c.Name, databaseName))
                 .Select(c => c.DbSchemas)
                 .FirstOrDefault()
@@ -269,8 +263,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
                 .Select(s => s.Tables)
                 .FirstOrDefault()
                 .Where(t => string.Equals(t.Name, tableName))
-                .Select(t => t.Columns)
                 .FirstOrDefault();
+
+
+            Assert.True(table != null, "table should not be null");
+            Assert.Equal("BASE TABLE", table.Type);
+            List<AdbcColumn> columns = table.Columns;
 
             Assert.True(columns != null, "Columns cannot be null");
             Assert.Equal(_testConfiguration.Metadata.ExpectedColumnCount, columns.Count);

--- a/go/adbc/driver/flightsql/flightsql_connection.go
+++ b/go/adbc/driver/flightsql/flightsql_connection.go
@@ -547,7 +547,7 @@ func (c *cnxn) readInfo(ctx context.Context, expectedSchema *arrow.Schema, info 
 }
 
 // Helper function to build up a map of catalogs to DB schemas
-func (c *cnxn) getObjectsDbSchemas(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string) (result map[string][]string, err error) {
+func (c *cnxn) getObjectsDbSchemas(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string, metadataRecords []internal.Metadata) (result map[string][]string, err error) {
 	if depth == adbc.ObjectDepthCatalogs {
 		return
 	}
@@ -588,7 +588,7 @@ func (c *cnxn) getObjectsDbSchemas(ctx context.Context, depth adbc.ObjectDepth, 
 	return
 }
 
-func (c *cnxn) getObjectsTables(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string, tableName *string, columnName *string, tableType []string) (result internal.SchemaToTableInfo, err error) {
+func (c *cnxn) getObjectsTables(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string, tableName *string, columnName *string, tableType []string, metadataRecords []internal.Metadata) (result internal.SchemaToTableInfo, err error) {
 	if depth == adbc.ObjectDepthCatalogs || depth == adbc.ObjectDepthDBSchemas {
 		return
 	}

--- a/go/adbc/driver/snowflake/connection.go
+++ b/go/adbc/driver/snowflake/connection.go
@@ -238,84 +238,59 @@ func (c *cnxn) GetInfo(ctx context.Context, infoCodes []adbc.InfoCode) (array.Re
 // All non-empty, non-nil strings should be a search pattern (as described
 // earlier).
 func (c *cnxn) GetObjects(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string, tableName *string, columnName *string, tableType []string) (array.RecordReader, error) {
+	metadataRecords, err := c.populateMetadata(ctx, depth, catalog, dbSchema, tableName, columnName, tableType)
+	if err != nil {
+		return nil, err
+	}
+
 	g := internal.GetObjects{Ctx: ctx, Depth: depth, Catalog: catalog, DbSchema: dbSchema, TableName: tableName, ColumnName: columnName, TableType: tableType}
+	g.MetadataRecords = metadataRecords
 	if err := g.Init(c.db.Alloc, c.getObjectsDbSchemas, c.getObjectsTables); err != nil {
 		return nil, err
 	}
 	defer g.Release()
 
-	rows, err := c.sqldb.QueryContext(ctx, "SHOW TERSE DATABASES", nil)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var (
-		created              time.Time
-		name                 string
-		kind, dbname, schema sql.NullString
-	)
-	for rows.Next() {
-		if err := rows.Scan(&created, &name, &kind, &dbname, &schema); err != nil {
-			return nil, errToAdbcErr(adbc.StatusInvalidData, err)
-		}
-
-		// SNOWFLAKE catalog contains functions and no tables
-		if name == "SNOWFLAKE" {
+	uniqueCatalogs := make(map[string]bool)
+	for _, data := range metadataRecords {
+		if !data.Dbname.Valid {
 			continue
 		}
 
-		// schema for SHOW TERSE DATABASES is:
-		// created_on:timestamp, name:text, kind:null, database_name:null, schema_name:null
-		// the last three columns are always null because they are not applicable for databases
-		// so we want values[1].(string) for the name
-		g.AppendCatalog(name)
+		if _, exists := uniqueCatalogs[data.Dbname.String]; !exists {
+			uniqueCatalogs[data.Dbname.String] = true
+			g.AppendCatalog(data.Dbname.String)
+		}
 	}
 
 	return g.Finish()
 }
 
-func (c *cnxn) getObjectsDbSchemas(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string) (result map[string][]string, err error) {
+func (c *cnxn) getObjectsDbSchemas(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string, metadataRecords []internal.Metadata) (result map[string][]string, err error) {
 	if depth == adbc.ObjectDepthCatalogs {
 		return
 	}
 
-	conditions := make([]string, 0)
-	if catalog != nil && *catalog != "" {
-		conditions = append(conditions, ` CATALOG_NAME ILIKE '`+*catalog+`'`)
-	}
-	if dbSchema != nil && *dbSchema != "" {
-		conditions = append(conditions, ` SCHEMA_NAME ILIKE '`+*dbSchema+`'`)
-	}
-
-	cond := strings.Join(conditions, " AND ")
-
 	result = make(map[string][]string)
+	uniqueCatalogSchema := make(map[string]map[string]bool)
 
-	query := `SELECT CATALOG_NAME, SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA`
-	if cond != "" {
-		query += " WHERE " + cond
-	}
-	var rows *sql.Rows
-	rows, err = c.sqldb.QueryContext(ctx, query)
-	if err != nil {
-		err = errToAdbcErr(adbc.StatusIO, err)
-		return
-	}
-	defer rows.Close()
-
-	var catalogName, schemaName string
-	for rows.Next() {
-		if err = rows.Scan(&catalogName, &schemaName); err != nil {
-			err = errToAdbcErr(adbc.StatusIO, err)
-			return
+	for _, data := range metadataRecords {
+		if !data.Dbname.Valid || !data.Schema.Valid {
+			continue
 		}
 
-		cat, ok := result[catalogName]
-		if !ok {
+		if _, exists := uniqueCatalogSchema[data.Dbname.String]; !exists {
+			uniqueCatalogSchema[data.Dbname.String] = make(map[string]bool)
+		}
+
+		cat, exists := result[data.Dbname.String]
+		if !exists {
 			cat = make([]string, 0, 1)
 		}
-		result[catalogName] = append(cat, schemaName)
+
+		if _, exists := uniqueCatalogSchema[data.Dbname.String][data.Schema.String]; !exists {
+			result[data.Dbname.String] = append(cat, data.Schema.String)
+			uniqueCatalogSchema[data.Dbname.String][data.Schema.String] = true
+		}
 	}
 
 	return
@@ -477,7 +452,7 @@ func toXdbcDataType(dt arrow.DataType) (xdbcType internal.XdbcDataType) {
 	}
 }
 
-func (c *cnxn) getObjectsTables(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string, tableName *string, columnName *string, tableType []string) (result internal.SchemaToTableInfo, err error) {
+func (c *cnxn) getObjectsTables(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string, tableName *string, columnName *string, tableType []string, metadataRecords []internal.Metadata) (result internal.SchemaToTableInfo, err error) {
 	if depth == adbc.ObjectDepthCatalogs || depth == adbc.ObjectDepthDBSchemas {
 		return
 	}
@@ -485,77 +460,293 @@ func (c *cnxn) getObjectsTables(ctx context.Context, depth adbc.ObjectDepth, cat
 	result = make(internal.SchemaToTableInfo)
 	includeSchema := depth == adbc.ObjectDepthAll || depth == adbc.ObjectDepthColumns
 
+	uniqueCatalogSchemaTable := make(map[string]map[string]map[string]bool)
+	for _, data := range metadataRecords {
+		if !data.Dbname.Valid || !data.Schema.Valid || !data.TblName.Valid || !data.TblType.Valid {
+			continue
+		}
+
+		if _, exists := uniqueCatalogSchemaTable[data.Dbname.String]; !exists {
+			uniqueCatalogSchemaTable[data.Dbname.String] = make(map[string]map[string]bool)
+		}
+
+		if _, exists := uniqueCatalogSchemaTable[data.Dbname.String][data.Schema.String]; !exists {
+			uniqueCatalogSchemaTable[data.Dbname.String][data.Schema.String] = make(map[string]bool)
+		}
+
+		if _, exists := uniqueCatalogSchemaTable[data.Dbname.String][data.Schema.String][data.TblName.String]; !exists {
+			uniqueCatalogSchemaTable[data.Dbname.String][data.Schema.String][data.TblName.String] = true
+
+			key := internal.CatalogAndSchema{
+				Catalog: data.Dbname.String, Schema: data.Schema.String}
+
+			result[key] = append(result[key], internal.TableInfo{
+				Name: data.TblName.String, TableType: data.TblType.String})
+		}
+	}
+
+	if includeSchema {
+		var (
+			prevKey      internal.CatalogAndSchema
+			curTableInfo *internal.TableInfo
+			fieldList    = make([]arrow.Field, 0)
+		)
+
+		for _, data := range metadataRecords {
+			if !data.Dbname.Valid || !data.Schema.Valid || !data.TblName.Valid {
+				continue
+			}
+
+			key := internal.CatalogAndSchema{Catalog: data.Dbname.String, Schema: data.Schema.String}
+			if prevKey != key || (curTableInfo != nil && curTableInfo.Name != data.TblName.String) {
+				if len(fieldList) > 0 && curTableInfo != nil {
+					curTableInfo.Schema = arrow.NewSchema(fieldList, nil)
+					fieldList = fieldList[:0]
+				}
+
+				info := result[key]
+				for i := range info {
+					if info[i].Name == data.TblName.String {
+						curTableInfo = &info[i]
+						break
+					}
+				}
+			}
+
+			prevKey = key
+			fieldList = append(fieldList, toField(data.ColName, data.IsNullable, data.DataType, data.NumericPrec, data.NumericPrecRadix, data.NumericScale, data.IsIdent, c.useHighPrecision, data.IdentGen, data.IdentIncrement, data.CharMaxLength, data.CharOctetLength, data.DatetimePrec, data.Comment, data.OrdinalPos))
+		}
+
+		if len(fieldList) > 0 && curTableInfo != nil {
+			curTableInfo.Schema = arrow.NewSchema(fieldList, nil)
+		}
+	}
+	return
+}
+
+func (c *cnxn) populateMetadata(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string, tableName *string, columnName *string, tableType []string) ([]internal.Metadata, error) {
+	var metadataRecords []internal.Metadata
+	if depth == adbc.ObjectDepthCatalogs {
+		rows, err := c.sqldb.QueryContext(ctx, prepareCatalogsSQL(), nil)
+		if err != nil {
+			return nil, err
+		}
+
+		for rows.Next() {
+			var data internal.Metadata
+			var skipDbNullField, skipSchemaNullField sql.NullString
+			// schema for SHOW TERSE DATABASES is:
+			// created_on:timestamp, name:text, kind:null, database_name:null, schema_name:null
+			// the last three columns are always null because they are not applicable for databases
+			// so we want values[1].(string) for the name
+			if err := rows.Scan(&data.Created, &data.Dbname, &data.Kind, &skipDbNullField, &skipSchemaNullField); err != nil {
+				return nil, errToAdbcErr(adbc.StatusInvalidData, err)
+			}
+
+			// SNOWFLAKE catalog contains functions and no tables
+			if data.Dbname.Valid && data.Dbname.String == "SNOWFLAKE" {
+				continue
+			}
+
+			metadataRecords = append(metadataRecords, data)
+		}
+	} else if depth == adbc.ObjectDepthDBSchemas {
+		query := prepareDbSchemasSQL(catalog, dbSchema)
+		rows, err := c.sqldb.QueryContext(ctx, query)
+		if err != nil {
+			return nil, errToAdbcErr(adbc.StatusIO, err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var data internal.Metadata
+			if err = rows.Scan(&data.Dbname, &data.Schema); err != nil {
+				return nil, errToAdbcErr(adbc.StatusIO, err)
+			}
+			metadataRecords = append(metadataRecords, data)
+		}
+	} else if depth == adbc.ObjectDepthTables {
+		query := prepareTablesSQL(catalog, dbSchema, tableName, tableType)
+		rows, err := c.sqldb.QueryContext(ctx, query)
+		if err != nil {
+			return nil, errToAdbcErr(adbc.StatusIO, err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var data internal.Metadata
+			if err = rows.Scan(&data.Dbname, &data.Schema, &data.TblName, &data.TblType); err != nil {
+				return nil, errToAdbcErr(adbc.StatusIO, err)
+			}
+			metadataRecords = append(metadataRecords, data)
+		}
+	} else {
+		query := prepareColumnsSQL(catalog, dbSchema, tableName, columnName)
+		rows, err := c.sqldb.QueryContext(ctx, query)
+		if err != nil {
+			return nil, errToAdbcErr(adbc.StatusIO, err)
+		}
+		defer rows.Close()
+
+		var data internal.Metadata
+
+		for rows.Next() {
+			// order here matches the order of the columns requested in the query
+			err = rows.Scan(&data.TblType, &data.Dbname, &data.Schema, &data.TblName, &data.ColName,
+				&data.OrdinalPos, &data.IsNullable, &data.DataType, &data.NumericPrec,
+				&data.NumericPrecRadix, &data.NumericScale, &data.IsIdent, &data.IdentGen,
+				&data.IdentIncrement, &data.CharMaxLength, &data.CharOctetLength, &data.DatetimePrec, &data.Comment)
+			if err != nil {
+				return nil, errToAdbcErr(adbc.StatusIO, err)
+			}
+			metadataRecords = append(metadataRecords, data)
+		}
+	}
+
+	return metadataRecords, nil
+}
+
+func prepareCatalogsSQL() string {
+	return "SHOW TERSE DATABASES"
+}
+
+func prepareDbSchemasSQL(catalog *string, dbSchema *string) string {
 	conditions := make([]string, 0)
 	if catalog != nil && *catalog != "" {
-		conditions = append(conditions, ` TABLE_CATALOG ILIKE '`+*catalog+`'`)
+		conditions = append(conditions, ` CATALOG_NAME ILIKE \'`+*catalog+`\'`)
 	}
 	if dbSchema != nil && *dbSchema != "" {
-		conditions = append(conditions, ` TABLE_SCHEMA ILIKE '`+*dbSchema+`'`)
+		conditions = append(conditions, ` SCHEMA_NAME ILIKE \'`+*dbSchema+`\'`)
+	}
+
+	cond := strings.Join(conditions, " AND ")
+	if cond != "" {
+		cond = `statement := 'SELECT * FROM (' || statement || ') WHERE ` + cond + `';`
+	}
+
+	queryPrefix := `DECLARE
+	    c1 CURSOR FOR SELECT DATABASE_NAME FROM INFORMATION_SCHEMA.DATABASES;
+			res RESULTSET;
+			counter INTEGER DEFAULT 0;
+			statement VARCHAR DEFAULT '';
+		BEGIN
+		  FOR rec IN c1 DO
+				IF (counter > 0) THEN
+				  statement := statement || ' UNION ALL ';
+				END IF;
+				statement := statement || ' SELECT CATALOG_NAME, SCHEMA_NAME FROM "' || rec.database_name || '".INFORMATION_SCHEMA.SCHEMATA';
+				counter := counter + 1;
+			END FOR;
+		  `
+	if catalog != nil && *catalog != "" {
+		queryPrefix = `DECLARE
+	    c1 CURSOR FOR SELECT DATABASE_NAME FROM INFORMATION_SCHEMA.DATABASES WHERE DATABASE_NAME ILIKE '` + *catalog + `';` +
+			`res RESULTSET;
+			counter INTEGER DEFAULT 0;
+			statement VARCHAR DEFAULT '';
+		BEGIN
+		  FOR rec IN c1 DO
+				IF (counter > 0) THEN
+				  statement := statement || ' UNION ALL ';
+				END IF;
+				statement := statement || ' SELECT CATALOG_NAME, SCHEMA_NAME FROM "' || rec.database_name || '".INFORMATION_SCHEMA.SCHEMATA';
+				counter := counter + 1;
+			END FOR;
+		  `
+	}
+	const querySuffix = `
+	    res := (EXECUTE IMMEDIATE :statement);
+			RETURN TABLE (res);
+		END;`
+
+	query := queryPrefix + cond + querySuffix
+	return query
+}
+
+func prepareTablesSQL(catalog *string, dbSchema *string, tableName *string, tableType []string) string {
+	conditions := make([]string, 0)
+	if catalog != nil && *catalog != "" {
+		conditions = append(conditions, ` TABLE_CATALOG ILIKE \'`+*catalog+`\'`)
+	}
+	if dbSchema != nil && *dbSchema != "" {
+		conditions = append(conditions, ` TABLE_SCHEMA ILIKE \'`+*dbSchema+`\'`)
 	}
 	if tableName != nil && *tableName != "" {
-		conditions = append(conditions, ` TABLE_NAME ILIKE '`+*tableName+`'`)
+		conditions = append(conditions, ` TABLE_NAME ILIKE \'`+*tableName+`\'`)
 	}
 
 	// first populate the tables and table types
-	var rows *sql.Rows
 	var tblConditions []string
 	if len(tableType) > 0 {
-		tblConditions = append(conditions, ` TABLE_TYPE IN ('`+strings.Join(tableType, `','`)+`')`)
+		tblConditions = append(conditions, ` TABLE_TYPE IN (\'`+strings.Join(tableType, `\',\'`)+`\')`)
 	} else {
 		tblConditions = conditions
 	}
 
+	queryPrefix := `DECLARE
+		c1 CURSOR FOR SELECT DATABASE_NAME FROM INFORMATION_SCHEMA.DATABASES;
+		res RESULTSET;
+		counter INTEGER DEFAULT 0;
+		statement VARCHAR DEFAULT '';
+	BEGIN
+		FOR rec IN c1 DO
+			IF (counter > 0) THEN
+				statement := statement || ' UNION ALL ';
+			END IF;
+			`
+	if catalog != nil && *catalog != "" {
+		queryPrefix = `DECLARE
+		c1 CURSOR FOR SELECT DATABASE_NAME FROM INFORMATION_SCHEMA.DATABASES WHERE DATABASE_NAME ILIKE '` + *catalog + `';` +
+			`res RESULTSET;
+		counter INTEGER DEFAULT 0;
+		statement VARCHAR DEFAULT '';
+	BEGIN
+		FOR rec IN c1 DO
+			IF (counter > 0) THEN
+				statement := statement || ' UNION ALL ';
+			END IF;
+			`
+	}
+	const noSchema = `statement := statement || ' SELECT table_catalog, table_schema, table_name, table_type FROM "' || rec.database_name || '".INFORMATION_SCHEMA.TABLES';
+			counter := counter + 1;
+		END FOR;
+		`
+	const querySuffix = `
+		res := (EXECUTE IMMEDIATE :statement);
+		RETURN TABLE (res);
+	END;`
+
 	cond := strings.Join(tblConditions, " AND ")
-	query := "SELECT table_catalog, table_schema, table_name, table_type FROM INFORMATION_SCHEMA.TABLES"
 	if cond != "" {
-		query += " WHERE " + cond
+		cond = `statement := 'SELECT * FROM (' || statement || ') WHERE ` + cond + `';`
 	}
-	rows, err = c.sqldb.QueryContext(ctx, query)
-	if err != nil {
-		err = errToAdbcErr(adbc.StatusIO, err)
-		return
+	query := queryPrefix + noSchema + cond + querySuffix
+	return query
+}
+
+func prepareColumnsSQL(catalog *string, dbSchema *string, tableName *string, columnName *string) string {
+	conditions := make([]string, 0)
+	if catalog != nil && *catalog != "" {
+		conditions = append(conditions, ` TABLE_CATALOG ILIKE \'`+*catalog+`\'`)
 	}
-	defer rows.Close()
-
-	var tblCat, tblSchema, tblName string
-	var tblType sql.NullString
-	for rows.Next() {
-		if err = rows.Scan(&tblCat, &tblSchema, &tblName, &tblType); err != nil {
-			err = errToAdbcErr(adbc.StatusIO, err)
-			return
-		}
-
-		key := internal.CatalogAndSchema{
-			Catalog: tblCat, Schema: tblSchema}
-
-		result[key] = append(result[key], internal.TableInfo{
-			Name: tblName, TableType: tblType.String})
+	if dbSchema != nil && *dbSchema != "" {
+		conditions = append(conditions, ` TABLE_SCHEMA ILIKE \'`+*dbSchema+`\'`)
+	}
+	if tableName != nil && *tableName != "" {
+		conditions = append(conditions, ` TABLE_NAME ILIKE \'`+*tableName+`\'`)
 	}
 
-	if includeSchema {
-		conditions := make([]string, 0)
-		if catalog != nil && *catalog != "" {
-			conditions = append(conditions, ` TABLE_CATALOG ILIKE \'`+*catalog+`\'`)
-		}
-		if dbSchema != nil && *dbSchema != "" {
-			conditions = append(conditions, ` TABLE_SCHEMA ILIKE \'`+*dbSchema+`\'`)
-		}
-		if tableName != nil && *tableName != "" {
-			conditions = append(conditions, ` TABLE_NAME ILIKE \'`+*tableName+`\'`)
-		}
-		// if we need to include the schemas of the tables, make another fetch
-		// to fetch the columns and column info
-		if columnName != nil && *columnName != "" {
-			conditions = append(conditions, ` column_name ILIKE \'`+*columnName+`\'`)
-		}
-		cond = strings.Join(conditions, " AND ")
-		if cond != "" {
-			cond = " WHERE " + cond
-		}
-		cond = `statement := 'SELECT * FROM (' || statement || ')` + cond +
-			` ORDER BY table_catalog, table_schema, table_name, ordinal_position';`
+	if columnName != nil && *columnName != "" {
+		conditions = append(conditions, ` column_name ILIKE \'`+*columnName+`\'`)
+	}
+	cond := strings.Join(conditions, " AND ")
+	if cond != "" {
+		cond = " WHERE " + cond
+	}
+	cond = `statement := 'SELECT * FROM (' || statement || ')` + cond +
+		` ORDER BY table_catalog, table_schema, table_name, ordinal_position';`
 
-		var queryPrefix = `DECLARE
+	var queryPrefix = `DECLARE
 			c1 CURSOR FOR SELECT DATABASE_NAME FROM INFORMATION_SCHEMA.DATABASES;
 			res RESULTSET;
 			counter INTEGER DEFAULT 0;
@@ -567,28 +758,35 @@ func (c *cnxn) getObjectsTables(ctx context.Context, depth adbc.ObjectDepth, cat
 				END IF;
 				`
 
-		const getSchema = `statement := statement ||
-			' SELECT
-					table_catalog, table_schema, table_name, column_name,
-					ordinal_position, is_nullable::boolean, data_type, numeric_precision,
-					numeric_precision_radix, numeric_scale, is_identity::boolean,
-					identity_generation, identity_increment,
-					character_maximum_length, character_octet_length, datetime_precision, comment
-			FROM ' || rec.database_name || '.INFORMATION_SCHEMA.COLUMNS';
+	const getSchema = `statement := statement ||
+				'SELECT T.table_type,
+				C.table_catalog, C.table_schema, C.table_name, C.column_name,
+						C.ordinal_position, C.is_nullable::boolean, C.data_type, C.numeric_precision,
+						C.numeric_precision_radix, C.numeric_scale, C.is_identity::boolean,
+						C.identity_generation, C.identity_increment,
+						C.character_maximum_length, C.character_octet_length, C.datetime_precision, C.comment
+				FROM
+				"' || rec.database_name || '".INFORMATION_SCHEMA.TABLES AS T
+			JOIN
+				"' || rec.database_name || '".INFORMATION_SCHEMA.COLUMNS AS C
+			ON
+				T.table_catalog = C.table_catalog
+				AND T.table_schema = C.table_schema
+				AND t.table_name = C.table_name';
 
 			  counter := counter + 1;
 			END FOR;
 		  `
 
-		const querySuffix = `
+	const querySuffix = `
 			res := (EXECUTE IMMEDIATE :statement);
 			RETURN TABLE (res);
 		END;`
 
-		if catalog != nil && *catalog != "" {
-			queryPrefix = `DECLARE
+	if catalog != nil && *catalog != "" {
+		queryPrefix = `DECLARE
 				c1 CURSOR FOR SELECT DATABASE_NAME FROM INFORMATION_SCHEMA.DATABASES WHERE DATABASE_NAME ILIKE '` + *catalog + `';` +
-				`res RESULTSET;
+			`res RESULTSET;
 				counter INTEGER DEFAULT 0;
 				statement VARCHAR DEFAULT '';
 			BEGIN
@@ -597,63 +795,9 @@ func (c *cnxn) getObjectsTables(ctx context.Context, depth adbc.ObjectDepth, cat
 						statement := statement || ' UNION ALL ';
 					END IF;
 					`
-		}
-		query = queryPrefix + getSchema + cond + querySuffix
-		rows, err = c.sqldb.QueryContext(ctx, query)
-		if err != nil {
-			return
-		}
-		defer rows.Close()
-
-		var (
-			colName, dataType                                         string
-			identGen, identIncrement, comment                         sql.NullString
-			ordinalPos                                                int
-			numericPrec, numericPrecRadix, numericScale, datetimePrec sql.NullInt16
-			isNullable, isIdent                                       bool
-			charMaxLength, charOctetLength                            sql.NullInt32
-
-			prevKey      internal.CatalogAndSchema
-			curTableInfo *internal.TableInfo
-			fieldList    = make([]arrow.Field, 0)
-		)
-
-		for rows.Next() {
-			// order here matches the order of the columns requested in the query
-			err = rows.Scan(&tblCat, &tblSchema, &tblName, &colName,
-				&ordinalPos, &isNullable, &dataType, &numericPrec,
-				&numericPrecRadix, &numericScale, &isIdent, &identGen,
-				&identIncrement, &charMaxLength, &charOctetLength, &datetimePrec, &comment)
-			if err != nil {
-				err = errToAdbcErr(adbc.StatusIO, err)
-				return
-			}
-
-			key := internal.CatalogAndSchema{Catalog: tblCat, Schema: tblSchema}
-			if prevKey != key || (curTableInfo != nil && curTableInfo.Name != tblName) {
-				if len(fieldList) > 0 && curTableInfo != nil {
-					curTableInfo.Schema = arrow.NewSchema(fieldList, nil)
-					fieldList = fieldList[:0]
-				}
-
-				info := result[key]
-				for i := range info {
-					if info[i].Name == tblName {
-						curTableInfo = &info[i]
-						break
-					}
-				}
-			}
-
-			prevKey = key
-			fieldList = append(fieldList, toField(colName, isNullable, dataType, numericPrec, numericPrecRadix, numericScale, isIdent, c.useHighPrecision, identGen, identIncrement, charMaxLength, charOctetLength, datetimePrec, comment, ordinalPos))
-		}
-
-		if len(fieldList) > 0 && curTableInfo != nil {
-			curTableInfo.Schema = arrow.NewSchema(fieldList, nil)
-		}
 	}
-	return
+	query := queryPrefix + getSchema + cond + querySuffix
+	return query
 }
 
 func descToField(name, typ, isnull, primary string, comment sql.NullString) (field arrow.Field, err error) {


### PR DESCRIPTION
Changes:
* Reduced SQL calls by making only one SQL call based on the ObjectsDepth and using that data to populate all the previous depth information
* Modified tests to check the table type returned
* GetObjects populates the MetadataRecords by making the necessary SQL call based on ObjectsDepth
* Modified the logic of GetObjects Init to pass MetadataRecords in getObjectsDbSchemas and getObjectsTables

<img width="638" alt="image" src="https://github.com/apache/arrow-adbc/assets/5041197/6c842ab4-a8d6-446d-ba69-c42ef620e868">
