### PR TITLE
test(go/adbc/driver/flightsql): Add TestMetadataGetObjectsColumnsXdbc test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.5.0
     hooks:
     - id: check-xml
     - id: check-yaml
@@ -40,7 +40,7 @@ repos:
     - id: trailing-whitespace
       exclude: "^r/.*?/_snaps/.*?.md$"
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v14.0.6"
+    rev: "v18.1.1"
     hooks:
       - id: clang-format
         types_or: [c, c++]
@@ -59,7 +59,7 @@ repos:
         - "--linelength=90"
         - "--verbose=2"
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.49.0
+    rev: v1.56.2
     hooks:
     - id: golangci-lint
       entry: bash -c 'cd go/adbc && golangci-lint run --fix --timeout 5m'
@@ -72,17 +72,17 @@ repos:
       args: [--autofix]
       types_or: [java]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.2.0
     hooks:
     - id: black
       types_or: [pyi, python]
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.0.0
     hooks:
     - id: flake8
       types_or: [python]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
     - id: isort
       types_or: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v2.3.0
     hooks:
     - id: check-xml
     - id: check-yaml
@@ -40,7 +40,7 @@ repos:
     - id: trailing-whitespace
       exclude: "^r/.*?/_snaps/.*?.md$"
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: "v18.1.1"
+    rev: "v14.0.6"
     hooks:
       - id: clang-format
         types_or: [c, c++]
@@ -59,7 +59,7 @@ repos:
         - "--linelength=90"
         - "--verbose=2"
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.56.2
+    rev: v1.49.0
     hooks:
     - id: golangci-lint
       entry: bash -c 'cd go/adbc && golangci-lint run --fix --timeout 5m'
@@ -72,17 +72,17 @@ repos:
       args: [--autofix]
       types_or: [java]
   - repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 22.3.0
     hooks:
     - id: black
       types_or: [pyi, python]
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 4.0.1
     hooks:
     - id: flake8
       types_or: [python]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 5.12.0
     hooks:
     - id: isort
       types_or: [python]

--- a/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
@@ -37,6 +37,8 @@ import (
 
 	"github.com/apache/arrow-adbc/go/adbc"
 	driver "github.com/apache/arrow-adbc/go/adbc/driver/flightsql"
+	"github.com/apache/arrow-adbc/go/adbc/driver/internal"
+	"github.com/apache/arrow-adbc/go/adbc/validation"
 	"github.com/apache/arrow/go/v16/arrow"
 	"github.com/apache/arrow/go/v16/arrow/array"
 	"github.com/apache/arrow/go/v16/arrow/flight"
@@ -1870,4 +1872,214 @@ func (suite *SessionOptionTests) TestGetSetStringList() {
 	val, err = o.GetOption(driver.OptionStringListSessionOptionPrefix + "stringlist")
 	suite.NoError(err)
 	suite.Equal(`[]`, val)
+}
+
+type GetObjectsTests struct {
+	suite.Suite
+
+	Driver adbc.Driver
+	Quirks validation.DriverQuirks
+	Cnxn   adbc.Connection
+	ctx    context.Context
+	DB     adbc.Database
+}
+
+func (suite *GetObjectsTests) SetupSuite() {
+	var err error
+	suite.Driver = suite.Quirks.SetupDriver(suite.T())
+	suite.DB, err = suite.Driver.NewDatabase(suite.Quirks.DatabaseOptions())
+	suite.NoError(err)
+
+	suite.ctx = context.Background()
+	suite.Cnxn, err = suite.DB.Open(suite.ctx)
+	suite.Require().NoError(err)
+}
+
+func (suite *GetObjectsTests) TestMetadataGetObjectsColumnsXdbc() {
+
+	suite.Require().NoError(suite.Quirks.DropTable(suite.Cnxn, "bulk_ingest"))
+
+	mdInts := make(map[string]string)
+	mdInts["TYPE_NAME"] = "NUMERIC"
+	mdInts["ORDINAL_POSITION"] = "1"
+	mdInts["XDBC_DATA_TYPE"] = strconv.Itoa(int(arrow.PrimitiveTypes.Int64.ID()))
+	mdInts["XDBC_TYPE_NAME"] = "NUMERIC"
+	mdInts["XDBC_SQL_DATA_TYPE"] = strconv.Itoa(int(internal.XdbcDataType_XDBC_BIGINT))
+	mdInts["XDBC_NULLABLE"] = strconv.FormatBool(true)
+	mdInts["XDBC_IS_NULLABLE"] = "YES"
+	mdInts["XDBC_PRECISION"] = strconv.Itoa(38)
+	mdInts["XDBC_SCALE"] = strconv.Itoa(0)
+	mdInts["XDBC_NUM_PREC_RADIX"] = strconv.Itoa(10)
+
+	mdStrings := make(map[string]string)
+	mdStrings["TYPE_NAME"] = "TEXT"
+	mdStrings["ORDINAL_POSITION"] = "2"
+	mdStrings["XDBC_DATA_TYPE"] = strconv.Itoa(int(arrow.BinaryTypes.String.ID()))
+	mdStrings["XDBC_TYPE_NAME"] = "TEXT"
+	mdStrings["XDBC_SQL_DATA_TYPE"] = strconv.Itoa(int(internal.XdbcDataType_XDBC_VARCHAR))
+	mdStrings["XDBC_IS_NULLABLE"] = "YES"
+	mdStrings["CHARACTER_MAXIMUM_LENGTH"] = strconv.Itoa(16777216)
+	mdStrings["XDBC_CHAR_OCTET_LENGTH"] = strconv.Itoa(16777216)
+
+	rec, _, err := array.RecordFromJSON(suite.Quirks.Alloc(), arrow.NewSchema(
+		[]arrow.Field{
+			{Name: "int64s", Type: arrow.PrimitiveTypes.Int64, Nullable: true, Metadata: arrow.MetadataFrom(mdInts)},
+			{Name: "strings", Type: arrow.BinaryTypes.String, Nullable: true, Metadata: arrow.MetadataFrom(mdStrings)},
+		}, nil), strings.NewReader(`[
+			{"int64s": 42, "strings": "foo"},
+			{"int64s": -42, "strings": null},
+			{"int64s": null, "strings": ""}
+		]`))
+	suite.Require().NoError(err)
+	defer rec.Release()
+
+	suite.Require().NoError(suite.Quirks.CreateSampleTable("bulk_ingest", rec))
+
+	tests := []struct {
+		name             string
+		colnames         []string
+		positions        []string
+		dataTypes        []string
+		comments         []string
+		xdbcDataType     []string
+		xdbcTypeName     []string
+		xdbcSqlDataType  []string
+		xdbcNullable     []string
+		xdbcIsNullable   []string
+		xdbcScale        []string
+		xdbcNumPrecRadix []string
+		xdbcCharMaxLen   []string
+		xdbcCharOctetLen []string
+		xdbcDateTimeSub  []string
+	}{
+		{
+			"BASIC",                       // name
+			[]string{"int64s", "strings"}, // colNames
+			[]string{"1", "2"},            // positions
+			[]string{"NUMBER", "TEXT"},    // dataTypes
+			[]string{"", ""},              // comments
+			[]string{"9", "13"},           // xdbcDataType
+			[]string{"NUMBER", "TEXT"},    // xdbcTypeName
+			[]string{"-5", "12"},          // xdbcSqlDataType
+			[]string{"1", "1"},            // xdbcNullable
+			[]string{"YES", "YES"},        // xdbcIsNullable
+			[]string{"0", "0"},            // xdbcScale
+			[]string{"10", "0"},           // xdbcNumPrecRadix
+			[]string{"38", "16777216"},    // xdbcCharMaxLen (xdbcPrecision)
+			[]string{"0", "16777216"},     // xdbcCharOctetLen
+			[]string{"-5", "12", "0"},     // xdbcDateTimeSub
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			rdr, err := suite.Cnxn.GetObjects(suite.ctx, adbc.ObjectDepthColumns, nil, nil, nil, nil, nil)
+			suite.Require().NoError(err)
+			defer rdr.Release()
+
+			suite.Truef(adbc.GetObjectsSchema.Equal(rdr.Schema()), "expected: %s\ngot: %s", adbc.GetObjectsSchema, rdr.Schema())
+			suite.True(rdr.Next())
+			rec := rdr.Record()
+			suite.Greater(rec.NumRows(), int64(0))
+			var (
+				foundExpected        = false
+				catalogDbSchemasList = rec.Column(1).(*array.List)
+				catalogDbSchemas     = catalogDbSchemasList.ListValues().(*array.Struct)
+				dbSchemaNames        = catalogDbSchemas.Field(0).(*array.String)
+				dbSchemaTablesList   = catalogDbSchemas.Field(1).(*array.List)
+				dbSchemaTables       = dbSchemaTablesList.ListValues().(*array.Struct)
+				tableColumnsList     = dbSchemaTables.Field(2).(*array.List)
+				tableColumns         = tableColumnsList.ListValues().(*array.Struct)
+
+				colnames          = make([]string, 0)
+				positions         = make([]string, 0)
+				comments          = make([]string, 0)
+				xdbcDataTypes     = make([]string, 0)
+				dataTypes         = make([]string, 0)
+				xdbcTypeNames     = make([]string, 0)
+				xdbcCharMaxLens   = make([]string, 0)
+				xdbcScales        = make([]string, 0)
+				xdbcNumPrecRadixs = make([]string, 0)
+				xdbcNullables     = make([]string, 0)
+				xdbcSqlDataTypes  = make([]string, 0)
+				xdbcDateTimeSub   = make([]string, 0)
+				xdbcCharOctetLen  = make([]string, 0)
+				xdbcIsNullables   = make([]string, 0)
+			)
+			for row := 0; row < int(rec.NumRows()); row++ {
+				dbSchemaIdxStart, dbSchemaIdxEnd := catalogDbSchemasList.ValueOffsets(row)
+				for dbSchemaIdx := dbSchemaIdxStart; dbSchemaIdx < dbSchemaIdxEnd; dbSchemaIdx++ {
+					schemaName := dbSchemaNames.Value(int(dbSchemaIdx))
+					tblIdxStart, tblIdxEnd := dbSchemaTablesList.ValueOffsets(int(dbSchemaIdx))
+					for tblIdx := tblIdxStart; tblIdx < tblIdxEnd; tblIdx++ {
+						tableName := dbSchemaTables.Field(0).(*array.String).Value(int(tblIdx))
+
+						if strings.EqualFold(schemaName, suite.Quirks.DBSchema()) && strings.EqualFold("bulk_ingest", tableName) {
+							foundExpected = true
+
+							colIdxStart, colIdxEnd := tableColumnsList.ValueOffsets(int(tblIdx))
+							for colIdx := colIdxStart; colIdx < colIdxEnd; colIdx++ {
+								name := tableColumns.Field(0).(*array.String).Value(int(colIdx))
+								colnames = append(colnames, strings.ToLower(name))
+
+								pos := tableColumns.Field(1).(*array.Int32).Value(int(colIdx))
+								positions = append(positions, strconv.Itoa(int(pos)))
+
+								comments = append(comments, tableColumns.Field(2).(*array.String).Value(int(colIdx)))
+
+								xdt := tableColumns.Field(3).(*array.Int16).Value(int(colIdx))
+								xdbcDataTypes = append(xdbcDataTypes, strconv.Itoa(int(xdt)))
+
+								dataType := tableColumns.Field(4).(*array.String).Value(int(colIdx))
+								dataTypes = append(dataTypes, dataType)
+								xdbcTypeNames = append(xdbcTypeNames, dataType)
+
+								// these are column size attributes used for either precision for numbers OR the length for text
+								maxLenOrPrecision := tableColumns.Field(5).(*array.Int32).Value(int(colIdx))
+								xdbcCharMaxLens = append(xdbcCharMaxLens, strconv.Itoa(int(maxLenOrPrecision)))
+
+								scale := tableColumns.Field(6).(*array.Int16).Value(int(colIdx))
+								xdbcScales = append(xdbcScales, strconv.Itoa(int(scale)))
+
+								radix := tableColumns.Field(7).(*array.Int16).Value(int(colIdx))
+								xdbcNumPrecRadixs = append(xdbcNumPrecRadixs, strconv.Itoa(int(radix)))
+
+								isnull := tableColumns.Field(8).(*array.Int16).Value(int(colIdx))
+								xdbcNullables = append(xdbcNullables, strconv.Itoa(int(isnull)))
+
+								sqlType := tableColumns.Field(10).(*array.Int16).Value(int(colIdx))
+								xdbcSqlDataTypes = append(xdbcSqlDataTypes, strconv.Itoa(int(sqlType)))
+
+								dtPrec := tableColumns.Field(11).(*array.Int16).Value(int(colIdx))
+								xdbcDateTimeSub = append(xdbcSqlDataTypes, strconv.Itoa(int(dtPrec)))
+
+								charOctetLen := tableColumns.Field(12).(*array.Int32).Value(int(colIdx))
+								xdbcCharOctetLen = append(xdbcCharOctetLen, strconv.Itoa(int(charOctetLen)))
+
+								xdbcIsNullables = append(xdbcIsNullables, tableColumns.Field(13).(*array.String).Value(int(colIdx)))
+							}
+						}
+					}
+				}
+			}
+
+			suite.False(rdr.Next())
+			suite.True(foundExpected)
+			suite.Equal(tt.colnames, colnames)                  // colNames
+			suite.Equal(tt.positions, positions)                // positions
+			suite.Equal(tt.comments, comments)                  // comments
+			suite.Equal(tt.xdbcDataType, xdbcDataTypes)         // xdbcDataType
+			suite.Equal(tt.dataTypes, dataTypes)                // dataTypes
+			suite.Equal(tt.xdbcTypeName, xdbcTypeNames)         // xdbcTypeName
+			suite.Equal(tt.xdbcCharMaxLen, xdbcCharMaxLens)     // xdbcCharMaxLen
+			suite.Equal(tt.xdbcScale, xdbcScales)               // xdbcScale
+			suite.Equal(tt.xdbcNumPrecRadix, xdbcNumPrecRadixs) // xdbcNumPrecRadix
+			suite.Equal(tt.xdbcNullable, xdbcNullables)         // xdbcNullable
+			suite.Equal(tt.xdbcSqlDataType, xdbcSqlDataTypes)   // xdbcSqlDataType
+			suite.Equal(tt.xdbcDateTimeSub, xdbcDateTimeSub)    // xdbcDateTimeSub
+			suite.Equal(tt.xdbcCharOctetLen, xdbcCharOctetLen)  // xdbcCharOctetLen
+			suite.Equal(tt.xdbcIsNullable, xdbcIsNullables)     // xdbcIsNullable
+
+		})
+	}
 }

--- a/go/adbc/driver/flightsql/flightsql_adbc_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_test.go
@@ -35,6 +35,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1005,6 +1006,12 @@ func (suite *DomainSocketTests) SetupSuite() {
 
 	suite.ctx = context.Background()
 	suite.Driver = driver.NewDriver(suite.alloc)
+
+	if runtime.GOOS == "windows" {
+		// Remove drive letter and reverse slash directions in path
+		listenSocket = strings.ReplaceAll(listenSocket[2:], "\\", "/")
+	}
+
 	suite.DB, err = suite.Driver.NewDatabase(map[string]string{
 		adbc.OptionKeyURI: "grpc+unix://" + listenSocket,
 	})

--- a/go/adbc/driver/snowflake/connection.go
+++ b/go/adbc/driver/snowflake/connection.go
@@ -408,7 +408,6 @@ func toField(name string, isnullable bool, dataType string, numPrec, numPrecRadi
 }
 
 func toXdbcDataType(dt arrow.DataType) (xdbcType internal.XdbcDataType) {
-	xdbcType = internal.XdbcDataType_XDBC_UNKNOWN_TYPE
 	switch dt.ID() {
 	case arrow.EXTENSION:
 		return toXdbcDataType(dt.(arrow.ExtensionType).StorageType())


### PR DESCRIPTION
Ports over TestMetadataGetObjectsColumnsXdbc from Snowflake to also be tested on FlightSQL.

Also makes the DomainSocketTest work correctly on Windows by correcting the expected path of the generated adbc.sock file.

Also removes an ineffectual assignment in the Snowflake driver that I couldn't commit without fixing.

Also Updates pre-commit as I again could not commit without fixing.