### PR TITLE
chore: wrap .env values in quotes to prevent parsing errors

### DIFF
--- a/.env
+++ b/.env
@@ -54,6 +54,6 @@ ADBC_JDBC_POSTGRESQL_URL=localhost:5432/postgres
 ADBC_JDBC_POSTGRESQL_USER=postgres
 ADBC_JDBC_POSTGRESQL_PASSWORD=password
 ADBC_JDBC_POSTGRESQL_DATABASE=postgres
-ADBC_POSTGRESQL_TEST_URI=postgresql://localhost:5432/postgres?user=postgres&password=password
+ADBC_POSTGRESQL_TEST_URI="postgresql://localhost:5432/postgres?user=postgres&password=password"
 ADBC_SQLITE_FLIGHTSQL_URI=grpc+tcp://localhost:8080
 ADBC_TEST_FLIGHTSQL_URI=grpc+tcp://localhost:41414


### PR DESCRIPTION
Enclose URL variables in `.env` with quotes to fix parsing errors caused by special characters like `&`.

Resolve #1778 