### PR TITLE
chore(dev/release): Fix Windows verification under conda

### DIFF
--- a/dev/release/verify-release-candidate.ps1
+++ b/dev/release/verify-release-candidate.ps1
@@ -108,6 +108,8 @@ if ($SourceKind -eq "local") {
     tar -C $ArrowSourceDir --strip-components 1 -xf $DistPath
 }
 
+$ArrowSourceDir = $ArrowSourceDir | Resolve-Path
+
 echo "Using $($ArrowSourceDir)"
 
 Show-Header "Create Conda Environment"
@@ -127,11 +129,11 @@ conda activate $(Join-Path $ArrowTempDir conda-env)
 conda remove -y --force gtest
 
 # Activating doesn't appear to set GOROOT
-$env:GOROOT = $(Join-Path $ArrowTempDir conda-env go)
+$env:GOROOT = $(Join-Path $ArrowTempDir conda-env go) | Resolve-Path
 
 Show-Header "Verify C/C++ Sources"
 
-$CppBuildDir = Join-Path $ArrowTempDir cpp-build
+$CppBuildDir = $(Join-Path $ArrowTempDir cpp-build) | Resolve-Path
 New-Item -ItemType Directory -Force -Path $CppBuildDir | Out-Null
 
 # XXX(apache/arrow-adbc#634): not working on Windows due to it picking

--- a/dev/release/verify-release-candidate.ps1
+++ b/dev/release/verify-release-candidate.ps1
@@ -92,6 +92,8 @@ if ($SourceKind -eq "local") {
 } else {
     $ArrowSourceDir = Join-Path $ArrowTempDir $DistName
     New-Item -ItemType Directory -Path $ArrowSourceDir -Force
+    # Convert to an absolute now that it should exist
+    $ArrowSourceDir = $ArrowSourceDir | Resolve-Path | % { $_.Path }
 
     Download-Dist-File "$($DistName).tar.gz"
     Download-Dist-File "$($DistName).tar.gz.sha512"
@@ -107,8 +109,6 @@ if ($SourceKind -eq "local") {
 
     tar -C $ArrowSourceDir --strip-components 1 -xf $DistPath
 }
-
-$ArrowSourceDir = $ArrowSourceDir | Resolve-Path
 
 echo "Using $($ArrowSourceDir)"
 
@@ -130,11 +130,11 @@ conda activate $(Join-Path $ArrowTempDir conda-env)
 conda remove -y --force gtest
 
 # Activating doesn't appear to set GOROOT
-$env:GOROOT = $(Join-Path $ArrowTempDir conda-env go) | Resolve-Path
+$env:GOROOT = $(Join-Path $ArrowTempDir conda-env go)
 
 Show-Header "Verify C/C++ Sources"
 
-$CppBuildDir = $(Join-Path $ArrowTempDir cpp-build) | Resolve-Path
+$CppBuildDir = Join-Path $ArrowTempDir cpp-build
 New-Item -ItemType Directory -Force -Path $CppBuildDir | Out-Null
 
 # XXX(apache/arrow-adbc#634): not working on Windows due to it picking

--- a/dev/release/verify-release-candidate.ps1
+++ b/dev/release/verify-release-candidate.ps1
@@ -117,7 +117,8 @@ Show-Header "Create Conda Environment"
 mamba create -c conda-forge -f -y -p $(Join-Path $ArrowTempDir conda-env) `
   --file $(Join-Path $ArrowSourceDir ci\conda_env_cpp.txt) `
   --file $(Join-Path $ArrowSourceDir ci\conda_env_python.txt) `
-  go
+  go `
+  m2w64-gcc
 
 Invoke-Expression $(conda shell.powershell hook | Out-String)
 conda activate $(Join-Path $ArrowTempDir conda-env)


### PR DESCRIPTION
This changes two things to make release verification run on my system:

- Adds ` | Resolve-Path` to three variables to make them absolute paths. Without this, cpp_build.ps1 was running CMake and pointing at the wrong path because it saves a relative path, cds into another directory, and then tries to use the relative path.
- Adds `m2w64-gcc` inline to the `mamba create` call to make sure the Go has access to gcc for building. I was a little surprised the existing `compilers` package doesn't install gcc so I'm not sure if something might have changed upstream.

Fixes #1683