### PR TITLE
build(c): don't expose Nanoarrow symbols

### DIFF
--- a/c/driver/postgresql/copy/postgres_copy_writer_test.cc
+++ b/c/driver/postgresql/copy/postgres_copy_writer_test.cc
@@ -307,7 +307,7 @@ TEST(PostgresCopyUtilsTest, PostgresCopyWriteNumeric) {
   ArrowSchemaInit(&schema.value);
   ASSERT_EQ(ArrowSchemaSetTypeStruct(&schema.value, 1), 0);
   ASSERT_EQ(
-      AdbcNsArrowSchemaSetTypeDecimal(schema.value.children[0], type, precision, scale),
+      PrivateArrowSchemaSetTypeDecimal(schema.value.children[0], type, precision, scale),
       0);
   ASSERT_EQ(ArrowSchemaSetName(schema.value.children[0], "col"), 0);
   ASSERT_EQ(adbc_validation::MakeBatch<ArrowDecimal*>(&schema.value, &array.value,

--- a/c/driver/postgresql/postgresql_benchmark.cc
+++ b/c/driver/postgresql/postgresql_benchmark.cc
@@ -207,8 +207,8 @@ static void BM_PostgresqlDecimalWrite(benchmark::State& state) {
   }
 
   for (size_t i = 0; i < ncols; i++) {
-    if (AdbcNsArrowSchemaSetTypeDecimal(schema.value.children[i], type, precision,
-                                        scale) != NANOARROW_OK) {
+    if (PrivateArrowSchemaSetTypeDecimal(schema.value.children[i], type, precision,
+                                         scale) != NANOARROW_OK) {
       state.SkipWithError("Call to ArrowSchemaSetTypeDecimal failed!");
       error.release(&error);
       return;

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1747,7 +1747,7 @@ TEST_P(PostgresDecimalTest, SelectValue) {
   ArrowSchemaInit(&schema.value);
   ASSERT_EQ(ArrowSchemaSetTypeStruct(&schema.value, 1), 0);
   ASSERT_EQ(
-      AdbcNsArrowSchemaSetTypeDecimal(schema.value.children[0], type, precision, scale),
+      PrivateArrowSchemaSetTypeDecimal(schema.value.children[0], type, precision, scale),
       0);
   ASSERT_EQ(ArrowSchemaSetName(schema.value.children[0], "col"), 0);
 

--- a/c/vendor/nanoarrow/nanoarrow.h
+++ b/c/vendor/nanoarrow/nanoarrow.h
@@ -27,7 +27,7 @@
   (NANOARROW_VERSION_MAJOR * 10000 + NANOARROW_VERSION_MINOR * 100 + \
    NANOARROW_VERSION_PATCH)
 
-#define NANOARROW_NAMESPACE AdbcNs
+#define NANOARROW_NAMESPACE Private
 
 #endif
 // Licensed to the Apache Software Foundation (ASF) under one

--- a/c/vendor/vendor_nanoarrow.sh
+++ b/c/vendor/vendor_nanoarrow.sh
@@ -39,7 +39,9 @@ main() {
     # resulting bundle is perfectly synchronized with the commit we've pulled.
     pushd "$SCRATCH"
     mkdir build && cd build
-    cmake .. -DNANOARROW_BUNDLE=ON -DNANOARROW_NAMESPACE=AdbcNs
+    # Do not use "adbc" in the namespace name since our scripts expose all
+    # such symbols
+    cmake .. -DNANOARROW_BUNDLE=ON -DNANOARROW_NAMESPACE=Private
     cmake --build .
     cmake --install . --prefix=../dist-adbc
     popd


### PR DESCRIPTION
Fixes #1605.