### PR TITLE
fix(csharp/src/Drivers/BigQuery): return null on GetValue exception

### DIFF
--- a/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
@@ -85,9 +85,10 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             if (!this.properties.TryGetValue(BigQueryParameters.ProjectId, out projectId))
                 throw new ArgumentException($"The {BigQueryParameters.ProjectId} parameter is not present");
 
-            if (this.properties.ContainsKey(BigQueryParameters.AuthenticationType))
+            if (this.properties.TryGetValue(BigQueryParameters.AuthenticationType, out string? newAuthenticationType))
             {
-                authenticationType = this.properties[BigQueryParameters.AuthenticationType];
+                if (!string.IsNullOrEmpty(newAuthenticationType))
+                    authenticationType = newAuthenticationType;
 
                 if (!authenticationType.Equals(BigQueryConstants.UserAuthenticationType, StringComparison.OrdinalIgnoreCase) &&
                     !authenticationType.Equals(BigQueryConstants.ServiceAccountAuthenticationType, StringComparison.OrdinalIgnoreCase))

--- a/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
@@ -85,8 +85,10 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             if (!this.properties.TryGetValue(BigQueryParameters.ProjectId, out projectId))
                 throw new ArgumentException($"The {BigQueryParameters.ProjectId} parameter is not present");
 
-            if (this.properties.TryGetValue(BigQueryParameters.AuthenticationType, out authenticationType))
+            if (this.properties.ContainsKey(BigQueryParameters.AuthenticationType))
             {
+                authenticationType = this.properties[BigQueryParameters.AuthenticationType];
+
                 if (!authenticationType.Equals(BigQueryConstants.UserAuthenticationType, StringComparison.OrdinalIgnoreCase) &&
                     !authenticationType.Equals(BigQueryConstants.ServiceAccountAuthenticationType, StringComparison.OrdinalIgnoreCase))
                 {

--- a/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
@@ -92,14 +92,21 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
 
         public override object GetValue(IArrowArray arrowArray, int index)
         {
-            switch (arrowArray)
+            try
             {
-                case StructArray structArray:
-                    return SerializeToJson(structArray, index);
-                case ListArray listArray:
-                    return listArray.GetSlicedValues(index);
-                default:
-                    return base.GetValue(arrowArray, index);
+                switch (arrowArray)
+                {
+                    case StructArray structArray:
+                        return SerializeToJson(structArray, index);
+                    case ListArray listArray:
+                        return listArray.GetSlicedValues(index);
+                    default:
+                        return base.GetValue(arrowArray, index);
+                }
+            }
+            catch
+            {
+                return null;
             }
         }
 

--- a/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
@@ -92,21 +92,14 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
 
         public override object GetValue(IArrowArray arrowArray, int index)
         {
-            try
+            switch (arrowArray)
             {
-                switch (arrowArray)
-                {
-                    case StructArray structArray:
-                        return SerializeToJson(structArray, index);
-                    case ListArray listArray:
-                        return listArray.GetSlicedValues(index);
-                    default:
-                        return base.GetValue(arrowArray, index);
-                }
-            }
-            catch
-            {
-                return null;
+                case StructArray structArray:
+                    return SerializeToJson(structArray, index);
+                case ListArray listArray:
+                    return listArray.GetSlicedValues(index);
+                default:
+                    return base.GetValue(arrowArray, index);
             }
         }
 
@@ -240,6 +233,9 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
 
         private Dictionary<String, object> ParseStructArray(StructArray structArray, int index)
         {
+            if (structArray.IsNull(index))
+                return null;
+
             Dictionary<String, object> jsonDictionary = new Dictionary<String, object>();
             StructType structType = (StructType)structArray.Data.DataType;
             for (int i = 0; i < structArray.Data.Children.Length; i++)


### PR DESCRIPTION
In a query such as `SELECT * FROM bigquery-public-data.fhir_synthea.explanation_of_benefit`, a number of items return null inside of the StructArray result. An exception is thrown from the underlying Arrow calls because we hit a scenario where Length and index are both 0, so an `ArgumentOutOfRangeException` is thrown per https://github.com/apache/arrow/blob/280bc112b23976d2f17c07c638bb62702ac89e8a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs#L356. 