### PR TITLE
chore(r): Housekeeping for R packages

### DIFF
--- a/docs/source/driver/duckdb.rst
+++ b/docs/source/driver/duckdb.rst
@@ -19,7 +19,7 @@
 DuckDB Support
 ==============
 
-**Available for:** C/C++, GLib/Ruby, Go, Python
+**Available for:** C/C++, GLib/Ruby, Go, Python, R
 
 `DuckDB`_ provides ADBC support since `version 0.8.0
 <https://duckdb.org/2023/05/17/announcing-duckdb-080.html>`_.
@@ -86,6 +86,18 @@ ADBC support in DuckDB requires the driver manager.
       You must have DuckDB 0.9.1 or higher.
 
       See the `DuckDB Python documentation`_.
+
+   .. tab-item:: R
+      :sync: r
+
+      You must have DuckDB 0.9.1 or higher.
+
+      .. code-block:: r
+
+         # install.packages("duckdb")
+         library(adbcdrivermanager)
+         db <- adbc_database_init(duckdb::duckdb_adbc(), ...)
+
 
 .. _DuckDB C++ documentation: https://duckdb.org/docs/api/adbc.html#c
 .. _DuckDB Python documentation: https://duckdb.org/docs/api/adbc.html#python

--- a/docs/source/driver/flight_sql.rst
+++ b/docs/source/driver/flight_sql.rst
@@ -19,7 +19,7 @@
 Flight SQL Driver
 =================
 
-**Available for:** C/C++, GLib/Ruby, Go, Java, Python
+**Available for:** C/C++, GLib/Ruby, Go, Java, Python, R
 
 The Flight SQL Driver provides access to any database implementing a
 :doc:`arrow:format/FlightSql` compatible endpoint.

--- a/docs/source/driver/installation.rst
+++ b/docs/source/driver/installation.rst
@@ -145,18 +145,21 @@ From conda-forge_:
 R
 =
 
-Install the appropriate driver package from GitHub:
+Install the appropriate driver package from CRAN:
+
+.. code-block:: r
+
+   install.packages("adbcsqlite")
+   install.packages("adbcpostgresql")
+   install.packages("duckdb")
+
+Drivers not yet available on CRAN can be installed from GitHub:
 
 .. code-block:: r
 
    # install.packages("pak")
    pak::pak("apache/arrow-adbc/r/adbcflightsql")
-   pak::pak("apache/arrow-adbc/r/adbcpostgresql")
    pak::pak("apache/arrow-adbc/r/adbcsnowflake")
-   pak::pak("apache/arrow-adbc/r/adbcsqlite")
-
-Installation of stable releases from CRAN is anticipated following the
-release of ADBC Libraries 0.6.0.
 
 Ruby
 ====

--- a/docs/source/driver/postgresql.rst
+++ b/docs/source/driver/postgresql.rst
@@ -75,8 +75,7 @@ Installation
 
       .. code-block:: r
 
-         # install.packages("pak")
-         pak::pak("apache/arrow-adbc/r/adbcpostgresql")
+         install.packages("adbcpostgresql")
 
 Usage
 =====

--- a/docs/source/driver/sqlite.rst
+++ b/docs/source/driver/sqlite.rst
@@ -65,10 +65,9 @@ Installation
    .. tab-item:: R
       :sync: r
 
-      .. code-block:: shell
+      .. code-block:: r
 
-         # install.packages("pak")
-         pak::pak("apache/arrow-adbc/r/adbcsqlite")
+         install.packages("adbcsqlite")
 
 Usage
 =====

--- a/r/adbcdrivermanager/NEWS.md
+++ b/r/adbcdrivermanager/NEWS.md
@@ -1,3 +1,11 @@
+# adbcdrivermanager 0.8.0
+
+- Update upstream ADBC libraries to version 0.8.0.
+
+# adbcdrivermanager 0.7.0
+
+- Update upstream ADBC libraries to version 0.7.0.
+
 # adbcdrivermanager 0.6.0
 
 - **r**: Ensure that info_codes are coerced to integer (#986)

--- a/r/adbcflightsql/DESCRIPTION
+++ b/r/adbcflightsql/DESCRIPTION
@@ -19,6 +19,7 @@ RoxygenNote: 7.2.3
 Suggests:
     nanoarrow,
     testthat (>= 3.0.0)
+SystemRequirements: GNU make, Go (>= 1.19.13)
 Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
 URL: https://github.com/apache/arrow-adbc

--- a/r/adbcflightsql/cleanup
+++ b/r/adbcflightsql/cleanup
@@ -16,3 +16,5 @@
 # under the License.
 
 rm src/*.o src/go/*.a
+rm -rf src/.go-cache
+rm -rf src/.go-path

--- a/r/adbcflightsql/configure
+++ b/r/adbcflightsql/configure
@@ -18,6 +18,22 @@
 R_BIN="$R_HOME/bin/R"
 RSCRIPT_BIN="$R_HOME/bin/Rscript"
 
+# Set to non-false for CRAN releases, which require this approach to comply with
+# guidance regarding large dependency sources. When non-false, this script
+# will fail if the download fails or if checksum verification fails on
+# the downloaded file.
+DOWNLOAD_DEPENDENCY_ARCHIVE="false"
+
+# CRAN checks CPU time to enforce ~2 cores for building. Set GOMAXPROCS to 1
+# when building on CRAN to be safe.
+if [ ! "$DOWNLOAD_DEPENDENCY_ARCHIVE" = "false" ] && [ -z "$GOMAXPROCS" ]; then
+  echo "Using GOMAXPROCS=1 for go build"
+  echo "Set GOMAXPROCS to a higher value in ~/.Renviron for a faster build"
+  GOMAXPROCS=1
+elif [ ! -z "$GOMAXPROCS" ]; then
+  echo "Using GOMAXPROCS=$GOMAXPROCS for go build"
+fi
+
 # Run bootstrap.R. This will have already run if we are installing a source
 # package built with pkgbuild::build() with pkgbuild >1.4.0; however, we
 # run it again in case this is R CMD INSTALL on a directory or
@@ -29,26 +45,45 @@ if [ -f bootstrap.R ]; then
 fi
 
 # Find the go binary so that we can go build!
+# If we've downloaded a specific version of go to src/go/tmp, use that
+# one (helpful for testing different version of go locally)
+PREVIOUSLY_DOWNLOADED_GO="`pwd`/src/go/tmp/go/bin/go"
+if [ -z "$GO_BIN" ] && [ -f "$PREVIOUSLY_DOWNLOADED_GO" ]; then
+  GO_BIN="$PREVIOUSLY_DOWNLOADED_GO"
+fi
+
+# Check go on PATH
 if [ -z "$GO_BIN" ]; then
   GO_BIN=`which go`
 fi
 
+# Try some default install locations that might not be on PATH
+DEFAULT_GO_WIN="C:/Program Files/Go/bin/go.exe"
+if [ -z "$GO_BIN" ] && [ -f "$DEFAULT_GO_WIN" ]; then
+  GO_BIN="$DEFAULT_GO_WIN"
+fi
+
+DEFAULT_GO_MACOS="/usr/local/go/bin/go"
+if [ -z "$GO_BIN" ] && [ -f "$DEFAULT_GO_MACOS" ]; then
+  GO_BIN="$DEFAULT_GO_MACOS"
+fi
+
+DEFAULT_GO_HOMEBREW_M1="/opt/homebrew/bin/go"
+if [ -z "$GO_BIN" ] && [ -f "$DEFAULT_GO_HOMEBREW_M1" ]; then
+  GO_BIN="$DEFAULT_GO_HOMEBREW_M1"
+fi
+
 if [ -z "$GO_BIN" ]; then
-  if [ ! -f src/go/tmp/go/bin/go ]; then
-    echo ""
-    echo "Downloading and extracting Go into the package source directory:"
-    echo "This may take a few minutes. To eliminate this step, install Go"
-    echo "from your faviourite package manager or set the GO_BIN environment variable:"
-    echo "- apt-get install golang"
-    echo "- brew install golang"
-    echo "- dnf install golang"
-    echo "- apk add go"
-    echo "- pacman -S go"
-
-    "$RSCRIPT_BIN" tools/download-go.R
-  fi
-
-  GO_BIN="`pwd`/src/go/tmp/go/bin/go"
+  echo ""
+  echo "The Go compiler is required to install this package. You can install go"
+  echo "from your faviourite package manager or set the GO_BIN environment variable:"
+  echo "- apt-get install golang"
+  echo "- brew install golang"
+  echo "- dnf install golang"
+  echo "- apk add go"
+  echo "- pacman -S go"
+  echo "...or from the official installers available at https://go.dev/dl/"
+  exit 1
 fi
 
 echo "Trying 'go version' with GO_BIN at '$GO_BIN'"
@@ -62,12 +97,8 @@ fi
 CC=`"$R_BIN" CMD config CC`
 CXX=`"$R_BIN" CMD config CXX`
 
-# clang and gcc use different symbol-hiding syntax and we need to
-# make sure to hide any Adbc* symbols that might conflict with another
-# driver.
-if "$R_BIN" CMD config CC | grep -e "clang" ; then
-  SYMBOL_ARGS="-Wl,-exported_symbol,_adbcflightsql_c_flightsql -Wl,-exported_symbol,_R_init_adbcflightsql"
-elif "$R_BIN" CMD config CC | grep -e "gcc" ; then
+# Attempt to hide symbols where possible
+if "$R_BIN" CMD config CC | grep -e "gcc" >/dev/null ; then
   SYMBOL_ARGS="-Wl,--version-script=go/symbols.map"
 fi
 
@@ -83,6 +114,7 @@ sed \
   -e "s|@libs@|$PKG_LIBS|" \
   -e "s|@cc@|$CC|" \
   -e "s|@cxx@|$CXX|" \
+  -e "s|@nproc@|$GOMAXPROCS|" \
   src/Makevars.in > src/Makevars
 
 if [ -f "src/go/adbc/pkg/flightsql/driver.go" ]; then

--- a/r/adbcflightsql/src/.gitignore
+++ b/r/adbcflightsql/src/.gitignore
@@ -17,3 +17,5 @@
 
 adbc.h
 Makevars
+.go-cache
+.go-path

--- a/r/adbcflightsql/src/Makevars.in
+++ b/r/adbcflightsql/src/Makevars.in
@@ -21,10 +21,11 @@ PKG_LIBS=-L$(CURDIR)/go -ladbc_driver_flightsql -lresolv @libs@
 CGO_CC = @cc@
 CGO_CXX = @cxx@
 CGO_CFLAGS = $(ALL_CPPFLAGS)
+GOMAXPROCS = @nproc@
 
 .PHONY: all gostatic
 all: $(SHLIB)
 $(SHLIB): gostatic
 
 gostatic:
-		(cd "$(CURDIR)/go/adbc"; CC="$(CGO_CC)" CXX="$(CGO_CXX)" CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(PKG_LIBS)" "@gobin@" build -v -tags driverlib -o $(CURDIR)/go/libadbc_driver_flightsql.a -buildmode=c-archive "./pkg/flightsql")
+		(cd "$(CURDIR)/go/adbc"; GOMAXPROCS=$(GOMAXPROCS) GOPATH="$(CURDIR)/.go-path" GOCACHE="$(CURDIR)/.go-cache" CC="$(CGO_CC)" CXX="$(CGO_CXX)" CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(PKG_LIBS)" "@gobin@" build -v -tags driverlib -o $(CURDIR)/go/libadbc_driver_flightsql.a -buildmode=c-archive "./pkg/flightsql")

--- a/r/adbcpostgresql/NEWS.md
+++ b/r/adbcpostgresql/NEWS.md
@@ -1,3 +1,11 @@
+# adbcdrivermanager 0.8.0
+
+- Update upstream ADBC libraries to version 0.8.0.
+
+# adbcdrivermanager 0.7.0
+
+- Update upstream ADBC libraries to version 0.7.0.
+
 # adbcpostgresql 0.6.0
 
 * Initial CRAN submission.

--- a/r/adbcpostgresql/cran-comments.md
+++ b/r/adbcpostgresql/cran-comments.md
@@ -4,6 +4,4 @@ Apache Arrow ADBC libraries version.
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
-
-* This is a new release.
+0 errors | 0 warnings | 0 notes

--- a/r/adbcsnowflake/DESCRIPTION
+++ b/r/adbcsnowflake/DESCRIPTION
@@ -18,8 +18,9 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Suggests:
     nanoarrow,
+    openssl,
     testthat (>= 3.0.0)
-SystemRequirements: GNU make
+SystemRequirements: GNU make, Go (>= 1.19.13)
 Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
 URL: https://github.com/apache/arrow-adbc

--- a/r/adbcsnowflake/cleanup
+++ b/r/adbcsnowflake/cleanup
@@ -16,3 +16,5 @@
 # under the License.
 
 rm src/*.o src/go/*.a
+rm -rf src/.go-cache
+rm -rf src/.go-path

--- a/r/adbcsnowflake/configure
+++ b/r/adbcsnowflake/configure
@@ -24,6 +24,16 @@ RSCRIPT_BIN="$R_HOME/bin/Rscript"
 # the downloaded file.
 DOWNLOAD_DEPENDENCY_ARCHIVE="false"
 
+# CRAN checks CPU time to enforce ~2 cores for building. Set GOMAXPROCS to 1
+# when building on CRAN to be safe.
+if [ ! "$DOWNLOAD_DEPENDENCY_ARCHIVE" = "false" ] && [ -z "$GOMAXPROCS" ]; then
+  echo "Using GOMAXPROCS=1 for go build"
+  echo "Set GOMAXPROCS to a higher value in ~/.Renviron for a faster build"
+  GOMAXPROCS=1
+elif [ ! -z "$GOMAXPROCS" ]; then
+  echo "Using GOMAXPROCS=$GOMAXPROCS for go build"
+fi
+
 # Run bootstrap.R. This will have already run if we are installing a source
 # package built with pkgbuild::build() with pkgbuild >1.4.0; however, we
 # run it again in case this is R CMD INSTALL on a directory or
@@ -62,8 +72,13 @@ if [ -f tools/src-go-adbc-vendor.zip ]; then
     cd ..
     "$RSCRIPT_BIN" tools/extract-go-vendor-archive.R
   else
-    echo "Checksum verification failed for vendored dependency archive"
-    exit 1
+    cd ..
+    if "$RSCRIPT_BIN" tools/verify-go-vendor-archive.R ; then
+      "$RSCRIPT_BIN" tools/extract-go-vendor-archive.R
+    else
+      echo "Checksum verification failed for vendored dependency archive"
+      exit 1
+    fi
   fi
 fi
 
@@ -120,12 +135,8 @@ fi
 CC=`"$R_BIN" CMD config CC`
 CXX=`"$R_BIN" CMD config CXX`
 
-# clang and gcc use different symbol-hiding syntax and we need to
-# make sure to hide any Adbc* symbols that might conflict with another
-# driver.
-if "$R_BIN" CMD config CC | grep -e "clang" >/dev/null ; then
-  SYMBOL_ARGS="-Wl,-exported_symbol,_adbcsnowflake_c_snowflake -Wl,-exported_symbol,_R_init_adbcsnowflake"
-elif "$R_BIN" CMD config CC | grep -e "gcc" >/dev/null ; then
+# Attempt to hide symbols where possible
+if "$R_BIN" CMD config CC | grep -e "gcc" >/dev/null ; then
   SYMBOL_ARGS="-Wl,--version-script=go/symbols.map"
 fi
 
@@ -148,6 +159,7 @@ sed \
   -e "s|@cflags@|$PKG_CPPFLAGS|" \
   -e "s|@cc@|$CC|" \
   -e "s|@cxx@|$CXX|" \
+  -e "s|@nproc@|$GOMAXPROCS|" \
   src/Makevars.in > src/Makevars
 
 if [ -f "src/go/adbc/pkg/snowflake/driver.go" ]; then

--- a/r/adbcsnowflake/src/.gitignore
+++ b/r/adbcsnowflake/src/.gitignore
@@ -17,3 +17,5 @@
 
 adbc.h
 Makevars
+.go-cache
+.go-path

--- a/r/adbcsnowflake/src/Makevars.in
+++ b/r/adbcsnowflake/src/Makevars.in
@@ -21,10 +21,11 @@ PKG_LIBS=-L$(CURDIR)/go -ladbc_driver_snowflake @libs@
 CGO_CC = @cc@
 CGO_CXX = @cxx@
 CGO_CFLAGS = $(ALL_CPPFLAGS)
+GOMAXPROCS = @nproc@
 
 .PHONY: all gostatic
 all: $(SHLIB)
 $(SHLIB): gostatic
 
 gostatic:
-		(cd "$(CURDIR)/go/adbc"; CC="$(CGO_CC)" CXX="$(CGO_CXX)" CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(PKG_LIBS)" "@gobin@" build -v -tags driverlib -o $(CURDIR)/go/libadbc_driver_snowflake.a -buildmode=c-archive "./pkg/snowflake")
+		(cd "$(CURDIR)/go/adbc"; GOMAXPROCS=$(GOMAXPROCS) GOPATH="$(CURDIR)/.go-path" GOCACHE="$(CURDIR)/.go-cache" CC="$(CGO_CC)" CXX="$(CGO_CXX)" CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(PKG_LIBS)" "@gobin@" build -v -tags driverlib -o $(CURDIR)/go/libadbc_driver_snowflake.a -buildmode=c-archive "./pkg/snowflake")

--- a/r/adbcsnowflake/tools/.gitignore
+++ b/r/adbcsnowflake/tools/.gitignore
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-src-go-adbc-vendor.zip*
+src-go-adbc-vendor.zip

--- a/r/adbcsnowflake/tools/create-go-vendor-archive.R
+++ b/r/adbcsnowflake/tools/create-go-vendor-archive.R
@@ -20,7 +20,7 @@ go_bin <- Sys.getenv("GO_BIN", unname(Sys.which("go")))
 withr::with_dir("src/go/adbc", {
   system(paste(shQuote(go_bin), "mod vendor -v"))
 
-  # go mod vendor for arrow/v13 doesn't include some files needed for go build
+  # go mod vendor for arrow/v14 doesn't include some files needed for go build
   tmp_zip <- tempfile()
   tmp_extract <- tempfile()
   local({
@@ -30,7 +30,7 @@ withr::with_dir("src/go/adbc", {
     })
 
     curl::curl_download(
-      "https://github.com/apache/arrow/archive/refs/tags/go/v13.0.0.zip",
+      "https://github.com/apache/arrow/archive/refs/tags/go/v14.0.2.zip",
       tmp_zip
     )
 
@@ -38,10 +38,10 @@ withr::with_dir("src/go/adbc", {
 
     src_go_arrow_cdata_arrow_dir <- file.path(
       tmp_extract,
-      "arrow-go-v13.0.0/go/arrow/cdata/arrow"
+      "arrow-go-v14.0.2/go/arrow/cdata/arrow"
     )
 
-    dst_go_arrow_cdata_dir <- "vendor/github.com/apache/arrow/go/v13/arrow/cdata/"
+    dst_go_arrow_cdata_dir <- "vendor/github.com/apache/arrow/go/v14/arrow/cdata/"
     stopifnot(file.copy(src_go_arrow_cdata_arrow_dir, dst_go_arrow_cdata_dir, recursive = TRUE))
   })
 

--- a/r/adbcsnowflake/tools/download-go-vendor-archive.R
+++ b/r/adbcsnowflake/tools/download-go-vendor-archive.R
@@ -25,4 +25,8 @@ if (identical(uri, "")) {
 
 cat(sprintf("Downloading vendored dependency archive from %s\n", uri))
 unlink("tools/src-go-adbc-vendor.zip")
-download.file(uri, "tools/src-go-adbc-vendor.zip")
+local({
+  opts <- options(timeout = max(300, getOption("timeout")))
+  on.exit(options(opts))
+  download.file(uri, "tools/src-go-adbc-vendor.zip", mode = "wb")
+})

--- a/r/adbcsnowflake/tools/verify-go-vendor-archive.R
+++ b/r/adbcsnowflake/tools/verify-go-vendor-archive.R
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+digest_openssl <- function(f) {
+  con <- file(f, "rb")
+  on.exit(close(con))
+  as.character(as.character(openssl::sha512(con)))
+}
+
+digest_digest <- function(f) {
+  digest::digest(f, algo = "sha512", file = TRUE)
+}
+
+read_check <- function(f) {
+  con <- file(f, "rb")
+  on.exit(close(con))
+  scan(con, character(1), n = 1, quiet = TRUE)
+}
+
+verify <- function() {
+  if (requireNamespace("digest", quietly = TRUE)) {
+    cat("Using digest::digest() to verify digest\n")
+    digest <- digest_digest("tools/src-go-adbc-vendor.zip")
+  } else if (requireNamespace("openssl", quietly = TRUE)) {
+    cat("Using openssl::sha512() to verify digest\n")
+    digest <- digest_openssl("tools/src-go-adbc-vendor.zip")
+  } else {
+    cat("openssl nor digest package was installed to verify digest\n")
+    return(FALSE)
+  }
+
+  digest_check <- read_check("tools/src-go-adbc-vendor.zip.sha512")
+  result <- identical(digest_check, digest)
+
+  if (isTRUE(result)) {
+    result
+  } else {
+    cat(sprintf("Digest: %s\n", digest))
+    cat(sprintf("Check : %s\n", digest_check))
+    FALSE
+  }
+}
+
+result <- try(verify())
+
+if (!isTRUE(result) && !interactive()) {
+  q(status = 1)
+} else if (!interactive()) {
+  q(status = 0)
+}

--- a/r/adbcsqlite/NEWS.md
+++ b/r/adbcsqlite/NEWS.md
@@ -1,3 +1,11 @@
+# adbcdrivermanager 0.8.0
+
+- Update upstream ADBC libraries to version 0.8.0.
+
+# adbcdrivermanager 0.7.0
+
+- Update upstream ADBC libraries to version 0.7.0.
+
 # adbcsqlite 0.6.0
 
 * Initial CRAN submission.

--- a/r/adbcsqlite/cran-comments.md
+++ b/r/adbcsqlite/cran-comments.md
@@ -4,6 +4,4 @@ Apache Arrow ADBC libraries version.
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
-
-* This is a new release.
+0 errors | 0 warnings | 0 notes


### PR DESCRIPTION
A few housekeeping updates:

- Updated documentation to reflect implementation/installation status in the documentation
- Updated NEWS entries up to the current version number
- Upstreamed updates requested by CRAN regarding the Snowflake driver (syncing most with the flightsql driver as well). Some of this could be factored out into a common 'how to link a go library from R' package, but it's probably too early for that since there isn't quite consensus on what is actually going to be required yet.