### PR TITLE
fix(r): Ensure CXX_STD is set everywhere

### DIFF
--- a/r/adbcdrivermanager/src/Makevars
+++ b/r/adbcdrivermanager/src/Makevars
@@ -15,4 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
+CXX_STD = CXX17
 PKG_CPPFLAGS=-I../src -DADBC_EXPORT=""

--- a/r/adbcpostgresql/src/Makevars.ucrt
+++ b/r/adbcpostgresql/src/Makevars.ucrt
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+CXX_STD = CXX17
 PKG_CPPFLAGS = -I../src -I../src/c/ -I../src/c/vendor/ -I../src/c/vendor/fmt/include/ -DADBC_EXPORT="" -D__USE_MINGW_ANSI_STDIO -DFMT_HEADER_ONLY=1
 
 PKG_LIBS = -lpq -lpgcommon -lpgport -lssl -lcrypto -lz -lsecur32 -lws2_32 -lwldap32 -lcrypt32

--- a/r/adbcsqlite/src/Makevars.in
+++ b/r/adbcsqlite/src/Makevars.in
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-CXXSTD = CXX17
+CXX_STD = CXX17
 PKG_CPPFLAGS=-I../src/ -I../src/c/ -I../src/c/vendor/ -I../src/c/vendor/fmt/include/ @cppflags@ -DADBC_EXPORT="" -DFMT_HEADER_ONLY=1 -D_LIBCPP_DISABLE_AVAILABILITY
 PKG_LIBS=@libs@
 


### PR DESCRIPTION
Upon submitting adbcpostgresql to CRAN, there is now a build error for R 4.1 on Windows, which uses C++14 as its default standard if unspecified. This gives:

```
g++ -std=gnu++14  -I"D:/RCompile/recent/R-4.2.3/include" -DNDEBUG -I../src -DADBC_EXPORT="" -D__USE_MINGW_ANSI_STDIO    -I"d:/rtools42/x86_64-w64-mingw32.static.posix/include"     -pedantic -O2 -Wall  -mfpmath=sse -msse2 -mstackrealign  -c connection.cc -o connection.o
In file included from connection.cc:37:
result_helper.h:37:8: error: 'optional' in namespace 'std' does not name a template type
   37 |   std::optional<double> ParseDouble() const {
      |        ^~~~~~~~
result_helper.h:37:3: note: 'std::optional' is only available from C++17 onwards
```

https://www.r-project.org/nosvn/R.check/r-oldrel-windows-x86_64/adbcpostgresql-00install.html