### PR TITLE
chore(dev/release): decouple version numbers

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -76,41 +76,13 @@ jobs:
       - name: Prepare version
         id: version
         run: |
-          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            VERSION=${GITHUB_REF_NAME#apache-arrow-adbc-}
-            VERSION=${VERSION%-rc*}
-          else
-            VERSION=$(grep 'set(ADBC_VERSION' c/cmake_modules/AdbcVersion.cmake | \
-                        grep -E -o '[0-9]+\.[0-9]+\.[0-9]+')
-            description=$(git describe \
-                            --always \
-                            --dirty \
-                            --long \
-                            --match "apache-arrow-adbc-[0-9]*.*" \
-                            --tags)
-            case "${description}" in
-              # apache-arrow-adbc-0.1.0-10-1234567-dirty
-              apache-arrow-adbc-*)
-                # 10-1234567-dirty
-                distance="${description#apache-arrow-adbc-*.*.*-}"
-                # 10-1234567
-                distance="${distance%-dirty}"
-                # 10
-                distance="${distance%-*}"
-                ;;
-              *)
-                distance=$(git log --format=oneline | wc -l)
-                ;;
-            esac
-            VERSION="${VERSION}.dev${distance}"
-          fi
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          source dev/release/versions.env
+          echo "VERSION=${VERSION}" | tee -a $GITHUB_ENV
 
       - name: Create archive
         run: |
           ci/scripts/source_build.sh \
-            apache-arrow-adbc-${{ steps.version.outputs.VERSION }} \
+            apache-arrow-adbc-${VERSION} \
             $(git log -n 1 --format=%h)
 
       - uses: actions/upload-artifact@v4
@@ -118,7 +90,7 @@ jobs:
           name: source
           retention-days: 7
           path: |
-            apache-arrow-adbc-${{ steps.version.outputs.VERSION }}.tar.gz
+            apache-arrow-adbc-*.tar.gz
 
   csharp:
     name: "C#/.NET"
@@ -177,8 +149,7 @@ jobs:
           source_archive=$(echo apache-arrow-adbc-*.tar.gz)
           VERSION=${source_archive#apache-arrow-adbc-}
           VERSION=${VERSION%.tar.gz}
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${VERSION}" | tee -a $GITHUB_ENV
 
           tar xf apache-arrow-adbc-${VERSION}.tar.gz
           mv apache-arrow-adbc-${VERSION} adbc
@@ -193,7 +164,7 @@ jobs:
         run: |
           pushd adbc
           docker compose run \
-            -e SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.version.outputs.VERSION }} \
+            -e SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION \
             docs
           popd
 
@@ -296,20 +267,19 @@ jobs:
           source_archive=$(echo apache-arrow-adbc-*.tar.gz)
           VERSION=${source_archive#apache-arrow-adbc-}
           VERSION=${VERSION%.tar.gz}
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${VERSION}" | tee -a $GITHUB_ENV
 
       - name: Extract source archive
         run: |
-          tar xf apache-arrow-adbc-${{ steps.info.outputs.VERSION }}.tar.gz
+          tar xf apache-arrow-adbc-$VERSION.tar.gz
 
-          source ./apache-arrow-adbc-${{ steps.info.outputs.VERSION }}/dev/release/versions.env
+          source ./apache-arrow-adbc-$VERSION/dev/release/versions.env
 
-          mv apache-arrow-adbc-${{ steps.info.outputs.VERSION }} adbc
+          mv apache-arrow-adbc-$VERSION adbc
           # Need to align the file path with the version number (and not the release)
-          cp -r adbc apache-arrow-adbc-${VERSION_NATIVE}
-          tar czf adbc/ci/linux-packages/apache-arrow-adbc-${VERSION_NATIVE}.tar.gz apache-arrow-adbc-${VERSION_NATIVE}
-          echo "VERSION=${VERSION_NATIVE}" | tee -a $GITHUB_ENV
+          cp -r adbc apache-arrow-adbc-$VERSION_NATIVE
+          tar czf adbc/ci/linux-packages/apache-arrow-adbc-$VERSION_NATIVE.tar.gz apache-arrow-adbc-${VERSION_NATIVE}
+          echo "VERSION=$VERSION_NATIVE" | tee -a $GITHUB_ENV
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -412,8 +382,7 @@ jobs:
           source_archive=$(echo apache-arrow-adbc-*.tar.gz)
           VERSION=${source_archive#apache-arrow-adbc-}
           VERSION=${VERSION%.tar.gz}
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${VERSION}" | tee -a $GITHUB_ENV
 
           tar xf apache-arrow-adbc-${VERSION}.tar.gz
           mv apache-arrow-adbc-${VERSION} adbc
@@ -479,11 +448,10 @@ jobs:
           source_archive=$(echo apache-arrow-adbc-*.tar.gz)
           VERSION=${source_archive#apache-arrow-adbc-}
           VERSION=${VERSION%.tar.gz}
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${VERSION}" | tee -a $GITHUB_ENV
 
-          tar xf apache-arrow-adbc-${VERSION}.tar.gz
-          mv apache-arrow-adbc-${VERSION} adbc
+          tar xf apache-arrow-adbc-$VERSION.tar.gz
+          mv apache-arrow-adbc-$VERSION adbc
 
       - name: Show inputs
         run: |
@@ -576,7 +544,7 @@ jobs:
         run: |
           pushd adbc
           docker compose run \
-            -e SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.version.outputs.VERSION }} \
+            -e SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION \
             python-wheel-manylinux
           popd
 
@@ -684,13 +652,13 @@ jobs:
         run: |
           pushd adbc
           vcpkg_version=$(cat ".env" | grep "VCPKG" | cut -d "=" -f2 | tr -d '"')
-          echo "VCPKG_VERSION=$vcpkg_version" >> "$GITHUB_OUTPUT"
+          echo "VCPKG_VERSION=$vcpkg_version" | tee -a "$GITHUB_ENV"
           popd
 
       - name: Install vcpkg
         run: |
           pushd adbc
-          ci/scripts/install_vcpkg.sh $VCPKG_ROOT ${{ steps.vcpkg_version.outputs.VCPKG_VERSION }}
+          ci/scripts/install_vcpkg.sh $VCPKG_ROOT $VCPKG_VERSION
           popd
 
       - uses: actions/setup-go@v5

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -276,6 +276,7 @@ jobs:
           source ./apache-arrow-adbc-$VERSION/dev/release/versions.env
 
           mv apache-arrow-adbc-$VERSION adbc
+          mv apache-arrow-adbc-$VERSION.tar.gz adbc/ci/linux-packages/
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -77,7 +77,7 @@ jobs:
         id: version
         run: |
           source dev/release/versions.env
-          echo "VERSION=${VERSION}" | tee -a $GITHUB_ENV
+          echo "VERSION=${RELEASE}" | tee -a $GITHUB_ENV
 
       - name: Create archive
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -276,10 +276,6 @@ jobs:
           source ./apache-arrow-adbc-$VERSION/dev/release/versions.env
 
           mv apache-arrow-adbc-$VERSION adbc
-          # Need to align the file path with the version number (and not the release)
-          cp -r adbc apache-arrow-adbc-$VERSION_NATIVE
-          tar czf adbc/ci/linux-packages/apache-arrow-adbc-$VERSION_NATIVE.tar.gz apache-arrow-adbc-${VERSION_NATIVE}
-          echo "VERSION=$VERSION_NATIVE" | tee -a $GITHUB_ENV
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -74,7 +74,6 @@ jobs:
           git fetch --tags --force origin
 
       - name: Prepare version
-        id: version
         run: |
           source dev/release/versions.env
           echo "VERSION=${RELEASE}" | tee -a $GITHUB_ENV
@@ -144,7 +143,6 @@ jobs:
           name: source
 
       - name: Extract source archive
-        id: version
         run: |
           source_archive=$(echo apache-arrow-adbc-*.tar.gz)
           VERSION=${source_archive#apache-arrow-adbc-}
@@ -248,7 +246,6 @@ jobs:
           path: arrow
 
       - name: Set output variables
-        id: info
         run: |
           echo "ARROW_SOURCE=$(pwd)/arrow" >> $GITHUB_ENV
           case ${{ matrix.target }} in
@@ -874,7 +871,6 @@ jobs:
           name: source
 
       - name: Extract source archive
-        id: version
         run: |
           source_archive=$(echo apache-arrow-adbc-*.tar.gz)
           VERSION=${source_archive#apache-arrow-adbc-}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -302,8 +302,14 @@ jobs:
       - name: Extract source archive
         run: |
           tar xf apache-arrow-adbc-${{ steps.info.outputs.VERSION }}.tar.gz
+
+          source ./apache-arrow-adbc-${{ steps.info.outputs.VERSION }}/dev/release/versions.env
+
           mv apache-arrow-adbc-${{ steps.info.outputs.VERSION }} adbc
-          mv apache-arrow-adbc-${{ steps.info.outputs.VERSION }}.tar.gz adbc/ci/linux-packages/
+          # Need to align the file path with the version number (and not the release)
+          cp -r adbc apache-arrow-adbc-${VERSION_NATIVE}
+          tar czf adbc/ci/linux-packages/apache-arrow-adbc-${VERSION_NATIVE}.tar.gz apache-arrow-adbc-${VERSION_NATIVE}
+          echo "VERSION=${VERSION_NATIVE}" | tee -a $GITHUB_ENV
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -527,7 +533,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["amd64", "arm64v8"]
+        # XXX(lidavidm): disable arm64 build for now while I test things
+        arch: ["amd64"]
         manylinux_version: ["2014"]
         is_pr:
           - ${{ startsWith(github.ref, 'refs/pull/') }}
@@ -546,11 +553,12 @@ jobs:
           source_archive=$(echo apache-arrow-adbc-*.tar.gz)
           VERSION=${source_archive#apache-arrow-adbc-}
           VERSION=${VERSION%.tar.gz}
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
           tar xf apache-arrow-adbc-${VERSION}.tar.gz
           mv apache-arrow-adbc-${VERSION} adbc
+
+          source adbc/dev/release/versions.env
+          echo "VERSION=${VERSION_NATIVE}" | tee -a $GITHUB_ENV
 
       - name: Show inputs
         run: |
@@ -654,11 +662,13 @@ jobs:
           source_archive=$(echo apache-arrow-adbc-*.tar.gz)
           VERSION=${source_archive#apache-arrow-adbc-}
           VERSION=${VERSION%.tar.gz}
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}" >> $GITHUB_ENV
 
           tar xf apache-arrow-adbc-${VERSION}.tar.gz
           mv apache-arrow-adbc-${VERSION} adbc
+
+          source adbc/dev/release/versions.env
+          echo "VERSION=${VERSION_NATIVE}" | tee -a $GITHUB_ENV
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION_NATIVE}" | tee -a $GITHUB_ENV
 
       - name: Show inputs
         run: |
@@ -805,11 +815,12 @@ jobs:
           source_archive=$(echo apache-arrow-adbc-*.tar.gz)
           VERSION=${source_archive#apache-arrow-adbc-}
           VERSION=${VERSION%.tar.gz}
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
           tar xf apache-arrow-adbc-${VERSION}.tar.gz
           mv apache-arrow-adbc-${VERSION} adbc
+
+          source adbc/dev/release/versions.env
+          echo "VERSION=${VERSION_NATIVE}" | tee -a $GITHUB_ENV
 
           (. adbc/.env && echo "GO_VERSION=${GO}") >> $GITHUB_ENV
 
@@ -903,11 +914,12 @@ jobs:
           source_archive=$(echo apache-arrow-adbc-*.tar.gz)
           VERSION=${source_archive#apache-arrow-adbc-}
           VERSION=${VERSION%.tar.gz}
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
-          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
           tar xf apache-arrow-adbc-${VERSION}.tar.gz
           mv apache-arrow-adbc-${VERSION} adbc
+
+          source adbc/dev/release/versions.env
+          echo "VERSION=${VERSION_NATIVE}" | tee -a $GITHUB_ENV
 
       - name: Show inputs
         run: |

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -892,7 +892,7 @@ jobs:
         run: |
           pushd adbc
           docker compose run  \
-            -e SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.version.outputs.VERSION }} \
+            -e SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION \
             python-sdist
           popd
 

--- a/ci/linux-packages/Rakefile
+++ b/ci/linux-packages/Rakefile
@@ -38,10 +38,15 @@ module Helper
     version_env = ENV["VERSION"]
     return version_env if version_env
 
-    meson_build = top_source_dir / "c" / "cmake_modules" / "AdbcVersion.cmake"
-    version = meson_build.read.scan(/ADBC_VERSION "(.+?)"/)[0][0]
-    formatted_release_time = release_time.strftime("%Y%m%d")
-    version.gsub(/-SNAPSHOT\z/) {"-dev#{formatted_release_time}"}
+    versions_env = top_source_dir / "dev" / "release" / "versions.env"
+    version = versions_env.read[/RELEASE="(.+?)"/, 1]
+    adbc_version_cmake = top_source_dir / "c" / "cmake_modules" / "AdbcVersion.cmake"
+    native_version = adbc_version_cmake.read[/ADBC_VERSION "(.+?)"/, 1]
+    if native_version.end_with?("-SNAPSHOT")
+      formatted_release_time = release_time.strftime("%Y%m%d")
+      version += "-dev#{formatted_release_time}"
+    end
+    version
   end
 
   def detect_release_time

--- a/dev/release/01-prepare.sh
+++ b/dev/release/01-prepare.sh
@@ -20,60 +20,61 @@
 set -ue
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$SOURCE_DIR/utils-common.sh"
+source "$SOURCE_DIR/utils-prepare.sh"
 
-if [ "$#" -ne 5 ]; then
-  echo "Usage: $0 <arrow-dir> <prev_veresion> <version> <next_version> <rc-num>"
-  echo "Usage: $0 ../arrow 0.1.0 0.2.0 0.3.0 0"
-  exit 1
-fi
+main() {
+    if [ "$#" -ne 2 ]; then
+        echo "Usage: $0 <arrow-dir> <rc_num>"
+        echo "Usage: $0 ../arrow 0"
+        exit 1
+    fi
 
-. $SOURCE_DIR/utils-prepare.sh
+    local -r arrow_dir="$1"
+    local -r rc_number="$2"
+    local -r release_candidate_tag="apache-arrow-adbc-${RELEASE}-rc${rc_number}"
 
-arrow_dir=$1
-prev_version=$2
-version=$3
-next_version=$4
-next_version_snapshot="${next_version}-SNAPSHOT"
-rc_number=$5
+    export ARROW_SOURCE="$(cd "${arrow_dir}" && pwd)"
 
-export ARROW_SOURCE="$(cd "${arrow_dir}" && pwd)"
+    if [[ $(git tag -l "${release_candidate_tag}") ]]; then
+        local -r next_rc_number=$(($rc_number+1))
+        echo "Tag ${release_candidate_tag} already exists, so create a new release candidate:"
+        echo "1. Create or checkout maint-<version>."
+        echo "2. Execute the script again with bumped RC number."
+        echo "Commands:"
+        echo "   git checkout maint-${version}"
+        echo "   dev/release/01-prepare.sh ${arrow_dir} ${next_rc_number}"
+        exit 1
+    fi
 
-release_candidate_tag="apache-arrow-adbc-${version}-rc${rc_number}"
+    ############################## Pre-Tag Commits ##############################
 
-if [[ $(git tag -l "${release_candidate_tag}") ]]; then
-    next_rc_number=$(($rc_number+1))
-    echo "Tag ${release_candidate_tag} already exists, so create a new release candidate:"
-    echo "1. Create or checkout maint-<version>."
-    echo "2. Execute the script again with bumped RC number."
-    echo "Commands:"
-    echo "   git checkout maint-${version}"
-    echo "   dev/release/01-prepare.sh ${version} ${next_version} ${next_rc_number}"
-    exit 1
-fi
+    header "Updating changelog for ${RELEASE}"
+    # Update changelog
+    # XXX: commitizen doesn't respect --tag-format with --incremental, so mimic
+    # it by hand.
+    (
+        echo ;
+        # Strip trailing blank line
+        printf '%s\n' "$(cz ch --dry-run --unreleased-version "ADBC Libraries ${RELEASE}" --start-rev apache-arrow-adbc-${PREVIOUS_RELEASE})"
+    ) >> ${SOURCE_DIR}/../../CHANGELOG.md
+    git add ${SOURCE_DIR}/../../CHANGELOG.md
+    git commit -m "chore: update CHANGELOG.md for ${RELEASE}"
 
-############################## Pre-Tag Commits ##############################
+    header "Prepare release ${RELEASE} on tag ${release_candidate_tag}"
 
-echo "Updating changelog for $version"
-# Update changelog
-# XXX: commitizen doesn't respect --tag-format with --incremental, so mimic
-# it by hand.
-(
-    echo ;
-    # Strip trailing blank line
-    printf '%s\n' "$(cz ch --dry-run --unreleased-version "ADBC Libraries ${version}" --start-rev apache-arrow-adbc-${prev_version})"
-) >> ${SOURCE_DIR}/../../CHANGELOG.md
-git add ${SOURCE_DIR}/../../CHANGELOG.md
-git commit -m "chore: update CHANGELOG.md for $version"
+    update_versions "release"
+    # --allow-empty required for RCs after the first
+    git commit -m "chore: update versions for ${RELEASE}" --allow-empty
 
-echo "Prepare release ${version} on tag ${release_candidate_tag}"
+    ######################### Tag the Release Candidate #########################
 
-update_versions "${version}" "${next_version}" "release"
-# --allow-empty required for RCs after the first
-git commit -m "chore: update versions for ${version}" --allow-empty
+    header "Tag the release candidate ${release_candidate_tag}"
 
-######################### Tag the Release Candidate #########################
+    git tag -a "${release_candidate_tag}" -m "ADBC Libraries ${RELEASE} RC ${rc_number}"
 
-git tag -a "${release_candidate_tag}" -m "ADBC Libraries ${version} RC ${rc_number}"
+    echo "Created release candidate tag: ${release_candidate_tag}"
+    echo "Push this tag before continuing!"
+}
 
-echo "Created release candidate tag: ${release_candidate_tag}"
-echo "Push this tag before continuing!"
+main "$@"

--- a/dev/release/01-prepare.sh
+++ b/dev/release/01-prepare.sh
@@ -42,7 +42,7 @@ main() {
         echo "1. Create or checkout maint-<version>."
         echo "2. Execute the script again with bumped RC number."
         echo "Commands:"
-        echo "   git checkout maint-${version}"
+        echo "   git checkout maint-${RELEASE}"
         echo "   dev/release/01-prepare.sh ${arrow_dir} ${next_rc_number}"
         exit 1
     fi

--- a/dev/release/03-source.sh
+++ b/dev/release/03-source.sh
@@ -18,27 +18,19 @@
 
 set -eu
 
-main() {
-    local -r source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    local -r source_top_dir="$( cd "${source_dir}/../../" && pwd )"
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SOURCE_DIR}/utils-common.sh"
+source "${SOURCE_DIR}/utils-prepare.sh"
 
-    if [ "$#" -ne 2 ]; then
-        echo "Usage: $0 <version> <rc-num>"
+main() {
+    if [ "$#" -ne 1 ]; then
+        echo "Usage: $0 <rc-num>"
         exit 1
     fi
-    local -r version="$1"
-    local -r rc_number="$2"
-    local -r tag="apache-arrow-adbc-${version}-rc${rc_number}"
-    local -r tarball="apache-arrow-adbc-${version}.tar.gz"
 
-    : ${REPOSITORY:="apache/arrow-adbc"}
-
-    if [[ ! -f "${source_dir}/.env" ]]; then
-        echo "You must create ${source_dir}/.env"
-        echo "You can use ${source_dir}/.env.example as a template"
-    fi
-
-    source "${source_dir}/.env"
+    local -r rc_number="$1"
+    local -r tag="apache-arrow-adbc-${RELEASE}-rc${rc_number}"
+    local -r tarball="apache-arrow-adbc-${RELEASE}.tar.gz"
 
     header "Downloading assets from release"
     local -r download_dir="packages/${tag}"
@@ -63,18 +55,16 @@ main() {
 
     # commit to svn
     svn add "tmp/${tag}"
-    svn ci -m "Apache Arrow ADBC ${version} RC${rc_number}" "tmp/${tag}"
+    if [[ "${DRY_RUN}" = 0 ]]; then
+        svn ci -m "Apache Arrow ADBC ${version} RC${rc_number}" "tmp/${tag}"
+    else
+        echo "Dry run: not committing to dist.apache.org"
+    fi
 
     # clean up
     rm -rf tmp
 
     echo "Uploaded at https://dist.apache.org/repos/dist/dev/arrow/${tag}"
-}
-
-header() {
-    echo "============================================================"
-    echo "${1}"
-    echo "============================================================"
 }
 
 main "$@"

--- a/dev/release/03-source.sh
+++ b/dev/release/03-source.sh
@@ -56,7 +56,7 @@ main() {
     # commit to svn
     svn add "tmp/${tag}"
     if [[ ${DRY_RUN} -eq 0 ]]; then
-        svn ci -m "Apache Arrow ADBC ${version} RC${rc_number}" "tmp/${tag}"
+        svn ci -m "Apache Arrow ADBC ${RELEASE} RC${rc_number}" "tmp/${tag}"
     else
         echo "Dry run: not committing to dist.apache.org"
     fi

--- a/dev/release/03-source.sh
+++ b/dev/release/03-source.sh
@@ -55,7 +55,7 @@ main() {
 
     # commit to svn
     svn add "tmp/${tag}"
-    if [[ "${DRY_RUN}" = 0 ]]; then
+    if [[ ${DRY_RUN} -eq 0 ]]; then
         svn ci -m "Apache Arrow ADBC ${version} RC${rc_number}" "tmp/${tag}"
     else
         echo "Dry run: not committing to dist.apache.org"

--- a/dev/release/04-java-upload.sh
+++ b/dev/release/04-java-upload.sh
@@ -21,22 +21,20 @@ set -e
 set -u
 set -o pipefail
 
-main() {
-    local -r source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    local -r source_top_dir="$(cd "${source_dir}/../../" && pwd)"
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SOURCE_DIR}/utils-common.sh"
+source "${SOURCE_DIR}/utils-prepare.sh"
 
-    if [ $# -ne 3 ]; then
-        echo "Usage: $0 <arrow-dir> <version> <rc-number>"
-        echo "Usage: $0 ../arrow 1.0.0 0"
+main() {
+    if [ $# -ne 2 ]; then
+        echo "Usage: $0 <arrow-dir> <rc-number>"
+        echo "Usage: $0 ../arrow 0"
         exit
     fi
 
     local -r arrow_dir="$(cd "$1" && pwd)"
-    local -r version="$2"
-    local -r rc_number="$3"
-    local -r tag="apache-arrow-adbc-${version}-rc${rc_number}"
-
-    : ${REPOSITORY:="apache/arrow-adbc"}
+    local -r rc_number="$2"
+    local -r tag="apache-arrow-adbc-${RELEASE}-rc${rc_number}"
 
     export ARROW_ARTIFACTS_DIR="$(pwd)/packages/${tag}/java"
     rm -rf "${ARROW_ARTIFACTS_DIR}"
@@ -51,7 +49,7 @@ main() {
        "${tag}"
 
     export UPLOAD_FORCE_SIGN=0
-    "${arrow_dir}/dev/release/06-java-upload.sh" "${version}" "${rc_number}"
+    "${arrow_dir}/dev/release/06-java-upload.sh" "${RELEASE}" "${rc_number}"
 }
 
 main "$@"

--- a/dev/release/05-linux-upload.sh
+++ b/dev/release/05-linux-upload.sh
@@ -21,22 +21,20 @@ set -e
 set -u
 set -o pipefail
 
-main() {
-    local -r source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    local -r source_top_dir="$(cd "${source_dir}/../../" && pwd)"
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SOURCE_DIR}/utils-common.sh"
+source "${SOURCE_DIR}/utils-prepare.sh"
 
-    if [ $# -ne 3 ]; then
-        echo "Usage: $0 <arrow-dir> <version> <rc-number>"
-        echo "Usage: $0 ../arrow 1.0.0 0"
+main() {
+    if [ $# -ne 2 ]; then
+        echo "Usage: $0 <arrow-dir> <rc-number>"
+        echo "Usage: $0 ../arrow 0"
         exit
     fi
 
     local -r arrow_dir="$(cd "$1" && pwd)"
-    local -r version="$2"
-    local -r rc_number="$3"
-    local -r tag="apache-arrow-adbc-${version}-rc${rc_number}"
-
-    : ${REPOSITORY:="apache/arrow-adbc"}
+    local -r rc_number="$2"
+    local -r tag="apache-arrow-adbc-${RELEASE}-rc${rc_number}"
 
     export ARROW_ARTIFACTS_DIR="$(pwd)/packages/${tag}/linux"
     rm -rf "${ARROW_ARTIFACTS_DIR}"
@@ -67,7 +65,7 @@ main() {
     export UPLOAD_ALMALINUX=${UPLOAD_ALMALINUX:-1}
     export UPLOAD_DEBIAN=${UPLOAD_DEBIAN:-1}
     export UPLOAD_UBUNTU=${UPLOAD_UBUNTU:-1}
-    "${arrow_dir}/dev/release/05-binary-upload.sh" "${version}" "${rc_number}"
+    "${arrow_dir}/dev/release/05-binary-upload.sh" "${RELEASE}" "${rc_number}"
 }
 
 main "$@"

--- a/dev/release/06-binary-verify.sh
+++ b/dev/release/06-binary-verify.sh
@@ -18,27 +18,27 @@
 
 set -euo pipefail
 
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SOURCE_DIR}/utils-common.sh"
+source "${SOURCE_DIR}/utils-prepare.sh"
+
 main() {
-    local -r source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    local -r source_top_dir="$( cd "${source_dir}/../../" && pwd )"
+    if [ $# -ne 1 ]; then
+        echo "Usage: $0 <rc-number>"
+        echo "Usage: $0 0"
+        exit
+    fi
 
-    local -r version="$1"
-    local -r rc_number="$2"
-    local -r tag="apache-arrow-adbc-${version}-rc${rc_number}"
+    local -r rc_number="$1"
+    local -r tag="apache-arrow-adbc-${RELEASE}-rc${rc_number}"
 
-    : ${WORKFLOW_REF:="main"}
-    : ${REPOSITORY:="apache/arrow-adbc"}
-
-    export SOURCE_DIR="${source_dir}"
-    source "${source_top_dir}/dev/release/utils-prepare.sh"
-
-    echo "Starting GitHub Actions workflow on ${REPOSITORY} for ${version} RC${rc_number}"
+    echo "Starting GitHub Actions workflow on ${REPOSITORY} for ${RELEASE} RC${rc_number}"
 
     gh workflow run \
        --repo "${REPOSITORY}" \
        --ref "${WORKFLOW_REF}" \
        verify.yml \
-       --raw-field version="${version}" \
+       --raw-field version="${RELEASE}" \
        --raw-field rc="${rc_number}"
 
     local run_id=""
@@ -56,7 +56,7 @@ main() {
     echo "Started GitHub Actions workflow with ID: ${run_id}"
     echo "You can wait for completion via: gh run watch --repo ${REPOSITORY} ${run_id}"
 
-    set_resolved_issues "${version}"
+    set_resolved_issues "${RELEASE}"
 
     echo "The following draft email has been created to send to the"
     echo "dev@arrow.apache.org mailing list"
@@ -67,7 +67,7 @@ main() {
 
     cat <<MAIL
 To: dev@arrow.apache.org
-Subject: [VOTE] Release Apache Arrow ADBC ${version} - RC${rc_number}
+Subject: [VOTE] Release Apache Arrow ADBC ${RELEASE} - RC${rc_number}
 
 Hello,
 
@@ -91,7 +91,7 @@ The vote will be open for at least 72 hours.
 
 Note: to verify APT/YUM packages on macOS/AArch64, you must \`export DOCKER_DEFAULT_PLATFORM=linux/amd64\`. (Or skip this step by \`export TEST_APT=0 TEST_YUM=0\`.)
 
-[1]: https://github.com/apache/arrow-adbc/issues?q=is%3Aissue+milestone%3A%22ADBC+Libraries+${version}%22+is%3Aclosed
+[1]: https://github.com/apache/arrow-adbc/issues?q=is%3Aissue+milestone%3A%22ADBC+Libraries+${RELEASE}%22+is%3Aclosed
 [2]: https://github.com/apache/arrow-adbc/commit/${commit}
 [3]: https://dist.apache.org/repos/dist/dev/arrow/${tag}/
 [4]: https://apache.jfrog.io/artifactory/arrow/almalinux-rc/

--- a/dev/release/06-binary-verify.sh
+++ b/dev/release/06-binary-verify.sh
@@ -73,7 +73,7 @@ Hello,
 
 I would like to propose the following release candidate (RC${rc_number}) of Apache Arrow ADBC version ${RELEASE}. This is a release consisting of ${RESOLVED_ISSUES} resolved GitHub issues [1].
 
-The version numbers of subcomponents are:
+The subcomponents are versioned independently:
 
 - C/C++/GLib/Go/Python/Ruby: ${VERSION_NATIVE}
 - C#: ${VERSION_CSHARP}
@@ -93,9 +93,9 @@ See also a verification result on GitHub Actions [11].
 
 The vote will be open for at least 72 hours.
 
-[ ] +1 Release this as Apache Arrow ADBC ${version}
+[ ] +1 Release this as Apache Arrow ADBC ${RELEASE}
 [ ] +0
-[ ] -1 Do not release this as Apache Arrow ADBC ${version} because...
+[ ] -1 Do not release this as Apache Arrow ADBC ${RELEASE} because...
 
 Note: to verify APT/YUM packages on macOS/AArch64, you must \`export DOCKER_DEFAULT_PLATFORM=linux/amd64\`. (Or skip this step by \`export TEST_APT=0 TEST_YUM=0\`.)
 

--- a/dev/release/06-binary-verify.sh
+++ b/dev/release/06-binary-verify.sh
@@ -71,7 +71,15 @@ Subject: [VOTE] Release Apache Arrow ADBC ${RELEASE} - RC${rc_number}
 
 Hello,
 
-I would like to propose the following release candidate (RC${rc_number}) of Apache Arrow ADBC version ${version}. This is a release consisting of ${RESOLVED_ISSUES} resolved GitHub issues [1].
+I would like to propose the following release candidate (RC${rc_number}) of Apache Arrow ADBC version ${RELEASE}. This is a release consisting of ${RESOLVED_ISSUES} resolved GitHub issues [1].
+
+The version numbers of subcomponents are:
+
+- C/C++/GLib/Go/Python/Ruby: ${VERSION_NATIVE}
+- C#: ${VERSION_CSHARP}
+- Java: ${VERSION_JAVA}
+- R: ${VERSION_R}
+- Rust: ${VERSION_RUST}
 
 This release candidate is based on commit: ${commit} [2]
 

--- a/dev/release/post-01-upload.sh
+++ b/dev/release/post-01-upload.sh
@@ -18,30 +18,33 @@
 
 set -eu
 
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SOURCE_DIR}/utils-common.sh"
+source "${SOURCE_DIR}/utils-prepare.sh"
+
 main() {
-    if [ "$#" -ne 2 ]; then
-        echo "Usage: $0 <version> <rc-num>"
+    if [ "$#" -ne 1 ]; then
+        echo "Usage: $0 <rc-num>"
         exit 1
     fi
-    local -r version="$1"
-    local -r rc_number="$2"
-    local -r tag="apache-arrow-adbc-${version}-rc${rc_number}"
+    local -r rc_number="$1"
+    local -r tag="apache-arrow-adbc-${RELEASE}-rc${rc_number}"
 
-    rc_id="apache-arrow-adbc-${version}-rc${rc_number}"
-    release_id="apache-arrow-adbc-${version}"
+    rc_id="apache-arrow-adbc-${RELEASE}-rc${rc_number}"
+    release_id="apache-arrow-adbc-${RELEASE}"
     echo "Copying dev/ to release/"
     svn \
         cp \
-        -m "Apache Arrow ADBC ${version}" \
+        -m "Apache Arrow ADBC ${RELEASE}" \
         https://dist.apache.org/repos/dist/dev/arrow/${rc_id} \
         https://dist.apache.org/repos/dist/release/arrow/${release_id}
 
     echo "Create final tag"
-    git tag -a "apache-arrow-adbc-${version}" -m "ADBC Libraries ${version}" "${tag}^{}"
+    git tag -a "apache-arrow-adbc-${RELEASE}" -m "ADBC Libraries ${RELEASE}" "${tag}^{}"
 
     echo "Success! The release is available here:"
     echo "  https://dist.apache.org/repos/dist/release/arrow/${release_id}"
-    echo "Please push the tag apache-arrow-adbc-${version}!"
+    echo "Please push the tag apache-arrow-adbc-${RELEASE}!"
 }
 
 main "$@"

--- a/dev/release/post-02-binary.sh
+++ b/dev/release/post-02-binary.sh
@@ -21,36 +21,27 @@ set -e
 set -u
 set -o pipefail
 
-main() {
-    local -r source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    local -r source_top_dir="$( cd "${source_dir}/../../" && pwd )"
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SOURCE_DIR}/utils-common.sh"
+source "${SOURCE_DIR}/utils-prepare.sh"
 
-    if [ "$#" -ne 2 ]; then
-        echo "Usage: $0 <version> <rc-num>"
+main() {
+    if [ "$#" -ne 1 ]; then
+        echo "Usage: $0 <rc-num>"
         exit 1
     fi
+    local -r rc_number="$1"
+    local -r tag="apache-arrow-adbc-${RELEASE}-rc${rc_number}"
 
-    local -r version="$1"
-    local -r rc_number="$2"
-    local -r tag="apache-arrow-adbc-${version}-rc${rc_number}"
-
-    : ${REPOSITORY:="apache/arrow-adbc"}
-
-    header "Publishing release ${version}"
+    header "Publishing release ${RELEASE}"
 
     gh release edit \
        --verify-tag \
        --repo "${REPOSITORY}" \
        "${tag}" \
-       --title="ADBC Libraries ${version}" \
+       --title="ADBC Libraries ${RELEASE}" \
        --prerelease=false \
-       --tag="apache-arrow-adbc-${version}"
-}
-
-header() {
-    echo "============================================================"
-    echo "${1}"
-    echo "============================================================"
+       --tag="apache-arrow-adbc-${RELEASE}"
 }
 
 main "$@"

--- a/dev/release/post-03-python.sh
+++ b/dev/release/post-03-python.sh
@@ -21,24 +21,21 @@ set -e
 set -u
 set -o pipefail
 
-main() {
-    local -r source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    local -r source_top_dir="$( cd "${source_dir}/../../" && pwd )"
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SOURCE_DIR}/utils-common.sh"
+source "${SOURCE_DIR}/utils-prepare.sh"
 
-    if [ "$#" -ne 2 ]; then
-        echo "Usage: $0 <version> <rc-num>"
+main() {
+    if [ "$#" -ne 1 ]; then
+        echo "Usage: $0 <rc-num>"
         exit 1
     fi
-
-    local -r version="$1"
-    local -r rc_number="$2"
-    local -r tag="apache-arrow-adbc-${version}"
-
-    : ${REPOSITORY:="apache/arrow-adbc"}
+    local -r rc_number="$1"
+    local -r tag="apache-arrow-adbc-${RELEASE}-rc${rc_number}"
 
     local -r tmp=$(mktemp -d -t "arrow-post-python.XXXXX")
 
-    header "Downloading Python packages for ${version}"
+    header "Downloading Python packages for ${RELEASE}"
 
     gh release download \
        --repo "${REPOSITORY}" \
@@ -47,7 +44,7 @@ main() {
        --pattern "*.whl" \
        --pattern "adbc_*.tar.gz" # sdist
 
-    header "Uploading Python packages for ${version}"
+    header "Uploading Python packages for ${RELEASE}"
 
     TWINE_ARGS=""
     if [ "${TEST_PYPI:-0}" -gt 0 ]; then
@@ -60,12 +57,6 @@ main() {
     rm -rf "${tmp}"
 
     echo "Success!"
-}
-
-header() {
-    echo "============================================================"
-    echo "${1}"
-    echo "============================================================"
 }
 
 main "$@"

--- a/dev/release/post-04-go.sh
+++ b/dev/release/post-04-go.sh
@@ -16,19 +16,30 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-set -ue
+
+set -e
+set -u
+set -o pipefail
 
 SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SOURCE_DIR}/utils-common.sh"
+source "${SOURCE_DIR}/utils-prepare.sh"
 
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <version>"
-    exit
-fi
+main() {
+    if [ "$#" -ne 0 ]; then
+        echo "Usage: $0"
+        exit 1
+    fi
 
-version=$1
-version_tag="apache-arrow-adbc-${version}"
-go_arrow_tag="go/adbc/v${version}"
+    header "Tagging Go release ${RELEASE}"
 
-git tag "${go_arrow_tag}" "${version_tag}"
-git push apache "${go_arrow_tag}"
+    version_tag="apache-arrow-adbc-${VERSION_NATIVE}"
+    go_arrow_tag="go/adbc/v${VERSION_NATIVE}"
+
+    git tag "${go_arrow_tag}" "${version_tag}"
+    echo "Created tag ${go_arrow_tag}"
+    echo "Please verify and push the tag:"
+    echo git push apache "${go_arrow_tag}"
+}
+
+main "$@"

--- a/dev/release/post-06-ruby.sh
+++ b/dev/release/post-06-ruby.sh
@@ -21,24 +21,24 @@ set -e
 set -u
 set -o pipefail
 
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SOURCE_DIR}/utils-common.sh"
+source "${SOURCE_DIR}/utils-prepare.sh"
+
 main() {
-    if [ "$#" -ne 1 ]; then
-        echo "Usage: $0 <version>"
-        echo "Usage: $0 1.0.0"
+    if [ "$#" -ne 0 ]; then
+        echo "Usage: $0"
         exit 1
     fi
 
-    local -r version="$1"
-
-    archive_name=apache-arrow-adbc-${version}
-
-    tar_gz=${archive_name}.tar.gz
+    local -r archive_name=apache-arrow-adbc-${RELEASE}
+    local -r tar_gz=${archive_name}.tar.gz
 
     rm -f ${tar_gz}
     curl \
       --remote-name \
       --fail \
-      https://downloads.apache.org/arrow/apache-arrow-adbc-${version}/${tar_gz}
+      https://downloads.apache.org/arrow/apache-arrow-adbc-${RELEASE}/${tar_gz}
     rm -rf ${archive_name}
     tar xf ${tar_gz}
 
@@ -53,7 +53,7 @@ main() {
     rm -f ${tar_gz}
 
     echo "Success! The released RubyGems are available here:"
-    echo "  https://rubygems.org/gems/red-adbc/versions/${version}"
+    echo "  https://rubygems.org/gems/red-adbc/versions/${VERSION_NATIVE}"
 }
 
 main "$@"

--- a/dev/release/post-07-csharp.sh
+++ b/dev/release/post-07-csharp.sh
@@ -24,24 +24,21 @@ set -u
 set -o pipefail
 
 main() {
-  if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <version>"
+  if [ "$#" -ne 0 ]; then
+    echo "Usage: $0"
     exit
   fi
 
-  local -r version="$1"
-  local -r tag="apache-arrow-adbc-${version}"
+  local -r tag="apache-arrow-adbc-${RELEASE}"
 
   if [ -z "${NUGET_API_KEY}" ]; then
     echo "NUGET_API_KEY is empty"
     exit 1
   fi
 
-  : ${REPOSITORY:="apache/arrow-adbc"}
-
   local -r tmp=$(mktemp -d -t "arrow-post-csharp.XXXXX")
 
-  header "Downloading C# packages for ${version}"
+  header "Downloading C# packages for ${VERSION_CSHARP}"
 
   gh release download \
      --repo "${REPOSITORY}" \
@@ -51,11 +48,11 @@ main() {
      --pattern "*.snupkg"
 
   local base_names=()
-  base_names+=(Apache.Arrow.Adbc.${version})
-  base_names+=(Apache.Arrow.Adbc.Client.${version})
-  base_names+=(Apache.Arrow.Adbc.Drivers.BigQuery.${version})
-  base_names+=(Apache.Arrow.Adbc.Drivers.FlightSql.${version})
-  base_names+=(Apache.Arrow.Adbc.Drivers.Interop.Snowflake.${version})
+  base_names+=(Apache.Arrow.Adbc.${VERSION_CSHARP})
+  base_names+=(Apache.Arrow.Adbc.Client.${VERSION_CSHARP})
+  base_names+=(Apache.Arrow.Adbc.Drivers.BigQuery.${VERSION_CSHARP})
+  base_names+=(Apache.Arrow.Adbc.Drivers.FlightSql.${VERSION_CSHARP})
+  base_names+=(Apache.Arrow.Adbc.Drivers.Interop.Snowflake.${VERSION_CSHARP})
   for base_name in "${base_names[@]}"; do
     dotnet nuget push \
       "${tmp}/${base_name}.nupkg" \
@@ -66,13 +63,7 @@ main() {
   rm -rf "${tmp}"
 
   echo "Success! The released NuGet package is available here:"
-  echo "  https://www.nuget.org/packages/Apache.Arrow.Adbc/${version}"
-}
-
-header() {
-    echo "============================================================"
-    echo "${1}"
-    echo "============================================================"
+  echo "  https://www.nuget.org/packages/Apache.Arrow.Adbc/${VERSION_CSHARP}"
 }
 
 main "$@"

--- a/dev/release/post-10-website.sh
+++ b/dev/release/post-10-website.sh
@@ -18,35 +18,31 @@
 
 set -eu
 
+SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SOURCE_DIR}/utils-common.sh"
+source "${SOURCE_DIR}/utils-prepare.sh"
+
 main() {
-    if [ "$#" -ne 3 ]; then
-        echo "Usage: $0 <arrow-site-checkout> <previous-version> <version>"
+    if [ "$#" -ne 1 ]; then
+        echo "Usage: $0 <arrow-site-checkout>"
         exit 1
     fi
     local -r arrow_site="$1"
-    local -r prev_version="$2"
-    local -r version="$3"
-
-    local -r source_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    local -r source_top_dir="$( cd "${source_dir}/../../" && pwd )"
-
-    export SOURCE_DIR="${source_dir}"
-    source "${source_top_dir}/dev/release/utils-prepare.sh"
 
     # Extract ADBC spec version from Doxygen macro in header.
-    local -r spec_version=$(grep '[\]version' "${source_top_dir}/adbc.h" | awk '{print $NF}')
+    local -r spec_version=$(grep '[\]version' "${SOURCE_TOP_DIR}/adbc.h" | awk '{print $NF}')
     local -r date=${POST_DATE:-$(date "+%Y-%m-%d")}
-    local -r filename="${arrow_site}/_posts/${date}-adbc-${version}-release.md"
-    local -r contributor_command="git shortlog --perl-regexp --author='^((?!dependabot\[bot\]).*)$' -sn apache-arrow-adbc-${prev_version}..apache-arrow-adbc-${version}"
+    local -r filename="${arrow_site}/_posts/${date}-adbc-${RELEASE}-release.md"
+    local -r contributor_command="git shortlog --perl-regexp --author='^((?!dependabot\[bot\]).*)$' -sn apache-arrow-adbc-${PREVIOUS_RELEASE}..apache-arrow-adbc-${RELEASE}"
     local -r contributor_list=$(eval "${contributor_command}")
     local -r contributors=$(echo "${contributor_list}" | wc -l)
 
-    set_resolved_issues "${version}"
+    set_resolved_issues "${RELEASE}"
 
     cat <<EOF | tee "${filename}"
 ---
 layout: post
-title: "Apache Arrow ADBC ${version} (Libraries) Release"
+title: "Apache Arrow ADBC ${RELEASE} (Libraries) Release"
 date: "${date} 00:00:00"
 author: pmc
 categories: [release]
@@ -70,13 +66,21 @@ limitations under the License.
 {% endcomment %}
 -->
 
-The Apache Arrow team is pleased to announce the ${version} release of
+The Apache Arrow team is pleased to announce the ${RELEASE} release of
 the Apache Arrow ADBC libraries. This covers includes [**${RESOLVED_ISSUES}
 resolved issues**][1] from [**${contributors} distinct contributors**][2].
 
 This is a release of the **libraries**, which are at version
-${version}.  The **API specification** is versioned separately and is
+${RELEASE}.  The **API specification** is versioned separately and is
 at version ${spec_version}.
+
+The subcomponents are versioned independently:
+
+- C/C++/GLib/Go/Python/Ruby: ${VERSION_NATIVE}
+- C#: ${VERSION_CSHARP}
+- Java: ${VERSION_JAVA}
+- R: ${VERSION_R}
+- Rust: ${VERSION_RUST}
 
 The release notes below are not exhaustive and only expose selected
 highlights of the release. Many other bugfixes and improvements have

--- a/dev/release/utils-common.sh
+++ b/dev/release/utils-common.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,31 +16,26 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
-set -o pipefail
+: ${DRY_RUN:=0}
+: ${REPOSITORY:="apache/arrow-adbc"}
+: ${WORKFLOW_REF:="main"}
 
-SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "${SOURCE_DIR}/utils-common.sh"
-source "${SOURCE_DIR}/utils-prepare.sh"
+SOURCE_TOP_DIR="$( cd "${SOURCE_DIR}/../../" && pwd )"
 
-main() {
-    if [ "$#" -ne 2 ]; then
-        echo "Usage: $0 <arrow-dir> <rc-num>"
-        echo "Usage: $0 ../arrow 0"
-        exit 1
-    fi
+if [[ ! -f "${SOURCE_DIR}/.env" ]]; then
+    echo "You must create ${SOURCE_DIR}/.env"
+    echo "You can use ${SOURCE_DIR}/.env.example as a template"
+fi
 
-    local -r arrow_dir="$(cd "$1" && pwd)"
-    local -r rc_number="$2"
+source "${SOURCE_DIR}/.env"
 
-    header "Deploying APT/Yum repositories ${RELEASE}"
-
-    export DEPLOY_DEFAULT=0
-    export DEPLOY_ALMALINUX=${DEPLOY_ALMALINUX:-1}
-    export DEPLOY_DEBIAN=${DEPLOY_DEBIAN:-1}
-    export DEPLOY_UBUNTU=${DEPLOY_UBUNTU:-1}
-    "${arrow_dir}/dev/release/post-02-binary.sh" "${RELEASE}" "${rc_number}"
+header() {
+    echo "============================================================"
+    echo "${1}"
+    echo "============================================================"
 }
 
-main "$@"
+header "Config"
+
+echo "Repository: ${REPOSITORY}"
+echo "Source Directory: ${SOURCE_TOP_DIR}"

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -50,7 +50,7 @@ update_versions() {
   esac
 
   header "Updating versions for release ${RELEASE}"
-  echo "CMake: ${cmake_version}"
+  echo "C: ${c_version}"
   echo "Conda: ${conda_version}"
   echo "C#: ${csharp_version}"
   echo "Docs: ${docs_version}"

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -118,8 +118,8 @@ update_versions() {
   else
     so_version() {
       local -r version=$1
-      local -r major_version=$(echo $linux_version | sed -E -e 's/^([0-9]+)\.[0-9]+\.[0-9]+$/\1/')
-      local -r minor_version=$(echo $linux_version | sed -E -e 's/^[0-9]+\.([0-9]+)\.[0-9]+$/\1/')
+      local -r major_version=$(echo $c_version | sed -E -e 's/^([0-9]+)\.[0-9]+\.[0-9]+$/\1/')
+      local -r minor_version=$(echo $c_version | sed -E -e 's/^[0-9]+\.([0-9]+)\.[0-9]+$/\1/')
       printf "%0d%02d" ${major_version} ${minor_version}
     }
     local -r deb_lib_suffix=$(so_version ${base_version})

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -23,6 +23,7 @@ update_versions() {
 
   local conda_version="${VERSION_NATIVE}"
   local csharp_version="${VERSION_CSHARP}"
+  local linux_version="${RELEASE}"
   local rust_version="${VERSION_CSHARP}"
   case ${type} in
     release)
@@ -30,7 +31,6 @@ update_versions() {
       local docs_version="${RELEASE}"
       local glib_version="${VERSION_NATIVE}"
       local java_version="${VERSION_JAVA}"
-      local linux_version="${VERSION_NATIVE}"
       local py_version="${VERSION_NATIVE}"
       local r_version="${VERSION_R}"
       ;;
@@ -39,7 +39,6 @@ update_versions() {
       local docs_version="${RELEASE} (dev)"
       local glib_version="${VERSION_NATIVE}-SNAPSHOT"
       local java_version="${VERSION_JAVA}-SNAPSHOT"
-      local linux_version="${VERSION_NATIVE}-SNAPSHOT"
       local py_version="${VERSION_NATIVE}dev"
       local r_version="${VERSION_R}.9000"
       ;;

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -26,7 +26,7 @@ update_versions() {
   local rust_version="${VERSION_CSHARP}"
   case ${type} in
     release)
-      local cmake_version="${VERSION_NATIVE}"
+      local c_version="${VERSION_NATIVE}"
       local docs_version="${RELEASE}"
       local glib_version="${VERSION_NATIVE}"
       local java_version="${VERSION_JAVA}"
@@ -35,7 +35,7 @@ update_versions() {
       local r_version="${VERSION_R}"
       ;;
     snapshot)
-      local cmake_version="${VERSION_NATIVE}-SNAPSHOT"
+      local c_version="${VERSION_NATIVE}-SNAPSHOT"
       local docs_version="${RELEASE} (dev)"
       local glib_version="${VERSION_NATIVE}-SNAPSHOT"
       local java_version="${VERSION_JAVA}-SNAPSHOT"
@@ -62,7 +62,7 @@ update_versions() {
   echo "Rust: ${rust_version}"
 
   pushd "${ADBC_DIR}/c/"
-  sed -i.bak -E "s/set\(ADBC_VERSION \".+\"\)/set(ADBC_VERSION \"${cmake_version}\")/g" cmake_modules/AdbcVersion.cmake
+  sed -i.bak -E "s/set\(ADBC_VERSION \".+\"\)/set(ADBC_VERSION \"${c_version}\")/g" cmake_modules/AdbcVersion.cmake
   rm cmake_modules/AdbcVersion.cmake.bak
   git add cmake_modules/AdbcVersion.cmake
   popd

--- a/dev/release/versions.env
+++ b/dev/release/versions.env
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# The release as a whole has a counter-based identifier (as in, 12.0.0 is the
+# The release as a whole has a counter-based identifier (as in, 12 is the
 # 12th release of ADBC).  This is used to identify tags, branches, and so on.
-RELEASE="12.0.0"
+RELEASE="12"
 PREVIOUS_RELEASE="0.11.0"
 
 # Individual components will have a SemVer.

--- a/dev/release/versions.env
+++ b/dev/release/versions.env
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,31 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-set -u
-set -o pipefail
+# The release as a whole has a date-based identifier.  This is used to
+# identify tags, branches, and so on.
+RELEASE="2024.05"
+PREVIOUS_RELEASE="0.11.0"
 
-SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "${SOURCE_DIR}/utils-common.sh"
-source "${SOURCE_DIR}/utils-prepare.sh"
-
-main() {
-    if [ "$#" -ne 2 ]; then
-        echo "Usage: $0 <arrow-dir> <rc-num>"
-        echo "Usage: $0 ../arrow 0"
-        exit 1
-    fi
-
-    local -r arrow_dir="$(cd "$1" && pwd)"
-    local -r rc_number="$2"
-
-    header "Deploying APT/Yum repositories ${RELEASE}"
-
-    export DEPLOY_DEFAULT=0
-    export DEPLOY_ALMALINUX=${DEPLOY_ALMALINUX:-1}
-    export DEPLOY_DEBIAN=${DEPLOY_DEBIAN:-1}
-    export DEPLOY_UBUNTU=${DEPLOY_UBUNTU:-1}
-    "${arrow_dir}/dev/release/post-02-binary.sh" "${RELEASE}" "${rc_number}"
-}
-
-main "$@"
+# Individual components will have a SemVer.
+VERSION_CSHARP="0.12.0"
+VERSION_JAVA="0.12.0"
+# Because C++/Go/Python are effectively tied at the hip, they share a single
+# version number. Also covers Conda/Linux packages.
+VERSION_NATIVE="1.0.0"
+VERSION_R="0.12.0"
+VERSION_RUST="0.12.0"

--- a/dev/release/versions.env
+++ b/dev/release/versions.env
@@ -17,7 +17,7 @@
 
 # The release as a whole has a date-based identifier.  This is used to
 # identify tags, branches, and so on.
-RELEASE="2024.05"
+RELEASE="2024.05.06"
 PREVIOUS_RELEASE="0.11.0"
 
 # Individual components will have a SemVer.

--- a/dev/release/versions.env
+++ b/dev/release/versions.env
@@ -15,16 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# The release as a whole has a date-based identifier.  This is used to
-# identify tags, branches, and so on.
+# The release as a whole has a counter-based identifier (as in, 12.0.0 is the
+# 12th release of ADBC).  This is used to identify tags, branches, and so on.
 RELEASE="12.0.0"
 PREVIOUS_RELEASE="0.11.0"
 
 # Individual components will have a SemVer.
 VERSION_CSHARP="0.12.0"
 VERSION_JAVA="0.12.0"
-# Because C++/Go/Python are effectively tied at the hip, they share a single
-# version number. Also covers Conda/Linux packages.
+# Because C++/Glib/Go/Python/Ruby are effectively tied at the hip, they share
+# a single version number. Also covers Conda/Linux packages.
 VERSION_NATIVE="1.0.0"
 VERSION_R="0.12.0"
 VERSION_RUST="0.12.0"

--- a/dev/release/versions.env
+++ b/dev/release/versions.env
@@ -17,7 +17,7 @@
 
 # The release as a whole has a date-based identifier.  This is used to
 # identify tags, branches, and so on.
-RELEASE="2024.05.06"
+RELEASE="12.0.0"
 PREVIOUS_RELEASE="0.11.0"
 
 # Individual components will have a SemVer.

--- a/dev/release/versions.env
+++ b/dev/release/versions.env
@@ -23,7 +23,7 @@ PREVIOUS_RELEASE="0.11.0"
 # Individual components will have a SemVer.
 VERSION_CSHARP="0.12.0"
 VERSION_JAVA="0.12.0"
-# Because C++/Glib/Go/Python/Ruby are effectively tied at the hip, they share
+# Because C++/GLib/Go/Python/Ruby are effectively tied at the hip, they share
 # a single version number. Also covers Conda/Linux packages.
 VERSION_NATIVE="1.0.0"
 VERSION_R="0.12.0"


### PR DESCRIPTION
Start refactoring our release process so that we can theoretically handle different version numbers in different language subprojects.

Fixes #1490.