### PR TITLE
fix(java/driver/jdbc): improve error messages thrown from JdbcDataSource connect failures

### DIFF
--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriverUtil.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriverUtil.java
@@ -56,7 +56,8 @@ final class JdbcDriverUtil {
 
   static AdbcException fromSqlException(SQLException e) {
     // Unwrap an unknown exception with a known cause inside of it
-    if (isUnknown(e) && e.getCause() instanceof SQLException
+    if (isUnknown(e)
+        && e.getCause() instanceof SQLException
         && !isUnknown((SQLException) e.getCause())) {
       return fromSqlException((SQLException) e.getCause());
     }
@@ -69,11 +70,7 @@ final class JdbcDriverUtil {
 
     // Otherwise handle as normal
     return new AdbcException(
-        message,
-        e.getCause(),
-        guessStatusCode(e.getSQLState()),
-        e.getSQLState(),
-        e.getErrorCode());
+        message, e.getCause(), guessStatusCode(e.getSQLState()), e.getSQLState(), e.getErrorCode());
   }
 
   static AdbcException fromSqlException(String format, SQLException e, Object... values) {

--- a/java/driver/jdbc/src/test/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriverUtilTest.java
+++ b/java/driver/jdbc/src/test/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriverUtilTest.java
@@ -31,7 +31,8 @@ public class JdbcDriverUtilTest {
   public void fromKnownSQLException() {
     SQLException knownException = new SQLException("Known SQL exception", "S1000", 100, null);
     AdbcException adbcException = JdbcDriverUtil.fromSqlException(knownException);
-    assertEquals(JdbcDriverUtil.prefixExceptionMessage(
+    assertEquals(
+        JdbcDriverUtil.prefixExceptionMessage(
         knownException.getMessage()), adbcException.getMessage());
     assertEquals(adbcException.getVendorCode(), knownException.getErrorCode());
     assertEquals(adbcException.getSqlState(), knownException.getSQLState());
@@ -41,7 +42,8 @@ public class JdbcDriverUtilTest {
   public void fromUnknownSQLException() {
     SQLException unknownSqlException = new SQLException("Unknown SQL exception");
     AdbcException adbcException = JdbcDriverUtil.fromSqlException(unknownSqlException);
-    assertEquals(JdbcDriverUtil.prefixExceptionMessage(
+    assertEquals(
+        JdbcDriverUtil.prefixExceptionMessage(
         unknownSqlException.getMessage()), adbcException.getMessage());
     assertEquals(adbcException.getVendorCode(), 0);
     assertNull(adbcException.getSqlState());
@@ -54,7 +56,8 @@ public class JdbcDriverUtilTest {
     SQLException unknownSqlException = new SQLException("Unknown SQL exception", knownException);
 
     AdbcException adbcException = JdbcDriverUtil.fromSqlException(unknownSqlException);
-    assertEquals(JdbcDriverUtil.prefixExceptionMessage(
+    assertEquals(
+        JdbcDriverUtil.prefixExceptionMessage(
         knownException.getMessage()), adbcException.getMessage());
     assertEquals(adbcException.getVendorCode(), knownException.getErrorCode());
     assertEquals(adbcException.getSqlState(), knownException.getSQLState());
@@ -64,8 +67,8 @@ public class JdbcDriverUtilTest {
   public void fromSQLExceptionCausedByConnectException() {
     // Wrap a known exception in an unknown exception.
     ConnectException connectException = new ConnectException();
-    SQLException knownException = new SQLException("Known SQL exception",
-        "S1000", 100, connectException);
+    SQLException knownException =
+        new SQLException("Known SQL exception", "S1000", 100, connectException);
 
     AdbcException adbcException = JdbcDriverUtil.fromSqlException(knownException);
     assertEquals(knownException.getMessage(), adbcException.getMessage());

--- a/java/driver/jdbc/src/test/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriverUtilTest.java
+++ b/java/driver/jdbc/src/test/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriverUtilTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.net.ConnectException;
 import java.sql.SQLException;
-
 import org.apache.arrow.adbc.core.AdbcException;
 import org.junit.jupiter.api.Test;
 
@@ -32,8 +31,8 @@ public class JdbcDriverUtilTest {
     SQLException knownException = new SQLException("Known SQL exception", "S1000", 100, null);
     AdbcException adbcException = JdbcDriverUtil.fromSqlException(knownException);
     assertEquals(
-        JdbcDriverUtil.prefixExceptionMessage(
-        knownException.getMessage()), adbcException.getMessage());
+        JdbcDriverUtil.prefixExceptionMessage(knownException.getMessage()),
+        adbcException.getMessage());
     assertEquals(adbcException.getVendorCode(), knownException.getErrorCode());
     assertEquals(adbcException.getSqlState(), knownException.getSQLState());
   }
@@ -43,8 +42,8 @@ public class JdbcDriverUtilTest {
     SQLException unknownSqlException = new SQLException("Unknown SQL exception");
     AdbcException adbcException = JdbcDriverUtil.fromSqlException(unknownSqlException);
     assertEquals(
-        JdbcDriverUtil.prefixExceptionMessage(
-        unknownSqlException.getMessage()), adbcException.getMessage());
+        JdbcDriverUtil.prefixExceptionMessage(unknownSqlException.getMessage()),
+        adbcException.getMessage());
     assertEquals(adbcException.getVendorCode(), 0);
     assertNull(adbcException.getSqlState());
   }
@@ -57,8 +56,8 @@ public class JdbcDriverUtilTest {
 
     AdbcException adbcException = JdbcDriverUtil.fromSqlException(unknownSqlException);
     assertEquals(
-        JdbcDriverUtil.prefixExceptionMessage(
-        knownException.getMessage()), adbcException.getMessage());
+        JdbcDriverUtil.prefixExceptionMessage(knownException.getMessage()),
+        adbcException.getMessage());
     assertEquals(adbcException.getVendorCode(), knownException.getErrorCode());
     assertEquals(adbcException.getSqlState(), knownException.getSQLState());
   }

--- a/java/driver/jdbc/src/test/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriverUtilTest.java
+++ b/java/driver/jdbc/src/test/java/org/apache/arrow/adbc/driver/jdbc/JdbcDriverUtilTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.adbc.driver.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.ConnectException;
+import java.sql.SQLException;
+
+import org.apache.arrow.adbc.core.AdbcException;
+import org.junit.jupiter.api.Test;
+
+public class JdbcDriverUtilTest {
+
+  @Test
+  public void fromKnownSQLException() {
+    SQLException knownException = new SQLException("Known SQL exception", "S1000", 100, null);
+    AdbcException adbcException = JdbcDriverUtil.fromSqlException(knownException);
+    assertEquals(JdbcDriverUtil.prefixExceptionMessage(
+        knownException.getMessage()), adbcException.getMessage());
+    assertEquals(adbcException.getVendorCode(), knownException.getErrorCode());
+    assertEquals(adbcException.getSqlState(), knownException.getSQLState());
+  }
+
+  @Test
+  public void fromUnknownSQLException() {
+    SQLException unknownSqlException = new SQLException("Unknown SQL exception");
+    AdbcException adbcException = JdbcDriverUtil.fromSqlException(unknownSqlException);
+    assertEquals(JdbcDriverUtil.prefixExceptionMessage(
+        unknownSqlException.getMessage()), adbcException.getMessage());
+    assertEquals(adbcException.getVendorCode(), 0);
+    assertNull(adbcException.getSqlState());
+  }
+
+  @Test
+  public void fromWrappedKnownSQLException() {
+    // Wrap a known exception in an unknown exception.
+    SQLException knownException = new SQLException("Known SQL exception", "S1000", 100, null);
+    SQLException unknownSqlException = new SQLException("Unknown SQL exception", knownException);
+
+    AdbcException adbcException = JdbcDriverUtil.fromSqlException(unknownSqlException);
+    assertEquals(JdbcDriverUtil.prefixExceptionMessage(
+        knownException.getMessage()), adbcException.getMessage());
+    assertEquals(adbcException.getVendorCode(), knownException.getErrorCode());
+    assertEquals(adbcException.getSqlState(), knownException.getSQLState());
+  }
+
+  @Test
+  public void fromSQLExceptionCausedByConnectException() {
+    // Wrap a known exception in an unknown exception.
+    ConnectException connectException = new ConnectException();
+    SQLException knownException = new SQLException("Known SQL exception",
+        "S1000", 100, connectException);
+
+    AdbcException adbcException = JdbcDriverUtil.fromSqlException(knownException);
+    assertEquals(knownException.getMessage(), adbcException.getMessage());
+    assertEquals(adbcException.getVendorCode(), knownException.getErrorCode());
+    assertEquals(adbcException.getSqlState(), knownException.getSQLState());
+    assertEquals(adbcException.getSqlState(), knownException.getSQLState());
+  }
+}


### PR DESCRIPTION
Improve error messages for JdbcDataSource connection failures.
- Identify JDBC-specific errors and only use the [JDBC] prefix for these.
- Unwrap unknown exceptions that hold known exceptions.

Fixes #1465.