### PR TITLE
feat(go/adbc/driver/snowflake): add '[ADBC]' to snowflake application name

### DIFF
--- a/go/adbc/driver/snowflake/snowflake_database.go
+++ b/go/adbc/driver/snowflake/snowflake_database.go
@@ -265,6 +265,9 @@ func (d *databaseImpl) SetOptions(cnOptions map[string]string) error {
 			}
 			d.cfg.ClientTimeout = dur
 		case OptionApplicationName:
+			if !strings.HasPrefix(v, "[ADBC]") {
+				v = "[ADBC][Go]" + v
+			}
 			d.cfg.Application = v
 		case OptionSSLSkipVerify:
 			switch v {

--- a/go/adbc/driver/snowflake/snowflake_database.go
+++ b/go/adbc/driver/snowflake/snowflake_database.go
@@ -176,9 +176,10 @@ func (d *databaseImpl) SetOptions(cnOptions map[string]string) error {
 		}
 	}
 
+	defaultAppName := "[ADBC][Go-" + infoDriverVersion + "]"
 	// set default application name to track
 	// unless user overrides it
-	d.cfg.Application = "[ADBC][Go]"
+	d.cfg.Application = defaultAppName
 
 	var err error
 	for k, v := range cnOptions {
@@ -270,7 +271,7 @@ func (d *databaseImpl) SetOptions(cnOptions map[string]string) error {
 			d.cfg.ClientTimeout = dur
 		case OptionApplicationName:
 			if !strings.HasPrefix(v, "[ADBC]") {
-				v = "[ADBC][Go]" + v
+				v = defaultAppName + v
 			}
 			d.cfg.Application = v
 		case OptionSSLSkipVerify:

--- a/go/adbc/driver/snowflake/snowflake_database.go
+++ b/go/adbc/driver/snowflake/snowflake_database.go
@@ -176,6 +176,10 @@ func (d *databaseImpl) SetOptions(cnOptions map[string]string) error {
 		}
 	}
 
+	// set default application name to track
+	// unless user overrides it
+	d.cfg.Application = "[ADBC][Go]"
+
 	var err error
 	for k, v := range cnOptions {
 		v := v // copy into loop scope

--- a/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
+++ b/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
@@ -132,9 +132,9 @@ def connect(
     if uri is not None:
         kwargs["uri"] = uri
     appname = kwargs.get(DatabaseOptions.APPLICATION_NAME.value, "")
-    kwargs[DatabaseOptions.APPLICATION_NAME.value] = (
-        f"[ADBC][Python-{__version__}]{appname}"
-    )
+    kwargs[
+        DatabaseOptions.APPLICATION_NAME.value
+    ] = f"[ADBC][Python-{__version__}]{appname}"
     return adbc_driver_manager.AdbcDatabase(driver=_driver_path(), **kwargs)
 
 

--- a/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
+++ b/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
@@ -131,7 +131,10 @@ def connect(
     kwargs = (db_kwargs or {}).copy()
     if uri is not None:
         kwargs["uri"] = uri
-    kwargs.setdefault(DatabaseOptions.APPLICATION_NAME, "[ADBC][Python]")
+    appname = kwargs.get(DatabaseOptions.APPLICATION_NAME.value, "")
+    kwargs[DatabaseOptions.APPLICATION_NAME.value] = (
+        f"[ADBC][Python-{__version__}]" + appname
+    )
     return adbc_driver_manager.AdbcDatabase(driver=_driver_path(), **kwargs)
 
 

--- a/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
+++ b/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
@@ -133,7 +133,7 @@ def connect(
         kwargs["uri"] = uri
     appname = kwargs.get(DatabaseOptions.APPLICATION_NAME.value, "")
     kwargs[DatabaseOptions.APPLICATION_NAME.value] = (
-        f"[ADBC][Python-{__version__}]" + appname
+        f"[ADBC][Python-{__version__}]{appname}"
     )
     return adbc_driver_manager.AdbcDatabase(driver=_driver_path(), **kwargs)
 

--- a/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
+++ b/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
@@ -131,6 +131,7 @@ def connect(
     kwargs = (db_kwargs or {}).copy()
     if uri is not None:
         kwargs["uri"] = uri
+    kwargs[DatabaseOptions.APPLICATION_NAME] = "[ADBC][Python]" + kwargs.get(DatabaseOptions.APPLICATION_NAME, "")
     return adbc_driver_manager.AdbcDatabase(driver=_driver_path(), **kwargs)
 
 

--- a/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
+++ b/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
@@ -131,7 +131,7 @@ def connect(
     kwargs = (db_kwargs or {}).copy()
     if uri is not None:
         kwargs["uri"] = uri
-    kwargs[DatabaseOptions.APPLICATION_NAME] = "[ADBC][Python]" + kwargs.get(DatabaseOptions.APPLICATION_NAME, "")
+    kwargs.setdefault(DatabaseOptions.APPLICATION_NAME, "[ADBC][Python]")
     return adbc_driver_manager.AdbcDatabase(driver=_driver_path(), **kwargs)
 
 


### PR DESCRIPTION
To help Snowflake track adoption and usage of the ADBC driver, we can explicitly add a prefix to any client application name to indicate the ADBC driver is the source of the requests.