### PR TITLE
feat(go/adbc/driver/flightsql): reflect gRPC status in vendor code

### DIFF
--- a/go/adbc/driver/flightsql/utils.go
+++ b/go/adbc/driver/flightsql/utils.go
@@ -20,6 +20,7 @@ package flightsql
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/apache/arrow-adbc/go/adbc"
 	"google.golang.org/grpc/codes"
@@ -92,9 +93,18 @@ func adbcFromFlightStatusWithDetails(err error, header, trailer metadata.MD, con
 	// XXX: must check both headers and trailers because some implementations
 	// (like gRPC-Java) will consolidate trailers into headers for failed RPCs
 	for key, values := range header {
-		switch key {
-		case "content-type", "grpc-status-details-bin":
+		switch {
+		case key == "content-type":
+			// Not useful info
 			continue
+		case key == "grpc-status-details-bin":
+			// gRPC library parses this above via grpcStatus.Proto()
+			continue
+		case strings.HasSuffix(key, "-bin"):
+			for _, value := range values {
+				// that's right, gRPC stuffs binary data into a "string"
+				details = append(details, &adbc.BinaryErrorDetail{Name: key, Detail: []byte(value)})
+			}
 		default:
 			for _, value := range values {
 				details = append(details, &adbc.TextErrorDetail{Name: key, Detail: value})
@@ -102,9 +112,18 @@ func adbcFromFlightStatusWithDetails(err error, header, trailer metadata.MD, con
 		}
 	}
 	for key, values := range trailer {
-		switch key {
-		case "content-type", "grpc-status-details-bin":
+		switch {
+		case key == "content-type":
+			// Not useful info
 			continue
+		case key == "grpc-status-details-bin":
+			// gRPC library parses this above via grpcStatus.Proto()
+			continue
+		case strings.HasSuffix(key, "-bin"):
+			for _, value := range values {
+				// that's right, gRPC stuffs binary data into a "string"
+				details = append(details, &adbc.BinaryErrorDetail{Name: key, Detail: []byte(value)})
+			}
 		default:
 			for _, value := range values {
 				details = append(details, &adbc.TextErrorDetail{Name: key, Detail: value})
@@ -114,9 +133,10 @@ func adbcFromFlightStatusWithDetails(err error, header, trailer metadata.MD, con
 
 	return adbc.Error{
 		// People don't read error messages, so backload the context and frontload the server error
-		Msg:     fmt.Sprintf("[FlightSQL] %s (%s; %s)", grpcStatus.Message(), grpcStatus.Code(), fmt.Sprintf(context, args...)),
-		Code:    adbcCode,
-		Details: details,
+		Msg:        fmt.Sprintf("[FlightSQL] %s (%s; %s)", grpcStatus.Message(), grpcStatus.Code(), fmt.Sprintf(context, args...)),
+		Code:       adbcCode,
+		VendorCode: int32(grpcStatus.Code()),
+		Details:    details,
 	}
 }
 

--- a/python/adbc_driver_flightsql/pyproject.toml
+++ b/python/adbc_driver_flightsql/pyproject.toml
@@ -44,3 +44,6 @@ include-package-data = true
 license-files = ["LICENSE.txt", "NOTICE.txt"]
 packages = ["adbc_driver_flightsql"]
 py-modules = ["adbc_driver_flightsql"]
+
+[tool.pytest.ini_options]
+xfail_strict = true

--- a/python/adbc_driver_manager/pyproject.toml
+++ b/python/adbc_driver_manager/pyproject.toml
@@ -43,6 +43,7 @@ markers = [
     "panicdummy: tests that require the testing-only panicdummy driver",
     "sqlite: tests that require the SQLite driver",
 ]
+xfail_strict = true
 
 [tool.setuptools]
 license-files = ["LICENSE.txt", "NOTICE.txt"]

--- a/python/adbc_driver_postgresql/pyproject.toml
+++ b/python/adbc_driver_postgresql/pyproject.toml
@@ -43,6 +43,7 @@ build-backend = "setuptools.build_meta"
 markers = [
     "polars: integration tests with polars",
 ]
+xfail_strict = true
 
 [tool.setuptools]
 include-package-data = true

--- a/python/adbc_driver_snowflake/pyproject.toml
+++ b/python/adbc_driver_snowflake/pyproject.toml
@@ -44,3 +44,6 @@ include-package-data = true
 license-files = ["LICENSE.txt", "NOTICE.txt"]
 packages = ["adbc_driver_snowflake"]
 py-modules = ["adbc_driver_snowflake"]
+
+[tool.pytest.ini_options]
+xfail_strict = true

--- a/python/adbc_driver_sqlite/pyproject.toml
+++ b/python/adbc_driver_sqlite/pyproject.toml
@@ -44,3 +44,6 @@ include-package-data = true
 license-files = ["LICENSE.txt", "NOTICE.txt"]
 packages = ["adbc_driver_sqlite"]
 py-modules = ["adbc_driver_sqlite"]
+
+[tool.pytest.ini_options]
+xfail_strict = true


### PR DESCRIPTION
Does not work in C/C++/Python due to #1576.

Fixes #1574.