### PR TITLE
feat(glib): Add Apache Arrow GLib integration library

### DIFF
--- a/ci/linux-packages/debian/control
+++ b/ci/linux-packages/debian/control
@@ -24,6 +24,7 @@ Build-Depends:
   debhelper-compat (= 12),
   gobject-introspection,
   golang | golang-1.20,
+  libarrow-glib-dev,
   libgirepository1.0-dev,
   libpq-dev,
   libsqlite3-dev,
@@ -197,3 +198,57 @@ Recommends:
 Description: Apache Arrow Database Connectivity (ADBC) driver manager
  .
  This package provides documentations.
+
+Package: libadbc-arrow-glib0
+Section: libs
+Architecture: any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends:
+  ${misc:Depends},
+  ${shlibs:Depends},
+  libadbc-glib0 (= ${binary:Version})
+Description: Apache Arrow Database Connectivity (ADBC) driver manager
+ .
+ This package provides library files for Apache Arrow GLib integration.
+
+Package: gir1.2-adbc-arrow-1.0
+Section: introspection
+Architecture: any
+Multi-Arch: same
+Depends:
+  ${gir:Depends},
+  ${misc:Depends},
+  gir1.2-adbc-1.0 (= ${binary:Version})
+Description: Apache Arrow Database Connectivity (ADBC) driver manager
+ .
+ This package provides GObject Introspection typelib files for Apache
+ Arrow GLib integration.
+
+Package: libadbc-arrow-glib-dev
+Section: libdevel
+Architecture: any
+Multi-Arch: same
+Depends:
+  ${misc:Depends},
+  gir1.2-adbc-arrow-1.0 (= ${binary:Version}),
+  libadbc-glib-dev (= ${binary:Version})
+Description: Apache Arrow Database Connectivity (ADBC) driver manager
+ .
+ This package provides header files for Apache Arrow GLib
+ integration.
+
+Package: libadbc-arrow-glib-doc
+Section: doc
+Architecture: all
+Multi-Arch: foreign
+Depends:
+  ${misc:Depends}
+Recommends:
+  libglib2.0-doc,
+  libadbc-glib-doc,
+  libarrow-glib-doc
+Description: Apache Arrow Database Connectivity (ADBC) driver manager
+ .
+ This package provides documentations for Apache Arrow GLib
+ integration.

--- a/ci/linux-packages/debian/gir1.2-adbc-arrow-1.0.install
+++ b/ci/linux-packages/debian/gir1.2-adbc-arrow-1.0.install
@@ -1,0 +1,1 @@
+usr/lib/*/girepository-1.0/ADBCArrow-*.typelib

--- a/ci/linux-packages/debian/libadbc-arrow-glib-dev.install
+++ b/ci/linux-packages/debian/libadbc-arrow-glib-dev.install
@@ -1,0 +1,6 @@
+usr/include/adbc-arrow-glib/
+usr/lib/*/libadbc-arrow-glib.so
+usr/lib/*/pkgconfig/adbc-arrow-glib.pc
+usr/share/adbc-arrow-glib/example/
+usr/share/gir-1.0/ADBCArrow-*.gir
+usr/share/vala/vapi/adbc-arrow-glib.*

--- a/ci/linux-packages/debian/libadbc-arrow-glib-doc.install
+++ b/ci/linux-packages/debian/libadbc-arrow-glib-doc.install
@@ -1,0 +1,1 @@
+usr/share/doc/adbc-arrow-glib/

--- a/ci/linux-packages/debian/libadbc-arrow-glib0.install
+++ b/ci/linux-packages/debian/libadbc-arrow-glib0.install
@@ -1,0 +1,1 @@
+usr/lib/*/libadbc-arrow-glib.so.*

--- a/ci/linux-packages/debian/libadbc-glib-dev.install
+++ b/ci/linux-packages/debian/libadbc-glib-dev.install
@@ -3,4 +3,4 @@ usr/lib/*/libadbc-glib.so
 usr/lib/*/pkgconfig/adbc-glib.pc
 usr/share/adbc-glib/example/
 usr/share/gir-1.0/ADBC-*.gir
-usr/share/vala/vapi/*
+usr/share/vala/vapi/adbc-glib.*

--- a/ci/linux-packages/yum/almalinux-8/Dockerfile
+++ b/ci/linux-packages/yum/almalinux-8/Dockerfile
@@ -25,6 +25,7 @@ RUN \
   yum install -y ${quiet} epel-release && \
   yum install -y https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
   yum install --enablerepo=powertools -y ${quiet} \
+    arrow-glib-devel \
     ccache \
     cmake \
     gcc-c++ \

--- a/ci/linux-packages/yum/almalinux-9/Dockerfile
+++ b/ci/linux-packages/yum/almalinux-9/Dockerfile
@@ -25,6 +25,7 @@ RUN \
   dnf install -y ${quiet} epel-release && \
   dnf install -y https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
   dnf install --enablerepo=crb -y ${quiet} \
+    arrow-glib-devel \
     ccache \
     cmake \
     gcc-c++ \

--- a/ci/linux-packages/yum/apache-arrow-adbc.spec.in
+++ b/ci/linux-packages/yum/apache-arrow-adbc.spec.in
@@ -40,6 +40,7 @@ License:	Apache-2.0
 URL:		https://arrow.apache.org/adbc/
 Source0:	https://www.apache.org/dyn/closer.lua?action=download&path=/arrow/arrow-adbc-%{version}/apache-arrow-adbc-%{version}.tar.gz
 
+BuildRequires:	arrow-glib-devel
 BuildRequires:	cmake
 BuildRequires:	gcc-c++
 BuildRequires:	gobject-introspection-devel
@@ -260,7 +261,7 @@ This package contains the libraries for ADBC GLib.
 %defattr(-,root,root,-)
 %doc README.md
 %license LICENSE.txt NOTICE.txt
-%{_libdir}/girepository-1.0/
+%{_libdir}/girepository-1.0/ADBC-*.typelib
 %{_libdir}/libadbc-glib.so.*
 
 %package glib-devel
@@ -278,8 +279,8 @@ Libraries and header files for ADBC GLib.
 %defattr(-,root,root,-)
 %doc README.md
 %license LICENSE.txt NOTICE.txt
-%{_datadir}/gir-1.0/
-%{_datadir}/vala/vapi/
+%{_datadir}/gir-1.0/ADBC-*.gir
+%{_datadir}/vala/vapi/adbc-glib.*
 %{_includedir}/adbc-glib/
 %{_libdir}/libadbc-glib.a
 %{_libdir}/libadbc-glib.so
@@ -298,6 +299,56 @@ Documentation for ADBC GLib.
 %license LICENSE.txt NOTICE.txt
 %{_datadir}/adbc-glib/example/
 %{_docdir}/adbc-glib/
+
+%package arrow-glib%{major_version}-libs
+Summary:	Runtime libraries for Apache Arrow GLib integration
+License:	Apache-2.0
+Requires:	%{name}-glib%{major_version}-libs = %{version}-%{release}
+
+%description arrow-glib%{major_version}-libs
+This package contains the libraries for Apache Arrow GLib integration.
+
+%files arrow-glib%{major_version}-libs
+%defattr(-,root,root,-)
+%doc README.md
+%license LICENSE.txt NOTICE.txt
+%{_libdir}/girepository-1.0/ADBCArrow-*.typelib
+%{_libdir}/libadbc-arrow-glib.so.*
+
+%package arrow-glib-devel
+Summary:	Libraries and header files for Apache Arrow GLib integration
+License:	Apache-2.0
+Requires:	%{name}-arrow-glib%{major_version}-libs = %{version}-%{release}
+Requires:	%{name}-glib-devel = %{version}-%{release}
+Requires:	arrow-glib-devel
+
+%description arrow-glib-devel
+Libraries and header files for Apache Arrow GLib integration
+
+%files arrow-glib-devel
+%defattr(-,root,root,-)
+%doc README.md
+%license LICENSE.txt NOTICE.txt
+%{_datadir}/gir-1.0/ADBCArrow-*.gir
+%{_datadir}/vala/vapi/adbc-arrow-glib.*
+%{_includedir}/adbc-arrow-glib/
+%{_libdir}/libadbc-arrow-glib.a
+%{_libdir}/libadbc-arrow-glib.so
+%{_libdir}/pkgconfig/adbc-arrow-glib.pc
+
+%package arrow-glib-doc
+Summary:	Documentation for Apache Arrow GLib integration
+License:	Apache-2.0
+
+%description arrow-glib-doc
+Documentation for Apache Arrow GLib integration.
+
+%files arrow-glib-doc
+%defattr(-,root,root,-)
+%doc README.md
+%license LICENSE.txt NOTICE.txt
+%{_datadir}/adbc-arrow-glib/example/
+%{_docdir}/adbc-arrow-glib/
 
 %changelog
 * Thu Apr 27 2023 Matt Topol <matt@voltrondata.com> - 0.4.0-1

--- a/ci/scripts/glib_test.sh
+++ b/ci/scripts/glib_test.sh
@@ -28,6 +28,7 @@ test_subproject() {
 
     export DYLD_LIBRARY_PATH="${install_dir}/lib${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}"
     export GI_TYPELIB_PATH="${build_dir}/glib/adbc-glib${GI_TYPELIB_PATH:+:${GI_TYPELIB_PATH}}"
+    export GI_TYPELIB_PATH="${build_dir}/glib/adbc-arrow-glib:${GI_TYPELIB_PATH}"
     export LD_LIBRARY_PATH="${install_dir}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
     export PKG_CONFIG_PATH="${install_dir}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
     if [[ -n "${CONDA_PREFIX}" ]]; then

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -197,3 +197,11 @@ ${APT_INSTALL} ruby-dev rubygems-integration
 gem install gobject-introspection
 ruby -r gi -e "p GI.load('ADBC')"
 echo "::endgroup::"
+
+echo "::group::Test ADBC Arrow GLib"
+
+${APT_INSTALL} libadbc-arrow-glib-dev=${package_version}
+${APT_INSTALL} libadbc-arrow-glib-doc=${package_version}
+
+ruby -r gi -e "p GI.load('ADBCArrow')"
+echo "::endgroup::"

--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -157,7 +157,7 @@ echo "::group::Test ADBC Snowflake Driver"
 ${install_command} --enablerepo=epel adbc-driver-snowflake-devel-${package_version}
 echo "::endgroup::"
 
-echo "::group::Test Apache Arrow GLib"
+echo "::group::Test ADBC GLib"
 export G_DEBUG=fatal-warnings
 
 ${install_command} --enablerepo=epel adbc-glib-devel-${package_version}
@@ -166,4 +166,12 @@ ${install_command} --enablerepo=epel adbc-glib-doc-${package_version}
 ${install_command} "${ruby_devel_packages[@]}"
 gem install gobject-introspection
 ruby -r gi -e "p GI.load('ADBC')"
+echo "::endgroup::"
+
+echo "::group::Test ADBC Arrow GLib"
+
+${install_command} --enablerepo=epel adbc-arrow-glib-devel-${package_version}
+${install_command} --enablerepo=epel adbc-arrow-glib-doc-${package_version}
+
+ruby -r gi -e "p GI.load('ADBCArrow')"
 echo "::endgroup::"

--- a/glib/adbc-arrow-glib/adbc-arrow-glib.h
+++ b/glib/adbc-arrow-glib/adbc-arrow-glib.h
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <adbc-arrow-glib/version.h>
+
+#include <adbc-arrow-glib/statement.h>

--- a/glib/adbc-arrow-glib/meson.build
+++ b/glib/adbc-arrow-glib/meson.build
@@ -1,0 +1,115 @@
+# -*- indent-tabs-mode: nil -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+sources = files(
+  'statement.c',
+)
+
+definition_headers = files(
+  'statement.h',
+)
+
+headers = definition_headers
+headers += files(
+  'adbc-arrow-glib.h',
+)
+
+version_h_conf = configuration_data()
+version_h_conf.set('GADBC_ARROW_VERSION', meson.project_version())
+version_h_conf.set('GADBC_ARROW_VERSION_MAJOR', version_major)
+version_h_conf.set('GADBC_ARROW_VERSION_MINOR', version_minor)
+version_h_conf.set('GADBC_ARROW_VERSION_MICRO', version_micro)
+version_h = configure_file(input: 'version.h.in',
+                           output: 'version.h',
+                           configuration: version_h_conf)
+headers += version_h
+
+enums = gnome.mkenums_simple('enum-types',
+                             identifier_prefix: 'GADBCArrow',
+                             sources: definition_headers,
+                             symbol_prefix: 'gadbc_arrow')
+enums_header = enums[1]
+
+install_headers(headers, subdir: 'adbc-arrow-glib')
+
+
+dependencies = [
+  adbc_glib,
+  arrow_glib,
+]
+libadbc_arrow_glib = library('adbc-arrow-glib',
+                             c_args: '-DG_LOG_DOMAIN="ADBC-Arrow"',
+                             sources: sources + enums,
+                             install: true,
+                             dependencies: dependencies,
+                             include_directories: base_include_directories,
+                             soversion: so_version,
+                             version: library_version)
+adbc_arrow_glib = \
+  declare_dependency(link_with: libadbc_arrow_glib,
+                     include_directories: base_include_directories,
+                     dependencies: dependencies,
+                     sources: enums_header)
+
+pkgconfig.generate(libadbc_arrow_glib,
+                   description: 'Arrow GLib integration API for ADBC GLib',
+                   filebase: 'adbc-arrow-glib',
+                   name: 'ADBC Arrow GLib',
+                   requires: ['adbc-glib', 'arrow-glib'],
+                   variables: pkgconfig_variables,
+                   version: meson.project_version())
+
+adbc_arrow_glib_gir = \
+  gnome.generate_gir(libadbc_arrow_glib,
+                     dependencies: [
+                       declare_dependency(sources: adbc_glib_gir),
+                       arrow_glib,
+                     ],
+                     export_packages: 'adbc-arrow-glib',
+                     extra_args: [
+                       '--warn-all',
+                     ],
+                     fatal_warnings: gi_fatal_warnings,
+                     header: 'adbc-arrow-glib/adbc-arrow-glib.h',
+                     identifier_prefix: 'GADBCArrow',
+                     includes: [
+                       'ADBC-1.0',
+                       'Arrow-1.0',
+                     ],
+                     install: true,
+                     namespace: 'ADBCArrow',
+                     nsversion: api_version,
+                     sources: sources + definition_headers + enums,
+                     symbol_prefix: 'gadbc_arrow')
+if generate_vapi
+  adbc_arrow_glib_vapi = \
+    gnome.generate_vapi('adbc-arrow-glib',
+                        gir_dirs: [
+                          arrow_glib.get_variable('girdir'),
+                        ],
+                        install: true,
+                        packages: [
+                          adbc_glib_vapi,
+                          'arrow-glib',
+                        ],
+                        sources: [adbc_arrow_glib_gir[0]],
+                        vapi_dirs: [
+                          arrow_glib.get_variable('vapidir'),
+                        ])
+endif

--- a/glib/adbc-arrow-glib/statement.c
+++ b/glib/adbc-arrow-glib/statement.c
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <adbc-arrow-glib/statement.h>
+
+/**
+ * SECTION: statement
+ * @title: GADBCArrowStatement
+ * @include: adbc-arrow-glib/adbc-arrow-glib.h
+ *
+ * #GADBCArrowStatement is a class for Arrow GLib integrated
+    statement.
+ */
+
+G_DEFINE_TYPE(GADBCArrowStatement, gadbc_arrow_statement, GADBC_TYPE_STATEMENT)
+
+static void gadbc_arrow_statement_init(GADBCArrowStatement* statement) {}
+
+static void gadbc_arrow_statement_class_init(GADBCArrowStatementClass* klass) {}
+
+/**
+ * gadbc_arrow_statement_new:
+ * @connection: A #GADBCConnection.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: A newly created #GADBCArrowStatement for @connection on
+ * success, %NULL otherwise.
+ *
+ * Since: 0.10.0
+ */
+GADBCArrowStatement* gadbc_arrow_statement_new(GADBCConnection* connection,
+                                               GError** error) {
+  GADBCArrowStatement* statement = g_object_new(GADBC_ARROW_TYPE_STATEMENT, NULL);
+  if (gadbc_statement_initialize(GADBC_STATEMENT(statement), connection,
+                                 "[adbc-arrow][statement][new]", error)) {
+    return statement;
+  } else {
+    g_object_unref(statement);
+    return NULL;
+  }
+}
+
+/**
+ * gadbc_arrow_statement_bind:
+ * @statement: A #GADBCArrowStatement.
+ * @record_batch: A #GArrowRecordBatch.
+ * @error: (out) (optional): Return location for a #GError or %NULL.
+ *
+ * Bind Arrow data. This can be used for bulk inserts or prepared
+ * statements.
+ *
+ * Returns: %TRUE if binding is done successfully, %FALSE
+ *   otherwise.
+ *
+ * Since: 0.10.0
+ */
+gboolean gadbc_arrow_statement_bind(GADBCArrowStatement* statement,
+                                    GArrowRecordBatch* record_batch, GError** error) {
+  gpointer c_abi_array = NULL;
+  gpointer c_abi_schema = NULL;
+  if (!garrow_record_batch_export(record_batch, &c_abi_array, &c_abi_schema, error)) {
+    return FALSE;
+  }
+  gboolean success =
+      gadbc_statement_bind(GADBC_STATEMENT(statement), c_abi_array, c_abi_schema, error);
+  g_free(c_abi_array);
+  g_free(c_abi_schema);
+  return success;
+}
+
+/**
+ * gadbc_arrow_statement_bind_stream:
+ * @statement: A #GADBCArrowStatement.
+ * @reader: A #GArrowRecordBatchReader.
+ * @error: (out) (optional): Return location for a #GError or %NULL.
+ *
+ * Bind Arrow data stream. This can be used for bulk inserts or prepared
+ * statements.
+ *
+ * Returns: %TRUE if binding is done successfully, %FALSE
+ *   otherwise.
+ *
+ * Since: 0.10.0
+ */
+gboolean gadbc_arrow_statement_bind_stream(GADBCArrowStatement* statement,
+                                           GArrowRecordBatchReader* reader,
+                                           GError** error) {
+  gpointer c_abi_array_stream = garrow_record_batch_reader_export(reader, error);
+  if (!c_abi_array_stream) {
+    return FALSE;
+  }
+  gboolean success =
+      gadbc_statement_bind_stream(GADBC_STATEMENT(statement), c_abi_array_stream, error);
+  g_free(c_abi_array_stream);
+  return success;
+}
+
+/**
+ * gadbc_arrow_statement_execute:
+ * @statement: A #GADBCStatement.
+ * @need_result: Whether the results are received by @reader or not.
+ * @reader: (out) (optional): Return location for the execution.
+ * @n_rows_affected: (out) (optional): Return location for the number of rows
+ *   affected if known.
+ * @error: (out) (optional): Return location for a #GError or %NULL.
+ *
+ * Execute a statement and get the results.
+ *
+ * This invalidates any prior result sets.
+ *
+ * Returns: %TRUE if execution is done successfully, %FALSE otherwise.
+ *
+ * Since: 0.10.0
+ */
+gboolean gadbc_arrow_statement_execute(GADBCArrowStatement* statement,
+                                       gboolean need_result,
+                                       GArrowRecordBatchReader** reader,
+                                       gint64* n_rows_affected, GError** error) {
+  gpointer c_abi_array_stream = NULL;
+  if (!gadbc_statement_execute(GADBC_STATEMENT(statement), need_result,
+                               reader ? &c_abi_array_stream : NULL, n_rows_affected,
+                               error)) {
+    return FALSE;
+  }
+  if (need_result && reader) {
+    *reader = garrow_record_batch_reader_import(c_abi_array_stream, error);
+    g_free(c_abi_array_stream);
+  }
+  return TRUE;
+}

--- a/glib/adbc-arrow-glib/statement.h
+++ b/glib/adbc-arrow-glib/statement.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <adbc-glib/adbc-glib.h>
+#include <arrow-glib/arrow-glib.h>
+
+#include <adbc-arrow-glib/version.h>
+
+G_BEGIN_DECLS
+
+#define GADBC_ARROW_TYPE_STATEMENT (gadbc_arrow_statement_get_type())
+G_DECLARE_DERIVABLE_TYPE(GADBCArrowStatement, gadbc_arrow_statement, GADBCArrow,
+                         STATEMENT, GADBCStatement)
+struct _GADBCArrowStatementClass {
+  GADBCStatementClass parent_class;
+};
+
+GADBC_ARROW_AVAILABLE_IN_0_10
+GADBCArrowStatement* gadbc_arrow_statement_new(GADBCConnection* connection,
+                                               GError** error);
+GADBC_ARROW_AVAILABLE_IN_0_10
+gboolean gadbc_arrow_statement_bind(GADBCArrowStatement* statement,
+                                    GArrowRecordBatch* record_batch, GError** error);
+GADBC_ARROW_AVAILABLE_IN_0_10
+gboolean gadbc_arrow_statement_bind_stream(GADBCArrowStatement* statement,
+                                           GArrowRecordBatchReader* reader,
+                                           GError** error);
+GADBC_ARROW_AVAILABLE_IN_0_10
+gboolean gadbc_arrow_statement_execute(GADBCArrowStatement* statement,
+                                       gboolean need_result,
+                                       GArrowRecordBatchReader** reader,
+                                       gint64* n_rows_affected, GError** error);
+
+G_END_DECLS

--- a/glib/adbc-arrow-glib/version.h.in
+++ b/glib/adbc-arrow-glib/version.h.in
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <glib.h>
+
+/**
+ * SECTION: version
+ * @section_id: version-macros
+ * @title: Version related macros
+ * @include: adbc-arrow-glib/adbc-arrow-glib.h
+ *
+ * ADBC Arrow GLib provides macros that can be used by C pre-processor.
+ * They are useful to check version related things at compile time.
+ */
+
+/**
+ * GADBC_ARROW_VERSION_MAJOR:
+ *
+ * The major version.
+ *
+ * Since: 0.10.0
+ */
+#define GADBC_ARROW_VERSION_MAJOR (@GADBC_ARROW_VERSION_MAJOR@)
+
+/**
+ * GADBC_ARROW_VERSION_MINOR:
+ *
+ * The minor version.
+ *
+ * Since: 0.10.0
+ */
+#define GADBC_ARROW_VERSION_MINOR (@GADBC_ARROW_VERSION_MINOR@)
+
+/**
+ * GADBC_ARROW_VERSION_MICRO:
+ *
+ * The micro version.
+ *
+ * Since: 0.10.0
+ */
+#define GADBC_ARROW_VERSION_MICRO (@GADBC_ARROW_VERSION_MICRO@)
+
+/**
+ * GADBC_ARROW_VERSION_CHECK:
+ * @major: A major version to check for.
+ * @minor: A minor version to check for.
+ * @micro: A micro version to check for.
+ *
+ * You can use this macro in C pre-processor.
+ *
+ * Returns: %TRUE if the compile time ADBC Arrow GLib version is the
+ *   same as or newer than the passed version, %FALSE otherwise.
+ *
+ * Since: 0.10.0
+ */
+#define GADBC_ARROW_VERSION_CHECK(major, minor, micro)  \
+  (GADBC_ARROW_VERSION_MAJOR > (major) ||               \
+   (GADBC_ARROW_VERSION_MAJOR == (major) &&             \
+    GADBC_ARROW_VERSION_MINOR > (minor)) ||             \
+   (GADBC_ARROW_VERSION_MAJOR == (major) &&             \
+    GADBC_ARROW_VERSION_MINOR == (minor) &&             \
+    GADBC_ARROW_VERSION_MICRO >= (micro)))
+
+/**
+ * GADBC_ARROW_DISABLE_DEPRECATION_WARNINGS:
+ *
+ * If this macro is defined, no deprecated warnings are produced.
+ *
+ * You must define this macro before including the
+ * adbc-arrow-glib/adbc-arrow-glib.h header.
+ *
+ * Since: 0.10.0
+ */
+
+#ifdef GADBC_ARROW_DISABLE_DEPRECATION_WARNINGS
+#  define GADBC_ARROW_DEPRECATED
+#  define GADBC_ARROW_DEPRECATED_FOR(function)
+#  define GADBC_ARROW_UNAVAILABLE(major, minor)
+#else
+#  define GADBC_ARROW_DEPRECATED G_DEPRECATED
+#  define GADBC_ARROW_DEPRECATED_FOR(function) G_DEPRECATED_FOR(function)
+#  define GADBC_ARROW_UNAVAILABLE(major, minor) G_UNAVAILABLE(major, minor)
+#endif
+
+/**
+ * GADBC_ARROW_VERSION_0_10:
+ *
+ * You can use this macro value for compile time API version check.
+ *
+ * Since: 0.10.0
+ */
+#define GADBC_ARROW_VERSION_0_10 G_ENCODE_VERSION(0, 10)
+
+/**
+ * GADBC_ARROW_VERSION_MIN_REQUIRED:
+ *
+ * You can use this macro for compile time API version check.
+ *
+ * This macro value must be one of the predefined version macros such
+ * as %GADBC_ARROW_VERSION_0_10.
+ *
+ * If you use any functions that is defined by newer version than
+ * %GADBC_ARROW_VERSION_MIN_REQUIRED, deprecated warnings are produced at
+ * compile time.
+ *
+ * You must define this macro before including the
+ * adbc-glib/adbc-glib.h header.
+ *
+ * Since: 0.10.0
+ */
+#ifndef GADBC_ARROW_VERSION_MIN_REQUIRED
+#  define GADBC_ARROW_VERSION_MIN_REQUIRED                              \
+  G_ENCODE_VERSION(GADBC_ARROW_VERSION_MAJOR, GADBC_ARROW_VERSION_MINOR)
+#endif
+
+/**
+ * GADBC_ARROW_VERSION_MAX_ALLOWED:
+ *
+ * You can use this macro for compile time API version check.
+ *
+ * This macro value must be one of the predefined version macros such
+ * as %GADBC_ARROW_VERSION_0_10.
+ *
+ * If you use any functions that is defined by newer version than
+ * %GADBC_ARROW_VERSION_MAX_ALLOWED, deprecated warnings are produced at
+ * compile time.
+ *
+ * You must define this macro before including the
+ * adbc-arrow-glib/adbc-arrow-glib.h header.
+ *
+ * Since: 0.10.0
+ */
+#ifndef GADBC_ARROW_VERSION_MAX_ALLOWED
+#  define GADBC_ARROW_VERSION_MAX_ALLOWED                               \
+  G_ENCODE_VERSION(GADBC_ARROW_VERSION_MAJOR, GADBC_ARROW_VERSION_MINOR)
+#endif
+
+
+#define GADBC_ARROW_AVAILABLE_IN_ALL
+
+#if GADBC_ARROW_VERSION_MIN_REQUIRED >= GADBC_ARROW_VERSION_0_10
+#  define GADBC_ARROW_DEPRECATED_IN_0_10                GADBC_ARROW_DEPRECATED
+#  define GADBC_ARROW_DEPRECATED_IN_0_10_FOR(function)  GADBC_ARROW_DEPRECATED_FOR(function)
+#else
+#  define GADBC_ARROW_DEPRECATED_IN_0_10
+#  define GADBC_ARROW_DEPRECATED_IN_0_10_FOR(function)
+#endif
+
+#if GADBC_ARROW_VERSION_MAX_ALLOWED < GADBC_ARROW_VERSION_0_10
+#  define GADBC_ARROW_AVAILABLE_IN_0_10 GADBC_ARROW_UNAVAILABLE(0, 10)
+#else
+#  define GADBC_ARROW_AVAILABLE_IN_0_10
+#endif

--- a/glib/adbc-glib/statement.c
+++ b/glib/adbc-glib/statement.c
@@ -65,6 +65,44 @@ static void gadbc_statement_class_init(GADBCStatementClass* klass) {
 }
 
 /**
+ * gadbc_statement_initialize: (skip)
+ * @statement: A #GADBCStatement.
+ * @connection: A #GADBCConnection.
+ * @context: A context for error message.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * This is only for implementing subclass of #GADBCStatement. In
+ * general, users should use gadbc_statement_new().
+ *
+ * Initializes an empty #GADBCStatement with the given
+ * #GADBCConnection.
+ *
+ * Returns: %TRUE if initialization is done successfully, %FALSE otherwise.
+ *
+ * Since: 0.10.0
+ */
+gboolean gadbc_statement_initialize(GADBCStatement* statement,
+                                    GADBCConnection* connection, const char* context,
+                                    GError** error) {
+  struct AdbcConnection* adbc_connection =
+      gadbc_connection_get_raw(connection, context, error);
+  if (!adbc_connection) {
+    return FALSE;
+  }
+  GADBCStatementPrivate* priv = gadbc_statement_get_instance_private(statement);
+  struct AdbcError adbc_error = {};
+  AdbcStatusCode status_code =
+      AdbcStatementNew(adbc_connection, &(priv->adbc_statement), &adbc_error);
+  priv->initialized = gadbc_error_check(error, status_code, &adbc_error, context);
+  if (!priv->initialized) {
+    return FALSE;
+  }
+  priv->connection = connection;
+  g_object_ref(priv->connection);
+  return TRUE;
+}
+
+/**
  * gadbc_statement_new:
  * @connection: A #GADBCConnection.
  * @error: (nullable): Return location for a #GError or %NULL.
@@ -75,25 +113,14 @@ static void gadbc_statement_class_init(GADBCStatementClass* klass) {
  * Since: 0.1.0
  */
 GADBCStatement* gadbc_statement_new(GADBCConnection* connection, GError** error) {
-  const gchar* context = "[adbc][statement][new]";
-  struct AdbcConnection* adbc_connection =
-      gadbc_connection_get_raw(connection, context, error);
-  if (!adbc_connection) {
-    return NULL;
-  }
   GADBCStatement* statement = g_object_new(GADBC_TYPE_STATEMENT, NULL);
-  GADBCStatementPrivate* priv = gadbc_statement_get_instance_private(statement);
-  struct AdbcError adbc_error = {};
-  AdbcStatusCode status_code =
-      AdbcStatementNew(adbc_connection, &(priv->adbc_statement), &adbc_error);
-  priv->initialized = gadbc_error_check(error, status_code, &adbc_error, context);
-  if (!priv->initialized) {
+  if (gadbc_statement_initialize(statement, connection, "[adbc][statement][new]",
+                                 error)) {
+    return statement;
+  } else {
     g_object_unref(statement);
     return NULL;
   }
-  priv->connection = connection;
-  g_object_ref(priv->connection);
-  return statement;
 }
 
 /**

--- a/glib/adbc-glib/statement.h
+++ b/glib/adbc-glib/statement.h
@@ -47,6 +47,10 @@ struct _GADBCStatementClass {
   GObjectClass parent_class;
 };
 
+GADBC_AVAILABLE_IN_0_10
+gboolean gadbc_statement_initialize(GADBCStatement* statement,
+                                    GADBCConnection* connection, const gchar* context,
+                                    GError** error);
 GADBC_AVAILABLE_IN_0_1
 GADBCStatement* gadbc_statement_new(GADBCConnection* connection, GError** error);
 GADBC_AVAILABLE_IN_0_1

--- a/glib/adbc-glib/version.h.in
+++ b/glib/adbc-glib/version.h.in
@@ -101,6 +101,15 @@
 #endif
 
 /**
+ * GADBC_VERSION_0_10:
+ *
+ * You can use this macro value for compile time API version check.
+ *
+ * Since: 0.10.0
+ */
+#define GADBC_VERSION_0_10 G_ENCODE_VERSION(0, 10)
+
+/**
  * GADBC_VERSION_0_4:
  *
  * You can use this macro value for compile time API version check.
@@ -164,6 +173,20 @@
 
 
 #define GADBC_AVAILABLE_IN_ALL
+
+#if GADBC_VERSION_MIN_REQUIRED >= GADBC_VERSION_0_10
+#  define GADBC_DEPRECATED_IN_0_10                GADBC_DEPRECATED
+#  define GADBC_DEPRECATED_IN_0_10_FOR(function)  GADBC_DEPRECATED_FOR(function)
+#else
+#  define GADBC_DEPRECATED_IN_0_10
+#  define GADBC_DEPRECATED_IN_0_10_FOR(function)
+#endif
+
+#if GADBC_VERSION_MAX_ALLOWED < GADBC_VERSION_0_10
+#  define GADBC_AVAILABLE_IN_0_10 GADBC_UNAVAILABLE(0, 10)
+#else
+#  define GADBC_AVAILABLE_IN_0_10
+#endif
 
 #if GADBC_VERSION_MIN_REQUIRED >= GADBC_VERSION_0_4
 #  define GADBC_DEPRECATED_IN_0_4                GADBC_DEPRECATED

--- a/glib/example/vala/meson.build
+++ b/glib/example/vala/meson.build
@@ -25,6 +25,7 @@ if build_example and generate_vapi
     ],
     'dependencies': [
       adbc_glib_vapi,
+      adbc_arrow_glib_vapi,
       arrow_glib,
       dependency('gobject-2.0'),
     ],
@@ -43,6 +44,6 @@ files = [
 ]
 install_data(files,
              install_dir: join_paths(data_dir,
-                                     meson.project_name(),
+                                     'adbc-arrow-glib',
                                      'example',
                                      'vala'))

--- a/glib/example/vala/sqlite.vala
+++ b/glib/example/vala/sqlite.vala
@@ -27,20 +27,15 @@ int main (string[] args) {
             var connection = new GADBC.Connection ();
             connection.init (database);
             try {
-                var statement = new GADBC.Statement (connection);
+                var statement = new GADBCArrow.Statement (connection);
                 string sql = "SELECT sqlite_version() AS version";
                 statement.set_sql_query (sql);
                 try {
-                    void *c_abi_array_stream = null;
+                    GArrow.RecordBatchReader reader;
                     int64 n_rows_affected;
-                    statement.execute (true, out c_abi_array_stream, out n_rows_affected);
-                    try {
-                        var reader = GArrow.RecordBatchReader.import (c_abi_array_stream);
-                        var table = reader.read_all ();
-                        stdout.printf ("Result:\n%s", table.to_string ());
-                    } finally {
-                        GLib.free (c_abi_array_stream);
-                    }
+                    statement.execute (true, out reader, out n_rows_affected);
+                    var table = reader.read_all ();
+                    stdout.printf ("Result:\n%s", table.to_string ());
                     exit_code = Posix.EXIT_SUCCESS;
                 } catch (GLib.Error error) {
                     GLib.error ("Failed to execute a statement: %s", error.message);

--- a/glib/meson.build
+++ b/glib/meson.build
@@ -78,11 +78,20 @@ if generate_vapi
 endif
 
 subdir('adbc-glib')
+arrow_glib = dependency('arrow-glib', required: generate_vapi)
+if arrow_glib.found()
+  subdir('adbc-arrow-glib')
+endif
 subdir('example')
 
 install_data('../LICENSE.txt',
              'README.md',
              install_dir: data_dir / 'doc' / meson.project_name())
+if arrow_glib.found()
+  install_data('../LICENSE.txt',
+               'README.md',
+               install_dir: data_dir / 'doc' / 'adbc-arrow-glib')
+endif
 
 ruby = find_program('ruby', required: false)
 if ruby.found()

--- a/glib/test/run.sh
+++ b/glib/test/run.sh
@@ -22,6 +22,7 @@ build_dir="$(cd .; pwd)"
 
 modules=(
   adbc-glib
+  adbc-arrow-glib
 )
 
 for module in "${modules[@]}"; do

--- a/ruby/dependency-check/Rakefile
+++ b/ruby/dependency-check/Rakefile
@@ -34,12 +34,12 @@ end
 namespace :dependency do
   desc "Check dependency"
   task :check do
-    unless PKGConfig.check_version?("adbc-glib",
+    unless PKGConfig.check_version?("adbc-arrow-glib",
                                     ADBC::Version::MAJOR,
                                     ADBC::Version::MINOR,
                                     ADBC::Version::MICRO)
-      unless NativePackageInstaller.install(debian: "libadbc-glib-dev",
-                                            redhat: "adbc-glib-devel")
+      unless NativePackageInstaller.install(debian: "libadbc-arrow-glib-dev",
+                                            redhat: "adbc-arrow-glib-devel")
         exit(false)
       end
     end

--- a/ruby/lib/adbc.rb
+++ b/ruby/lib/adbc.rb
@@ -24,6 +24,16 @@ require "adbc/loader"
 module ADBC
   class Error < StandardError
   end
+end
 
-  Loader.load
+ADBC::Loader.load
+begin
+  ADBCArrow::Loader.load
+rescue GObjectIntrospection::RepositoryError
+else
+  module ADBC
+    RawStatement = Statement
+    remove_const(:Statement)
+    Statement = ADBCArrow::Statement
+  end
 end

--- a/ruby/lib/adbc/loader.rb
+++ b/ruby/lib/adbc/loader.rb
@@ -43,3 +43,22 @@ module ADBC
     end
   end
 end
+
+module ADBCArrow
+  class Loader < GObjectIntrospection::Loader
+    class << self
+      def load
+        super("ADBCArrow", ADBCArrow)
+      end
+    end
+
+    private
+    def post_load(repository, namespace)
+      require_libraries
+    end
+
+    def require_libraries
+      require_relative "arrow-statement"
+    end
+  end
+end

--- a/ruby/lib/adbc/statement-openable.rb
+++ b/ruby/lib/adbc/statement-openable.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,25 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require "pathname"
-require "test-unit"
-
-(ENV["ADBC_DLL_PATH"] || "").split(File::PATH_SEPARATOR).each do |path|
-  RubyInstaller::Runtime.add_dll_directory(path)
+module ADBC
+  module StatementOpenable
+    def open(connection)
+      statement = new(connection)
+      if block_given?
+        begin
+          yield(statement)
+        ensure
+          statement.release
+        end
+      else
+        statement
+      end
+    end
+  end
 end
-
-base_dir = Pathname(__dir__).parent
-test_dir = base_dir + "test"
-
-require "gi"
-
-ADBC = GI.load("ADBC")
-begin
-  ADBCArrow = GI.load("ADBCArrow")
-rescue GObjectIntrospection::RepositoryError => error
-  puts("ADBCArrow isn't found: #{error}")
-end
-
-require_relative "helper"
-
-exit(Test::Unit::AutoRunner.run(true, test_dir.to_s))

--- a/ruby/lib/adbc/statement-operations.rb
+++ b/ruby/lib/adbc/statement-operations.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,25 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require "pathname"
-require "test-unit"
+module ADBC
+  module StatementOperations
+    def ingest(table_name, values, mode: :create)
+      self.ingest_target_table = table_name
+      self.ingest_mode = mode
+      bind(values) do
+        execute(need_result: false)
+      end
+    end
 
-(ENV["ADBC_DLL_PATH"] || "").split(File::PATH_SEPARATOR).each do |path|
-  RubyInstaller::Runtime.add_dll_directory(path)
+    def query(sql, &block)
+      self.sql_query = sql
+      execute(&block)
+    end
+  end
 end
-
-base_dir = Pathname(__dir__).parent
-test_dir = base_dir + "test"
-
-require "gi"
-
-ADBC = GI.load("ADBC")
-begin
-  ADBCArrow = GI.load("ADBCArrow")
-rescue GObjectIntrospection::RepositoryError => error
-  puts("ADBCArrow isn't found: #{error}")
-end
-
-require_relative "helper"
-
-exit(Test::Unit::AutoRunner.run(true, test_dir.to_s))


### PR DESCRIPTION
Fixes #1280.

We can use
`GArrowRecordBatch`/`GArrowSchema`/`GArrowRecordBatchReader` instead of C data API with this library.