### PR TITLE
chore(r): Ensure that Go caches nor binary objects created during test compile end up in R source tarballs

### DIFF
--- a/r/adbcflightsql/.Rbuildignore
+++ b/r/adbcflightsql/.Rbuildignore
@@ -11,3 +11,5 @@
 ^docs$
 ^pkgdown$
 ^cran-comments\.md$
+^src/\.go-cache$
+^src/\.go-path$

--- a/r/adbcsnowflake/.Rbuildignore
+++ b/r/adbcsnowflake/.Rbuildignore
@@ -9,3 +9,5 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^src/\.go-cache$
+^src/\.go-path$

--- a/r/adbcsqlite/configure
+++ b/r/adbcsqlite/configure
@@ -70,7 +70,7 @@ if [ ! -z "$R_ADBC_SQLITE_ON_WINDOWS" ]; then
   PKG_CPPFLAGS="$PKG_CPPFLAGS -D__USE_MINGW_ANSI_STDIO"
 fi
 
-rm -f tools/test.o sqlite_test sqlite_test.log || true
+rm -f tools/test.o tools/test_extension.o sqlite_test sqlite_test.log || true
 
 sed \
   -e "s|@cppflags@|$PKG_CPPFLAGS|" \


### PR DESCRIPTION
Closes #1430.