### PR TITLE
feat(go/adbc/driver/flightsql): expose FlightInfo during polling

### DIFF
--- a/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
@@ -483,6 +483,32 @@ func (srv *IncrementalPollTestServer) PollFlightInfo(ctx context.Context, desc *
 		return nil, status.Errorf(codes.NotFound, "Query ID not found")
 	}
 
+	if query.query == "infinite" {
+		query.nextIndex++
+
+		descriptor, err := proto.Marshal(&wrapperspb.StringValue{Value: queryId})
+		if err != nil {
+			return nil, err
+		}
+		return &flight.PollInfo{
+			Info: &flight.FlightInfo{
+				Schema: nil,
+				Endpoint: []*flight.FlightEndpoint{{
+					Ticket: &flight.Ticket{
+						Ticket: []byte{},
+					},
+				}},
+				AppMetadata: []byte("app metadata"),
+			},
+			FlightDescriptor: &flight.FlightDescriptor{
+				Type: flight.DescriptorCMD,
+				Cmd:  descriptor,
+			},
+			// always makes a bit of progress, never gets anywhere
+			Progress: proto.Float64(float64(query.nextIndex) / 100.0),
+		}, nil
+	}
+
 	testCase, ok := srv.testCases[query.query]
 	if !ok {
 		if query.query == "unavailable" {
@@ -518,6 +544,32 @@ func (srv *IncrementalPollTestServer) PollFlightInfoStatement(ctx context.Contex
 		}
 
 		return srv.MakePollInfo(&unavailableCase, srv.queries[queryId], queryId)
+	} else if query.GetQuery() == "infinite" {
+		srv.queries[queryId] = &IncrementalQuery{
+			query:     query.GetQuery(),
+			nextIndex: 0,
+		}
+
+		descriptor, err := proto.Marshal(&wrapperspb.StringValue{Value: queryId})
+		if err != nil {
+			return nil, err
+		}
+		return &flight.PollInfo{
+			Info: &flight.FlightInfo{
+				Schema: nil,
+				Endpoint: []*flight.FlightEndpoint{{
+					Ticket: &flight.Ticket{
+						Ticket: []byte{},
+					},
+				}},
+				AppMetadata: []byte("app metadata"),
+			},
+			FlightDescriptor: &flight.FlightDescriptor{
+				Type: flight.DescriptorCMD,
+				Cmd:  descriptor,
+			},
+			Progress: proto.Float64(0),
+		}, nil
 	}
 
 	testCase, ok := srv.testCases[query.GetQuery()]
@@ -725,6 +777,48 @@ func (ts *IncrementalPollTests) TestOptionValue() {
 	var adbcErr adbc.Error
 	ts.ErrorAs(stmt.SetOption(adbc.OptionKeyIncremental, "foobar"), &adbcErr)
 	ts.Equal(adbc.StatusInvalidArgument, adbcErr.Code)
+}
+
+func (ts *IncrementalPollTests) TestAppMetadata() {
+	ctx, cancel := context.WithCancel(context.Background())
+	stmt, err := ts.cnxn.NewStatement()
+	ts.NoError(err)
+	defer stmt.Close()
+
+	ts.NoError(stmt.SetOption(adbc.OptionKeyIncremental, adbc.OptionValueEnabled))
+
+	ts.NoError(stmt.SetSqlQuery("infinite"))
+	_, partitions, _, err := stmt.ExecutePartitions(ctx)
+	ts.NoError(err)
+	ts.Equalf(uint64(1), partitions.NumPartitions, "%#v", partitions)
+
+	progress := 0.0
+	go func() {
+		var err error
+		var info []byte
+		for {
+			// While the below is stuck, we should be able to get the app metadata and progress
+			progress, err = stmt.(adbc.GetSetOptions).GetOptionDouble(adbc.OptionKeyProgress)
+			ts.NoError(err)
+
+			info, err = stmt.(adbc.GetSetOptions).GetOptionBytes(driver.OptionLastFlightInfo)
+			ts.NoError(err)
+			var flightInfo flight.FlightInfo
+			ts.NoError(proto.Unmarshal(info, &flightInfo))
+			ts.Equal([]byte("app metadata"), flightInfo.AppMetadata)
+
+			if progress > 0.03 {
+				break
+			}
+		}
+		cancel()
+	}()
+
+	// will get stuck forever, but will "make progress"
+	_, _, _, err = stmt.ExecutePartitions(ctx)
+	var adbcErr adbc.Error
+	ts.ErrorAs(err, &adbcErr)
+	ts.Equal(adbc.StatusCancelled, adbcErr.Code)
 }
 
 func (ts *IncrementalPollTests) TestUnavailable() {

--- a/go/adbc/driver/flightsql/flightsql_driver.go
+++ b/go/adbc/driver/flightsql/flightsql_driver.go
@@ -60,6 +60,7 @@ const (
 	OptionTimeoutUpdate       = "adbc.flight.sql.rpc.timeout_seconds.update"
 	OptionRPCCallHeaderPrefix = "adbc.flight.sql.rpc.call_header."
 	OptionCookieMiddleware    = "adbc.flight.sql.rpc.with_cookie_middleware"
+	OptionLastFlightInfo      = "adbc.flight.sql.statement.exec.last_flight_info"
 	infoDriverName            = "ADBC Flight SQL Driver - Go"
 )
 

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -186,6 +186,7 @@ func (s *statement) clearIncrementalQuery() error {
 			}
 		}
 		s.incrementalState = &incrementalState{}
+		s.lastInfo.Store(nil)
 	}
 	return nil
 }
@@ -254,6 +255,9 @@ func (s *statement) GetOptionBytes(key string) ([]byte, error) {
 	switch key {
 	case OptionLastFlightInfo:
 		info := s.lastInfo.Load()
+		if info == nil {
+			return []byte{}, nil
+		}
 		serialized, err := proto.Marshal(info)
 		if err != nil {
 			return nil, adbc.Error{

--- a/python/adbc_driver_flightsql/adbc_driver_flightsql/__init__.py
+++ b/python/adbc_driver_flightsql/adbc_driver_flightsql/__init__.py
@@ -104,6 +104,15 @@ class ConnectionOptions(enum.Enum):
 class StatementOptions(enum.Enum):
     """Statement options specific to the Flight SQL driver."""
 
+    #: The latest FlightInfo value.
+    #:
+    #: Thread-safe.  Mostly useful when using incremental execution, where an
+    #: advanced client may want to inspect the latest FlightInfo from the
+    #: service, but without waiting for execute_partitions to return.  (The
+    #: service may send an updated FlightInfo with progress/app_metadata
+    #: values, but execute_partitions will only return if there are new
+    #: endpoints.)
+    LAST_FLIGHT_INFO = "adbc.flight.sql.statement.exec.last_flight_info"
     #: The number of batches to queue per partition. Defaults to 5.
     #:
     #: This controls how much we read ahead on result sets.

--- a/python/adbc_driver_flightsql/tests/test_incremental.py
+++ b/python/adbc_driver_flightsql/tests/test_incremental.py
@@ -111,6 +111,13 @@ def test_incremental_error_poll(test_dbapi) -> None:
 
 def test_incremental_cancel(test_dbapi) -> None:
     with test_dbapi.cursor() as cur:
+        assert (
+            cur.adbc_statement.get_option_bytes(
+                FlightSqlStatementOptions.LAST_FLIGHT_INFO.value
+            )
+            == b""
+        )
+
         cur.adbc_statement.set_options(
             **{
                 StatementOptions.INCREMENTAL.value: "true",

--- a/python/adbc_driver_flightsql/tests/test_incremental.py
+++ b/python/adbc_driver_flightsql/tests/test_incremental.py
@@ -16,13 +16,16 @@
 # under the License.
 
 import re
+import threading
 
 import google.protobuf.any_pb2 as any_pb2
 import google.protobuf.wrappers_pb2 as wrappers_pb2
 import pyarrow
+import pyarrow.flight
 import pytest
 
 import adbc_driver_manager
+from adbc_driver_flightsql import StatementOptions as FlightSqlStatementOptions
 from adbc_driver_manager import StatementOptions
 
 SCHEMA = pyarrow.schema([("ints", "int32")])
@@ -104,6 +107,47 @@ def test_incremental_error_poll(test_dbapi) -> None:
 
         partitions, _ = cur.adbc_execute_partitions("error_poll_later")
         assert partitions == []
+
+
+def test_incremental_cancel(test_dbapi) -> None:
+    with test_dbapi.cursor() as cur:
+        cur.adbc_statement.set_options(
+            **{
+                StatementOptions.INCREMENTAL.value: "true",
+            }
+        )
+        partitions, schema = cur.adbc_execute_partitions("forever")
+        assert len(partitions) == 1
+
+        passed = False
+
+        def _bg():
+            nonlocal passed
+            while True:
+                progress = cur.adbc_statement.get_option_float(
+                    StatementOptions.PROGRESS.value
+                )
+                # XXX: upstream PyArrow never bothered exposing app_metadata
+                raw_info = cur.adbc_statement.get_option_bytes(
+                    FlightSqlStatementOptions.LAST_FLIGHT_INFO.value
+                )
+
+                # check that it's a valid info
+                pyarrow.flight.FlightInfo.deserialize(raw_info)
+                passed = b"app metadata" in raw_info
+
+                if progress > 0.07:
+                    break
+            cur.adbc_cancel()
+
+        t = threading.Thread(target=_bg, daemon=True)
+        t.start()
+
+        with pytest.raises(test_dbapi.OperationalError, match="(?i)cancelled"):
+            cur.adbc_execute_partitions("forever")
+
+        t.join()
+        assert passed
 
 
 def test_incremental_immediately(test_dbapi) -> None:


### PR DESCRIPTION
Fixes #1571.