### PR TITLE
chore(csharp): bump Microsoft.NET.Test.Sdk from 17.6.0 to 17.8.0 in /csharp

### DIFF
--- a/csharp/test/Apache.Arrow.Adbc.Tests/Apache.Arrow.Adbc.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/Apache.Arrow.Adbc.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="System.Text.Json" Version="7.0.4" />
     <PackageReference Include="xunit" Version="2.6.4" />

--- a/csharp/test/Drivers/BigQuery/Apache.Arrow.Adbc.Tests.Drivers.BigQuery.csproj
+++ b/csharp/test/Drivers/BigQuery/Apache.Arrow.Adbc.Tests.Drivers.BigQuery.csproj
@@ -3,7 +3,7 @@
      <TargetFrameworks>net472;net6.0</TargetFrameworks>
    </PropertyGroup>
     <ItemGroup>
-     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
      <PackageReference Include="xunit" Version="2.6.4" />
      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
        <PrivateAssets>all</PrivateAssets>

--- a/csharp/test/Drivers/FlightSql/Apache.Arrow.Adbc.Tests.Drivers.FlightSql.csproj
+++ b/csharp/test/Drivers/FlightSql/Apache.Arrow.Adbc.Tests.Drivers.FlightSql.csproj
@@ -5,7 +5,7 @@
     <SignAssembly>False</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.4" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>

--- a/csharp/test/Drivers/Interop/Snowflake/Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake.csproj
+++ b/csharp/test/Drivers/Interop/Snowflake/Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake.csproj
@@ -3,7 +3,7 @@
      <TargetFrameworks>net472;net6.0</TargetFrameworks>
    </PropertyGroup>
     <ItemGroup>
-     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
      <PackageReference Include="xunit" Version="2.6.4" />
      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
        <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
(The dependabot upgrade isn't working probably because the source has a mix of versions.)