### PR TITLE
chore(dev/release): slight fix for non-conda verification and docs

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -456,7 +456,7 @@ test_python() {
   show_header "Build and test Python libraries"
 
   # Build and test Python
-  maybe_setup_virtualenv cython duckdb pandas protobuf pyarrow pytest setuptools_scm setuptools || exit 1
+  maybe_setup_virtualenv cython duckdb pandas protobuf pyarrow pytest setuptools_scm setuptools importlib_resources || exit 1
   maybe_setup_conda --file "${ADBC_DIR}/ci/conda_env_python.txt" || exit 1
 
   if [ "${USE_CONDA}" -gt 0 ]; then

--- a/docs/source/development/releasing.rst
+++ b/docs/source/development/releasing.rst
@@ -213,9 +213,13 @@ How to Verify Release Candidates
    - C and C++ compilers (or the equivalent of ``build-essential`` for your platform)
    - Python 3
    - Ruby with headers
+      - meson is required
    - bundler, rake, red-arrow, and test-unit Ruby gems
    - GLib and gobject-introspection with headers
+      - pkg-config or cmake must be able to find libarrow-glib.so
+      - GI_TYPELIB_PATH should be set to the path to the girepository-1.0 directory
    - Java JRE and JDK (Java 8+)
+      - the javadoc command must also be accessible
    - Go
    - CMake, ninja-build, libpq (with headers), SQLite (with headers)
 


### PR DESCRIPTION
updating the docs and release verification script based on my experience for non-conda verification runs