### PR TITLE
fix(c/driver/postgresql): fix ingest with multiple batches

### DIFF
--- a/c/driver/postgresql/postgres_copy_reader.h
+++ b/c/driver/postgresql/postgres_copy_reader.h
@@ -1460,13 +1460,17 @@ static inline ArrowErrorCode MakeCopyFieldWriter(struct ArrowSchema* schema,
 
 class PostgresCopyStreamWriter {
  public:
-  ArrowErrorCode Init(struct ArrowSchema* schema, struct ArrowArray* array) {
+  ArrowErrorCode Init(struct ArrowSchema* schema) {
     schema_ = schema;
     NANOARROW_RETURN_NOT_OK(
         ArrowArrayViewInitFromSchema(&array_view_.value, schema, nullptr));
-    NANOARROW_RETURN_NOT_OK(ArrowArrayViewSetArray(&array_view_.value, array, nullptr));
     root_writer_.Init(&array_view_.value);
     ArrowBufferInit(&buffer_.value);
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode SetArray(struct ArrowArray* array) {
+    NANOARROW_RETURN_NOT_OK(ArrowArrayViewSetArray(&array_view_.value, array, nullptr));
     return NANOARROW_OK;
   }
 
@@ -1507,6 +1511,11 @@ class PostgresCopyStreamWriter {
   }
 
   const struct ArrowBuffer& WriteBuffer() const { return buffer_.value; }
+
+  void Rewind() {
+    records_written_ = 0;
+    buffer_->size_bytes = 0;
+  }
 
  private:
   PostgresCopyFieldTupleWriter root_writer_;

--- a/c/driver/postgresql/postgres_util.h
+++ b/c/driver/postgresql/postgres_util.h
@@ -166,9 +166,11 @@ struct Handle {
 
   Handle() { std::memset(&value, 0, sizeof(value)); }
 
-  ~Handle() { Releaser<Resource>::Release(&value); }
+  ~Handle() { reset(); }
 
   Resource* operator->() { return &value; }
+
+  void reset() { Releaser<Resource>::Release(&value);  }
 };
 
 }  // namespace adbcpq

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -565,7 +565,12 @@ struct BindStream {
   AdbcStatusCode ExecuteCopy(PGconn* conn, int64_t* rows_affected,
                              struct AdbcError* error) {
     if (rows_affected) *rows_affected = 0;
-    PGresult* result = nullptr;
+
+    PostgresCopyStreamWriter writer;
+    CHECK_NA(INTERNAL, writer.Init(&bind_schema.value), error);
+    CHECK_NA(INTERNAL, writer.InitFieldWriters(nullptr), error);
+
+    CHECK_NA(INTERNAL, writer.WriteHeader(nullptr), error);
 
     while (true) {
       Handle<struct ArrowArray> array;
@@ -579,20 +584,9 @@ struct BindStream {
       }
       if (!array->release) break;
 
-      Handle<struct ArrowArrayView> array_view;
-      CHECK_NA(
-          INTERNAL,
-          ArrowArrayViewInitFromSchema(&array_view.value, &bind_schema.value, nullptr),
-          error);
-      CHECK_NA(INTERNAL, ArrowArrayViewSetArray(&array_view.value, &array.value, nullptr),
-               error);
-
-      PostgresCopyStreamWriter writer;
-      CHECK_NA(INTERNAL, writer.Init(&bind_schema.value, &array.value), error);
-      CHECK_NA(INTERNAL, writer.InitFieldWriters(nullptr), error);
+      CHECK_NA(INTERNAL, writer.SetArray(&array.value), error);
 
       // build writer buffer
-      CHECK_NA(INTERNAL, writer.WriteHeader(nullptr), error);
       int write_result;
       do {
         write_result = writer.WriteRecord(nullptr);
@@ -611,25 +605,26 @@ struct BindStream {
         return ADBC_STATUS_IO;
       }
 
-      if (PQputCopyEnd(conn, NULL) <= 0) {
-        SetError(error, "Error message returned by PQputCopyEnd: %s",
-                 PQerrorMessage(conn));
-        return ADBC_STATUS_IO;
-      }
-
-      result = PQgetResult(conn);
-      ExecStatusType pg_status = PQresultStatus(result);
-      if (pg_status != PGRES_COMMAND_OK) {
-        AdbcStatusCode code =
-            SetError(error, result, "[libpq] Failed to execute COPY statement: %s %s",
-                     PQresStatus(pg_status), PQerrorMessage(conn));
-        PQclear(result);
-        return code;
-      }
-
-      PQclear(result);
       if (rows_affected) *rows_affected += array->length;
+      writer.Rewind();
     }
+
+    if (PQputCopyEnd(conn, NULL) <= 0) {
+      SetError(error, "Error message returned by PQputCopyEnd: %s", PQerrorMessage(conn));
+      return ADBC_STATUS_IO;
+    }
+
+    PGresult* result = PQgetResult(conn);
+    ExecStatusType pg_status = PQresultStatus(result);
+    if (pg_status != PGRES_COMMAND_OK) {
+      AdbcStatusCode code =
+          SetError(error, result, "[libpq] Failed to execute COPY statement: %s %s",
+                   PQresStatus(pg_status), PQerrorMessage(conn));
+      PQclear(result);
+      return code;
+    }
+
+    PQclear(result);
     return ADBC_STATUS_OK;
   }
 };

--- a/docs/source/python/recipe/postgresql.rst
+++ b/docs/source/python/recipe/postgresql.rst
@@ -26,6 +26,11 @@ Authenticate with a username and password
 
 .. _recipe-postgresql-create-append:
 
+Create/append to a table from an Arrow dataset
+==============================================
+
+.. recipe:: postgresql_create_dataset_table.py
+
 Create/append to a table from an Arrow table
 ============================================
 

--- a/docs/source/python/recipe/postgresql_create_dataset_table.py
+++ b/docs/source/python/recipe/postgresql_create_dataset_table.py
@@ -1,0 +1,184 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# RECIPE STARTS HERE
+
+#: ADBC makes it easy to load PyArrow datasets into your datastore.
+
+import os
+import tempfile
+from pathlib import Path
+
+import pyarrow
+import pyarrow.csv
+import pyarrow.dataset
+import pyarrow.feather
+import pyarrow.parquet
+
+import adbc_driver_postgresql.dbapi
+
+uri = os.environ["ADBC_POSTGRESQL_TEST_URI"]
+conn = adbc_driver_postgresql.dbapi.connect(uri)
+
+#: For the purposes of testing, we'll first make sure the tables we're about
+#: to use don't exist.
+with conn.cursor() as cur:
+    cur.execute("DROP TABLE IF EXISTS csvtable")
+    cur.execute("DROP TABLE IF EXISTS ipctable")
+    cur.execute("DROP TABLE IF EXISTS pqtable")
+    cur.execute("DROP TABLE IF EXISTS csvdataset")
+    cur.execute("DROP TABLE IF EXISTS ipcdataset")
+    cur.execute("DROP TABLE IF EXISTS pqdataset")
+
+conn.commit()
+
+#: Generating sample data
+#: ~~~~~~~~~~~~~~~~~~~~~~
+
+tempdir = tempfile.TemporaryDirectory(
+    prefix="adbc-docs-",
+    ignore_cleanup_errors=True,
+)
+root = Path(tempdir.name)
+table = pyarrow.table(
+    [
+        [1, 1, 2],
+        ["foo", "bar", "baz"],
+    ],
+    names=["ints", "strs"],
+)
+
+#: First we'll write single files.
+
+csv_file = root / "example.csv"
+pyarrow.csv.write_csv(table, csv_file)
+
+ipc_file = root / "example.arrow"
+pyarrow.feather.write_feather(table, ipc_file)
+
+parquet_file = root / "example.parquet"
+pyarrow.parquet.write_table(table, parquet_file)
+
+#: We'll also generate some partitioned datasets.
+
+csv_dataset = root / "csv_dataset"
+pyarrow.dataset.write_dataset(
+    table,
+    csv_dataset,
+    format="csv",
+    partitioning=["ints"],
+)
+
+ipc_dataset = root / "ipc_dataset"
+pyarrow.dataset.write_dataset(
+    table,
+    ipc_dataset,
+    format="feather",
+    partitioning=["ints"],
+)
+
+parquet_dataset = root / "parquet_dataset"
+pyarrow.dataset.write_dataset(
+    table,
+    parquet_dataset,
+    format="parquet",
+    partitioning=["ints"],
+)
+
+#: Loading CSV Files into PostgreSQL
+#: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+#: We can directly pass a :py:class:`pyarrow.RecordBatchReader` (from
+#: ``open_csv``) to ``adbc_ingest``.  We can also pass a
+#: :py:class:`pyarrow.dataset.Dataset`, or a
+#: :py:class:`pyarrow.dataset.Scanner`.
+
+with conn.cursor() as cur:
+    reader = pyarrow.csv.open_csv(csv_file)
+    cur.adbc_ingest("csvtable", reader, mode="create")
+
+    reader = pyarrow.dataset.dataset(
+        csv_dataset,
+        format="csv",
+        partitioning=["ints"],
+    )
+    cur.adbc_ingest("csvdataset", reader, mode="create")
+
+conn.commit()
+
+with conn.cursor() as cur:
+    cur.execute("SELECT ints, strs FROM csvtable ORDER BY ints, strs ASC")
+    assert cur.fetchall() == [(1, "bar"), (1, "foo"), (2, "baz")]
+
+    cur.execute("SELECT ints, strs FROM csvdataset ORDER BY ints, strs ASC")
+    assert cur.fetchall() == [(1, "bar"), (1, "foo"), (2, "baz")]
+
+#: Loading Arrow IPC (Feather) Files into PostgreSQL
+#: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+with conn.cursor() as cur:
+    reader = pyarrow.ipc.RecordBatchFileReader(ipc_file)
+    #: Because of quirks in the PyArrow API, we have to read the file into
+    #: memory.
+    cur.adbc_ingest("ipctable", reader.read_all(), mode="create")
+
+    #: The Dataset API will stream the data into memory and then into
+    #: PostgreSQL, though.
+    reader = pyarrow.dataset.dataset(
+        ipc_dataset,
+        format="feather",
+        partitioning=["ints"],
+    )
+    cur.adbc_ingest("ipcdataset", reader, mode="create")
+
+conn.commit()
+
+with conn.cursor() as cur:
+    cur.execute("SELECT ints, strs FROM ipctable ORDER BY ints, strs ASC")
+    assert cur.fetchall() == [(1, "bar"), (1, "foo"), (2, "baz")]
+
+    cur.execute("SELECT ints, strs FROM ipcdataset ORDER BY ints, strs ASC")
+    assert cur.fetchall() == [(1, "bar"), (1, "foo"), (2, "baz")]
+
+#: Loading Parquet Files into PostgreSQL
+#: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+with conn.cursor() as cur:
+    reader = pyarrow.parquet.ParquetFile(parquet_file)
+    cur.adbc_ingest("pqtable", reader.iter_batches(), mode="create")
+
+    reader = pyarrow.dataset.dataset(
+        parquet_dataset,
+        format="parquet",
+        partitioning=["ints"],
+    )
+    cur.adbc_ingest("pqdataset", reader, mode="create")
+
+conn.commit()
+
+with conn.cursor() as cur:
+    cur.execute("SELECT ints, strs FROM pqtable ORDER BY ints, strs ASC")
+    assert cur.fetchall() == [(1, "bar"), (1, "foo"), (2, "baz")]
+
+    cur.execute("SELECT ints, strs FROM pqdataset ORDER BY ints, strs ASC")
+    assert cur.fetchall() == [(1, "bar"), (1, "foo"), (2, "baz")]
+
+#: Cleanup
+#: ~~~~~~~
+
+conn.close()
+tempdir.cleanup()


### PR DESCRIPTION
The COPY writer was ending the COPY command after each batch, so any dataset with more than one batch would fail. Instead, write the header once and don't end the command until we've written all batches.

Fixes #1310.