### PR TITLE
docs(r): fix source links from pkgdown site

### DIFF
--- a/r/adbcdrivermanager/_pkgdown.yml
+++ b/r/adbcdrivermanager/_pkgdown.yml
@@ -28,3 +28,10 @@ template:
           </a>
         </li>
       </ul>
+
+repo:
+  url:
+    home: https://github.com/apache/arrow-adbc/
+    source: https://github.com/apache/arrow-adbc/blob/main/r/adbcdrivermanager/
+    issue: https://github.com/apache/arrow-adbc/issues/
+    user: https://github.com/

--- a/r/adbcflightsql/_pkgdown.yml
+++ b/r/adbcflightsql/_pkgdown.yml
@@ -28,3 +28,10 @@ template:
           </a>
         </li>
       </ul>
+
+repo:
+  url:
+    home: https://github.com/apache/arrow-adbc/
+    source: https://github.com/apache/arrow-adbc/blob/main/r/adbcflightsql/
+    issue: https://github.com/apache/arrow-adbc/issues/
+    user: https://github.com/

--- a/r/adbcpostgresql/_pkgdown.yml
+++ b/r/adbcpostgresql/_pkgdown.yml
@@ -28,3 +28,10 @@ template:
           </a>
         </li>
       </ul>
+
+repo:
+  url:
+    home: https://github.com/apache/arrow-adbc/
+    source: https://github.com/apache/arrow-adbc/blob/main/r/adbcpostgresql/
+    issue: https://github.com/apache/arrow-adbc/issues/
+    user: https://github.com/

--- a/r/adbcsnowflake/_pkgdown.yml
+++ b/r/adbcsnowflake/_pkgdown.yml
@@ -28,3 +28,10 @@ template:
           </a>
         </li>
       </ul>
+
+repo:
+  url:
+    home: https://github.com/apache/arrow-adbc/
+    source: https://github.com/apache/arrow-adbc/blob/main/r/adbcsnowflake/
+    issue: https://github.com/apache/arrow-adbc/issues/
+    user: https://github.com/

--- a/r/adbcsqlite/_pkgdown.yml
+++ b/r/adbcsqlite/_pkgdown.yml
@@ -28,3 +28,10 @@ template:
           </a>
         </li>
       </ul>
+
+repo:
+  url:
+    home: https://github.com/apache/arrow-adbc/
+    source: https://github.com/apache/arrow-adbc/blob/main/r/adbcsqlite/
+    issue: https://github.com/apache/arrow-adbc/issues/
+    user: https://github.com/


### PR DESCRIPTION
Same as apache/arrow-nanoarrow#315

Since the R package is in a subdirectory, I believe this setting is necessary to ensure that the links to the source files are generated correctly.