### PR TITLE
feat(csharp): Implement remaining functions in 1.0 spec

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/AdbcStatement.cs
+++ b/csharp/src/Apache.Arrow.Adbc/AdbcStatement.cs
@@ -44,13 +44,27 @@ namespace Apache.Arrow.Adbc
         /// </summary>
         public virtual byte[] SubstraitPlan
         {
-            get { throw new NotImplementedException(); }
-            set { throw new NotImplementedException(); }
+            get { throw AdbcException.NotImplemented("Statement does not support SubstraitPlan"); }
+            set { throw AdbcException.NotImplemented("Statement does not support SubstraitPlan"); }
         }
 
+        /// <summary>
+        /// Binds this statement to a <see cref="RecordBatch"/> to provide parameter values or bulk data ingestion.
+        /// </summary>
+        /// <param name="batch">the RecordBatch to bind</param>
+        /// <param name="schema">the schema of the RecordBatch</param>
         public virtual void Bind(RecordBatch batch, Schema schema)
         {
             throw AdbcException.NotImplemented("Statement does not support Bind");
+        }
+
+        /// <summary>
+        /// Binds this statement to an <see cref="IArrowArrayStream"/> to provide parameter values or bulk data ingestion.
+        /// </summary>
+        /// <param name="stream"></param>
+        public virtual void BindStream(IArrowArrayStream stream)
+        {
+            throw AdbcException.NotImplemented("Statement does not support BindStream");
         }
 
         /// <summary>

--- a/csharp/src/Apache.Arrow.Adbc/Extensions/MarshalExtensions.cs
+++ b/csharp/src/Apache.Arrow.Adbc/Extensions/MarshalExtensions.cs
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-#if NETSTANDARD
-
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -25,6 +23,7 @@ namespace Apache.Arrow.Adbc.Extensions
 {
     public static class MarshalExtensions
     {
+#if NETSTANDARD
         public static unsafe string PtrToStringUTF8(IntPtr intPtr)
         {
             if (intPtr == IntPtr.Zero)
@@ -60,7 +59,7 @@ namespace Apache.Arrow.Adbc.Extensions
 
             int nb = Encoding.UTF8.GetMaxByteCount(s.Length);
 
-            IntPtr pMem = Marshal.AllocCoTaskMem(nb + 1);
+            IntPtr pMem = Marshal.AllocHGlobal(nb + 1);
 
             int nbWritten;
             byte* pbMem = (byte*)pMem;
@@ -74,7 +73,27 @@ namespace Apache.Arrow.Adbc.Extensions
 
             return pMem;
         }
+#else
+        public static IntPtr StringToCoTaskMemUTF8(string s)
+        {
+            return Marshal.StringToCoTaskMemUTF8(s);
+        }
+#endif
+
+        public static unsafe byte[] MarshalBuffer(void* ptr, int size)
+        {
+            if (ptr == null)
+            {
+                return null;
+            }
+
+            byte[] bytes = new byte[size];
+            fixed (byte* firstByte = bytes)
+            {
+                Buffer.MemoryCopy(ptr, firstByte, size, size);
+            }
+
+            return bytes;
+        }
     }
 }
-
-#endif

--- a/csharp/src/Apache.Arrow.Adbc/PartitionDescriptor.cs
+++ b/csharp/src/Apache.Arrow.Adbc/PartitionDescriptor.cs
@@ -32,6 +32,8 @@ namespace Apache.Arrow.Adbc
             _descriptor = descriptor;
         }
 
+        public ReadOnlySpan<byte> Descriptor => _descriptor;
+
         public override bool Equals(object obj)
         {
             PartitionDescriptor? other = obj as PartitionDescriptor?;


### PR DESCRIPTION
Implements the remaining functions in the 1.0 specification in the C interop layer.

Closes #1221