### PR TITLE
fix(go/adbc/driver/snowflake): Make SHOW WAREHOUSES test less flaky

### DIFF
--- a/go/adbc/driver/snowflake/driver_test.go
+++ b/go/adbc/driver/snowflake/driver_test.go
@@ -1360,7 +1360,49 @@ func (suite *SnowflakeTests) TestStatementEmptyResultSet() {
 	suite.True(rdr.Next())
 	rec := rdr.Record()
 	suite.Equal(n, rec.NumRows())
-	suite.EqualValues(26, rec.NumCols())
+
+	// Snowflake may add more columns to the result of this query in the future,
+	// so we just test a subset known to be supported at the time of writing
+	expectedFieldNames := []string{
+		"name",
+		"state",
+		"type",
+		"size",
+		"running",
+		"queued",
+		"is_default",
+		"is_current",
+		"auto_suspend",
+		"auto_resume",
+		"available",
+		"provisioning",
+		"quiescing",
+		"other",
+		"created_on",
+		"resumed_on",
+		"updated_on",
+		"owner",
+		"comment",
+		"resource_monitor",
+		"actives",
+		"pendings",
+		"failed",
+		"suspended",
+		"uuid",
+		"budget",
+		"owner_role_type",
+	}
+
+	fields := rec.Schema().Fields()
+outer: // Check that each of the expected field names are in the result schema
+	for _, expectedFieldName := range expectedFieldNames {
+		for _, f := range fields {
+			if f.Name == expectedFieldName {
+				continue outer
+			}
+		}
+		suite.Failf("unexpected result schema", "column '%s' expected but not found", expectedFieldName)
+	}
 
 	suite.False(rdr.Next())
 	suite.NoError(rdr.Err())


### PR DESCRIPTION
Minor fix to a test that has been breaking each time Snowflake added a new field to the result of a `SHOW WAREHOUSES` query.

Previously we asserted the number of columns, but this number has been changing. Instead of completely removing this part of the test, we can assert the columns we know currently should be present and expect that Snowflake won't make breaking changes to the schema by removing columns. The specific contents of the schema are not relevant to the original purpose of the test anyway, so it should be fine if the actual schema continues to grow beyond what is asserted here.