### PR TITLE
fix(r/adbcpostgresql): Link -lcrypt32 on Windows

### DIFF
--- a/r/adbcpostgresql/src/Makevars.ucrt
+++ b/r/adbcpostgresql/src/Makevars.ucrt
@@ -17,7 +17,7 @@
 
 PKG_CPPFLAGS = -I../src -DADBC_EXPORT="" -D__USE_MINGW_ANSI_STDIO
 
-PKG_LIBS = -lpq -lpgcommon -lpgport -lssl -lcrypto -lz -lsecur32 -lws2_32 -lwldap32
+PKG_LIBS = -lpq -lpgcommon -lpgport -lssl -lcrypto -lz -lsecur32 -lws2_32 -lwldap32 -lcrypt32
 
 OBJECTS = init.o \
     error.o \


### PR DESCRIPTION
As requested by Tomas:

```
Dear Dewey,

I am sorry to report that your package's Makevars.ucrt needs to be updated for an upcoming release of Rtools: one also has to link crypt32, please see the attached patch.

Please update so that your package will keep working in future versions of Rtools. This can be done unconditionally, because the library was available even before, just wasn't needed - so it should be fine to simply use the patch.
```