### PR TITLE
fix(r/adbcdrivermanager): Use std::vector<uint8_t> instead of std::basic_string<uint8_t>

### DIFF
--- a/r/adbcdrivermanager/src/driver_base.h
+++ b/r/adbcdrivermanager/src/driver_base.h
@@ -266,9 +266,7 @@ class ObjectBase {
 
   AdbcStatusCode CSetOptionBytes(const char* key, const uint8_t* value, size_t length,
                                  AdbcError* error) {
-    std::vector<uint8_t> cppvalue(length);
-    memcpy(cppvalue.data(), value, length);
-
+    std::vector<uint8_t> cppvalue(value, value + length);
     Option option(cppvalue);
     return SetOption(key, option);
   }

--- a/r/adbcdrivermanager/src/driver_base.h
+++ b/r/adbcdrivermanager/src/driver_base.h
@@ -119,7 +119,7 @@ class Option {
 
   Option() : type_(TYPE_MISSING) {}
   explicit Option(const std::string& value) : type_(TYPE_STRING), value_string_(value) {}
-  explicit Option(const std::basic_string<uint8_t>& value)
+  explicit Option(const std::vector<uint8_t>& value)
       : type_(TYPE_BYTES), value_bytes_(value) {}
   explicit Option(double value) : type_(TYPE_DOUBLE), value_double_(value) {}
   explicit Option(int64_t value) : type_(TYPE_INT), value_int_(value) {}
@@ -128,7 +128,7 @@ class Option {
 
   const std::string& GetStringUnsafe() const { return value_string_; }
 
-  const std::basic_string<uint8_t>& GetBytesUnsafe() const { return value_bytes_; }
+  const std::vector<uint8_t>& GetBytesUnsafe() const { return value_bytes_; }
 
   int64_t GetIntUnsafe() const { return value_int_; }
 
@@ -137,7 +137,7 @@ class Option {
  private:
   Type type_;
   std::string value_string_;
-  std::basic_string<uint8_t> value_bytes_;
+  std::vector<uint8_t> value_bytes_;
   double value_double_;
   int64_t value_int_;
 
@@ -165,7 +165,7 @@ class Option {
   AdbcStatusCode CGet(uint8_t* out, size_t* length) const {
     switch (type_) {
       case TYPE_BYTES: {
-        const std::basic_string<uint8_t>& value = GetBytesUnsafe();
+        const std::vector<uint8_t>& value = GetBytesUnsafe();
         if (*length < value.size()) {
           *length = value.size();
         } else {
@@ -266,7 +266,9 @@ class ObjectBase {
 
   AdbcStatusCode CSetOptionBytes(const char* key, const uint8_t* value, size_t length,
                                  AdbcError* error) {
-    std::basic_string<uint8_t> cppvalue(value, length);
+    std::vector<uint8_t> cppvalue(length);
+    memcpy(cppvalue.data(), value, length);
+
     Option option(cppvalue);
     return SetOption(key, option);
   }


### PR DESCRIPTION
Because it makes more sense, but also with clang18, CRAN reports a warning:

```
In file included from driver_test.cc:24:
In file included from ./driver_base.h:19:
In file included from /usr/local/clang-trunk/bin/../include/c++/v1/memory:939:
In file included from /usr/local/clang-trunk/bin/../include/c++/v1/__memory/shared_ptr.h:21:
In file included from /usr/local/clang-trunk/bin/../include/c++/v1/__fwd/ostream.h:13:
/usr/local/clang-trunk/bin/../include/c++/v1/__fwd/string.h:45:41: warning: 'char_traits<unsigned char>' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 19, so please migrate off of it. [-Wdeprecated-declarations]
   45 | template <class _CharT, class _Traits = char_traits<_CharT>, class _Allocator = allocator<_CharT> >
      |                                         ^
./driver_base.h:168:20: note: in instantiation of default argument for 'basic_string<uint8_t>' required here
  168 |         const std::basic_string<uint8_t>& value = GetBytesUnsafe();
      |                    ^~~~~~~~~~~~~~~~~~~~~
/usr/local/clang-trunk/bin/../include/c++/v1/__string/char_traits.h:81:8: note: 'char_traits<unsigned char>' has been explicitly marked deprecated here
   81 | struct _LIBCPP_DEPRECATED_(
      |        ^
/usr/local/clang-trunk/bin/../include/c++/v1/__config:933:53: note: expanded from macro '_LIBCPP_DEPRECATED_'
  933 | #      define _LIBCPP_DEPRECATED_(m) __attribute__((__deprecated__(m)))
      |                                                     ^
```