### PR TITLE
fix(csharp/src/Apache.Arrow.Adbc/C): finalizer threw exception

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
+++ b/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
@@ -364,6 +364,15 @@ namespace Apache.Arrow.Adbc.C
                 }
             }
 
+            internal unsafe ref CAdbcDriver DriverUnsafe
+            {
+                get
+                {
+                    Debug.Assert(_references > 0);
+                    return ref _nativeDriver;
+                }
+            }
+
             internal ImportedAdbcDriver AddReference()
             {
                 Interlocked.Increment(ref _references);
@@ -541,7 +550,7 @@ namespace Apache.Arrow.Adbc.C
                         {
                             using (CallHelper caller = new CallHelper())
                             {
-                                caller.Call(_driver.Driver.DatabaseRelease, ref _nativeDatabase);
+                                caller.Call(_driver.DriverUnsafe.DatabaseRelease, ref _nativeDatabase);
                             }
                         }
                     }
@@ -819,7 +828,7 @@ namespace Apache.Arrow.Adbc.C
                         {
                             using (CallHelper caller = new CallHelper())
                             {
-                                caller.Call(_driver.Driver.ConnectionRelease, ref _nativeConnection);
+                                caller.Call(_driver.DriverUnsafe.ConnectionRelease, ref _nativeConnection);
                             }
                         }
                     }
@@ -1065,7 +1074,7 @@ namespace Apache.Arrow.Adbc.C
                         {
                             using (CallHelper caller = new CallHelper())
                             {
-                                caller.Call(_driver.Driver.StatementRelease, ref _nativeStatement);
+                                caller.Call(_driver.DriverUnsafe.StatementRelease, ref _nativeStatement);
                             }
                         }
                     }


### PR DESCRIPTION
Allow imported objects to access a disposed driver when they themselves are disposed, because finalization order is nondeterministic.

Closes #1817