### PR TITLE
fix(go/adbc/driver/flightsql): should use `ctx.Err().Error()`

### DIFF
--- a/go/adbc/driver/flightsql/utils.go
+++ b/go/adbc/driver/flightsql/utils.go
@@ -144,9 +144,9 @@ func checkContext(maybeErr error, ctx context.Context) error {
 	if maybeErr != nil {
 		return maybeErr
 	} else if ctx.Err() == context.Canceled {
-		return adbc.Error{Msg: "Cancelled by request", Code: adbc.StatusCancelled}
+		return adbc.Error{Msg: ctx.Err().Error(), Code: adbc.StatusCancelled}
 	} else if ctx.Err() == context.DeadlineExceeded {
-		return adbc.Error{Msg: "Deadline exceeded", Code: adbc.StatusTimeout}
+		return adbc.Error{Msg: ctx.Err().Error(), Code: adbc.StatusTimeout}
 	}
 	return ctx.Err()
 }


### PR DESCRIPTION
As pointed out by @zeroshade [here](https://github.com/apache/arrow-adbc/pull/1722#discussion_r1572903343), this should be handled by doing `adbc.Error{Msg: ctx.Err(), Code:....}`.