### PR TITLE
feat(c/driver/postgresql): customize numeric conversion

### DIFF
--- a/c/driver/postgresql/statement.h
+++ b/c/driver/postgresql/statement.h
@@ -33,6 +33,12 @@
 #define ADBC_POSTGRESQL_OPTION_BATCH_SIZE_HINT_BYTES \
   "adbc.postgresql.batch_size_hint_bytes"
 
+#define ADBC_POSTGRESQL_NUMERIC_CONVERSION "adbc.postgresql.numeric_conversion"
+
+#define ADBC_POSTGRESQL_NC_OPTION_TO_STRING "to_string"
+
+#define ADBC_POSTGRESQL_NC_OPTION_TO_DOUBLE "to_double"
+
 namespace adbcpq {
 class PostgresConnection;
 class PostgresStatement;
@@ -162,5 +168,6 @@ class PostgresStatement {
   } ingest_;
 
   TupleReader reader_;
+  NumericConversionStrategy numeric_conversion_;
 };
 }  // namespace adbcpq


### PR DESCRIPTION
- introduces statement-level option `adbc.postgresql.numeric_conversion`
- the option is used to tell result reader what strategy to use when converting numeric values to Arrow data; since this cannot be done 1-1, the reader has to convert to other data type
  - clients can use this option to specify the strategy
- value can be either `to_string` or `to_double`
  - when not specified defaults to `to_string`
  - `to_string` -> numerics converted loss-less to string representation
  - when `to_double` -> numeric converted to double (with possible loss of precision)