### PR TITLE
feat(glib): Add garrow_connection_get_statistic_names()

### DIFF
--- a/glib/adbc-glib/connection.h
+++ b/glib/adbc-glib/connection.h
@@ -252,6 +252,9 @@ gpointer gadbc_connection_get_statistics(GADBCConnection* connection,
                                          const gchar* catalog, const gchar* db_schema,
                                          const gchar* table_name, gboolean approximate,
                                          GError** error);
+GADBC_AVAILABLE_IN_1_0
+gpointer gadbc_connection_get_statistic_names(GADBCConnection* connection,
+                                              GError** error);
 GADBC_AVAILABLE_IN_0_4
 gboolean gadbc_connection_commit(GADBCConnection* connection, GError** error);
 GADBC_AVAILABLE_IN_0_4

--- a/glib/test/test-connection.rb
+++ b/glib/test/test-connection.rb
@@ -714,6 +714,14 @@ class ConnectionTest < Test::Unit::TestCase
     end
   end
 
+  def test_statistic_names
+    c_abi_array_stream = @connection.statistic_names
+    import_array_stream(c_abi_array_stream) do |reader|
+      table = reader.read_all
+      assert_equal([], table.raw_records)
+    end
+  end
+
   def test_commit
     open_connection do |connection|
       execute_sql(connection,


### PR DESCRIPTION
Fixes #1747.

This is the binding of `AdbcConnectionGetStatisticNames()`.