### PR TITLE
ci: enable dependabot for golang, java

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,18 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore: "
+  - package-ecosystem: "gomod"
+    directory: "/go/adbc/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(go/adbc): "
+  - package-ecosystem: "maven"
+    directory: "/java/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(java): "
   - package-ecosystem: "nuget"
     directory: "/csharp/"
     schedule:


### PR DESCRIPTION
Fixes #1616.