### PR TITLE
ci(rust): move `rustfmt` to pre-commit

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,8 +73,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ steps.rust.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ steps.rust.outputs.version }}-
-      - name: Rustfmt
-        run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -Dwarnings
       - name: Test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,5 +105,10 @@ repos:
       pass_filenames: true
       files: '(c/driver_manager/adbc_driver_manager\.)|(^adbc\.h)'
       entry: "./ci/scripts/run_cgo_drivermgr_check.sh"
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    - id: fmt
+      name: rustfmt
 
 exclude: "^c/vendor/.*"


### PR DESCRIPTION
As suggested in https://github.com/apache/arrow-adbc/pull/1749#discussion_r1576103518.