### PR TITLE
chore(dev/release): pin 15.0.2 for now

### DIFF
--- a/ci/conda_env_glib.txt
+++ b/ci/conda_env_glib.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-arrow-c-glib
+arrow-c-glib=15.0.2
 glib
 gobject-introspection
 meson

--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -20,7 +20,7 @@ importlib-resources
 # nodejs is required by pyright
 nodejs >=13.0.0
 pandas
-pyarrow>=8.0.0
+pyarrow=15.0.2
 pyright
 pytest
 setuptools


### PR DESCRIPTION
Since (1) there is no arrow-c-glib for 16.0.0 yet and (2) for 16.0.0 we need to switch to pyarrow-all