### PR TITLE
chore(ci/linux-packages): remove explicit arrow-glib-devel dependency

### DIFF
--- a/ci/linux-packages/yum/apache-arrow-adbc.spec.in
+++ b/ci/linux-packages/yum/apache-arrow-adbc.spec.in
@@ -319,7 +319,6 @@ Summary:	Libraries and header files for Apache Arrow GLib integration
 License:	Apache-2.0
 Requires:	%{name}-arrow-glib%{major_version}-libs = %{version}-%{release}
 Requires:	%{name}-glib-devel = %{version}-%{release}
-Requires:	arrow-glib-devel
 
 %description arrow-glib-devel
 Libraries and header files for Apache Arrow GLib integration


### PR DESCRIPTION
RPM generates dependencies automatically based on package contents such as `.pc`. Let's use it instead of specifying `arrow-glib-devel` explicitly by `Requires:`.

Fixes #1839.