### PR TITLE
chore(r/adbcsnowflake): Add application name to Snowflake driver

### DIFF
--- a/r/adbcsnowflake/R/adbcsnowflake-package.R
+++ b/r/adbcsnowflake/R/adbcsnowflake-package.R
@@ -54,7 +54,16 @@ adbcsnowflake <- function() {
 #' @importFrom adbcdrivermanager adbc_database_init
 #' @export
 adbc_database_init.adbcsnowflake_driver_snowflake <- function(driver, ..., uri = NULL) {
-  options <- list(..., uri = uri)
+  options <- list(
+    ...,
+    uri = uri,
+    adbc.snowflake.sql.client_option.app_name = paste0(
+      "[ADBC][R-",
+      packageVersion("adbcsnowflake"),
+      "]"
+    )
+  )
+
   adbcdrivermanager::adbc_database_init_default(
     driver,
     options,


### PR DESCRIPTION
A follow-up to https://github.com/apache/arrow-adbc/pull/1525 to add an R-specific prefix for the Snowflake driver. We could allow this to be customized, too, but I would prefer to that feature to be requested before pursuing it.

Closes #1526.