### PR TITLE
test(go/adbc/driver/flightsql): test handling of bad locations

### DIFF
--- a/docs/source/driver/flight_sql.rst
+++ b/docs/source/driver/flight_sql.rst
@@ -326,6 +326,12 @@ The options are as follows:
     For example, this controls the timeout of the underlying Flight
     calls that implement bulk ingestion, or transaction support.
 
+There is also a timeout that is set on the :cpp:class:`AdbcDatabase`:
+
+``adbc.flight.sql.rpc.timeout_seconds.connect``
+    A timeout (in floating-point seconds) for establishing a connection.  The
+    default is 20 seconds.
+
 Transactions
 ------------
 

--- a/go/adbc/driver/flightsql/flightsql_driver.go
+++ b/go/adbc/driver/flightsql/flightsql_driver.go
@@ -35,6 +35,7 @@ import (
 	"net/url"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/apache/arrow-adbc/go/adbc"
 	"github.com/apache/arrow-adbc/go/adbc/driver/driverbase"
@@ -53,6 +54,7 @@ const (
 	OptionWithBlock           = "adbc.flight.sql.client_option.with_block"
 	OptionWithMaxMsgSize      = "adbc.flight.sql.client_option.with_max_msg_size"
 	OptionAuthorizationHeader = "adbc.flight.sql.authorization_header"
+	OptionTimeoutConnect      = "adbc.flight.sql.rpc.timeout_seconds.connect"
 	OptionTimeoutFetch        = "adbc.flight.sql.rpc.timeout_seconds.fetch"
 	OptionTimeoutQuery        = "adbc.flight.sql.rpc.timeout_seconds.query"
 	OptionTimeoutUpdate       = "adbc.flight.sql.rpc.timeout_seconds.update"
@@ -126,7 +128,11 @@ func (d *driverImpl) NewDatabase(opts map[string]string) (adbc.Database, error) 
 
 	db := &databaseImpl{
 		DatabaseImplBase: driverbase.NewDatabaseImplBase(&d.DriverImplBase),
-		hdrs:             make(metadata.MD),
+		timeout: timeoutOption{
+			// Match gRPC default
+			connectTimeout: time.Second * 20,
+		},
+		hdrs: make(metadata.MD),
 	}
 
 	var err error


### PR DESCRIPTION
Add a test to ensure that the driver can still fetch data from a server that returns 1 unreachable and 1 reachable location. Also, add a new option to adjust the connect timeout.

Fixes #1527.