### PR TITLE
fix(go/adbc/drivermgr): don't call potentially nil pointer

### DIFF
--- a/go/adbc/drivermgr/wrapper.go
+++ b/go/adbc/drivermgr/wrapper.go
@@ -27,7 +27,12 @@ package drivermgr
 // #include "adbc.h"
 // #include <stdlib.h>
 //
-// void releaseErr(struct AdbcError* err) { err->release(err); }
+// void releaseErr(struct AdbcError* err) {
+//     if (err->release != NULL) {
+//         err->release(err);
+//         err->release = NULL;
+//     }
+// }
 // struct ArrowArray* allocArr() {
 //     return (struct ArrowArray*)malloc(sizeof(struct ArrowArray));
 // }
@@ -112,7 +117,13 @@ type Database struct {
 }
 
 func toAdbcError(code adbc.Status, e *C.struct_AdbcError) error {
-	err := &adbc.Error{
+	if e == nil || e.release == nil {
+		return adbc.Error{
+			Code: code,
+			Msg:  "[drivermgr] nil error",
+		}
+	}
+	err := adbc.Error{
 		Code:       code,
 		VendorCode: int32(e.vendor_code),
 		Msg:        C.GoString(e.message),

--- a/go/adbc/drivermgr/wrapper_sqlite_test.go
+++ b/go/adbc/drivermgr/wrapper_sqlite_test.go
@@ -453,7 +453,7 @@ func (dm *DriverMgrSuite) TestSqlExecuteInvalid() {
 	_, _, err = st.ExecuteQuery(dm.ctx)
 	dm.Require().Error(err)
 
-	var adbcErr *adbc.Error
+	var adbcErr adbc.Error
 	dm.ErrorAs(err, &adbcErr)
 	dm.ErrorContains(adbcErr, "[SQLite] Failed to prepare query:")
 	dm.ErrorContains(adbcErr, "syntax error")
@@ -610,7 +610,7 @@ func TestDriverMgrCustomInitFunc(t *testing.T) {
 		"entrypoint": "ThisSymbolDoesNotExist",
 	})
 	assert.Nil(t, db)
-	var exp *adbc.Error
+	var exp adbc.Error
 	assert.ErrorAs(t, err, &exp)
 	assert.Equal(t, adbc.StatusInternal, exp.Code)
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Fixes #1476.