### PR TITLE
fix(go/adbc/driver/snowflake): Records dropped on ingestion when empty batch is present

### DIFF
--- a/go/adbc/driver/snowflake/bulk_ingestion.go
+++ b/go/adbc/driver/snowflake/bulk_ingestion.go
@@ -342,7 +342,7 @@ func writeParquet(
 	defer pqWriter.Close()
 
 	for rec := range in {
-		err = pqWriter.Write(rec)
+		err = pqWriter.WriteBuffered(rec)
 		rec.Release()
 		if err != nil {
 			return err

--- a/go/adbc/driver/snowflake/driver_test.go
+++ b/go/adbc/driver/snowflake/driver_test.go
@@ -325,26 +325,26 @@ type SnowflakeTests struct {
 	stmt   adbc.Statement
 }
 
-func (s *SnowflakeTests) SetupTest() {
+func (suite *SnowflakeTests) SetupTest() {
 	var err error
-	s.driver = s.Quirks.SetupDriver(s.T())
-	s.db, err = s.driver.NewDatabase(s.Quirks.DatabaseOptions())
-	s.Require().NoError(err)
-	s.ctx = context.Background()
-	s.cnxn, err = s.db.Open(s.ctx)
-	s.Require().NoError(err)
-	s.stmt, err = s.cnxn.NewStatement()
-	s.Require().NoError(err)
+	suite.driver = suite.Quirks.SetupDriver(suite.T())
+	suite.db, err = suite.driver.NewDatabase(suite.Quirks.DatabaseOptions())
+	suite.Require().NoError(err)
+	suite.ctx = context.Background()
+	suite.cnxn, err = suite.db.Open(suite.ctx)
+	suite.Require().NoError(err)
+	suite.stmt, err = suite.cnxn.NewStatement()
+	suite.Require().NoError(err)
 }
 
-func (s *SnowflakeTests) TearDownTest() {
-	s.Require().NoError(s.stmt.Close())
-	s.Require().NoError(s.cnxn.Close())
-	s.Quirks.TearDownDriver(s.T(), s.driver)
-	s.cnxn = nil
-	s.NoError(s.db.Close())
-	s.db = nil
-	s.driver = nil
+func (suite *SnowflakeTests) TearDownTest() {
+	suite.Require().NoError(suite.stmt.Close())
+	suite.Require().NoError(suite.cnxn.Close())
+	suite.Quirks.TearDownDriver(suite.T(), suite.driver)
+	suite.cnxn = nil
+	suite.NoError(suite.db.Close())
+	suite.db = nil
+	suite.driver = nil
 }
 
 func (suite *SnowflakeTests) TestSqlIngestTimestamp() {

--- a/go/adbc/driver/snowflake/driver_test.go
+++ b/go/adbc/driver/snowflake/driver_test.go
@@ -327,19 +327,19 @@ type SnowflakeTests struct {
 
 func (suite *SnowflakeTests) SetupTest() {
 	var err error
+	suite.ctx = context.Background()
 	suite.driver = suite.Quirks.SetupDriver(suite.T())
 	suite.db, err = suite.driver.NewDatabase(suite.Quirks.DatabaseOptions())
-	suite.Require().NoError(err)
-	suite.ctx = context.Background()
+	suite.NoError(err)
 	suite.cnxn, err = suite.db.Open(suite.ctx)
-	suite.Require().NoError(err)
+	suite.NoError(err)
 	suite.stmt, err = suite.cnxn.NewStatement()
-	suite.Require().NoError(err)
+	suite.NoError(err)
 }
 
 func (suite *SnowflakeTests) TearDownTest() {
-	suite.Require().NoError(suite.stmt.Close())
-	suite.Require().NoError(suite.cnxn.Close())
+	suite.NoError(suite.stmt.Close())
+	suite.NoError(suite.cnxn.Close())
 	suite.Quirks.TearDownDriver(suite.T(), suite.driver)
 	suite.cnxn = nil
 	suite.NoError(suite.db.Close())

--- a/go/adbc/driver/snowflake/record_reader.go
+++ b/go/adbc/driver/snowflake/record_reader.go
@@ -123,6 +123,7 @@ func getTransformer(sc *arrow.Schema, ld gosnowflake.ArrowStreamLoader, useHighP
 								if err != nil {
 									return nil, err
 								}
+								defer result.Release()
 								return compute.CastArray(ctx, result, compute.UnsafeCastOptions(f.Type))
 							}
 						} else {

--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -20,7 +20,7 @@ module github.com/apache/arrow-adbc/go/adbc
 go 1.21
 
 require (
-	github.com/apache/arrow/go/v17 v17.0.0-20240503231747-7cd9c6fbd313
+	github.com/apache/arrow/go/v17 v17.0.0-20240520131450-cc3e2db30094
 	github.com/bluele/gcache v0.0.2
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
@@ -31,7 +31,7 @@ require (
 	golang.org/x/sync v0.7.0
 	golang.org/x/tools v0.21.0
 	google.golang.org/grpc v1.63.2
-	google.golang.org/protobuf v1.34.0
+	google.golang.org/protobuf v1.34.1
 )
 
 require (

--- a/go/adbc/go.sum
+++ b/go/adbc/go.sum
@@ -20,8 +20,8 @@ github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/apache/arrow/go/v15 v15.0.0 h1:1zZACWf85oEZY5/kd9dsQS7i+2G5zVQcbKTHgslqHNA=
 github.com/apache/arrow/go/v15 v15.0.0/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
-github.com/apache/arrow/go/v17 v17.0.0-20240503231747-7cd9c6fbd313 h1:wnD2WBKoiH6iuEuhg33RsaslZ6aqfrviadRza3bNJZ4=
-github.com/apache/arrow/go/v17 v17.0.0-20240503231747-7cd9c6fbd313/go.mod h1:jeCSgGamSUiG483VAAaKkPn5wa/dTCVrSmCzF6PUlEo=
+github.com/apache/arrow/go/v17 v17.0.0-20240520131450-cc3e2db30094 h1:DnkS2LPX69st/7BvQVwtGUcLR9RTkrVrdlYnMm89AxY=
+github.com/apache/arrow/go/v17 v17.0.0-20240520131450-cc3e2db30094/go.mod h1:GLRwak999pJQN7WbKiL5F6OOOq046IOQ/HduXhjTaUo=
 github.com/apache/thrift v0.20.0 h1:631+KvYbsBZxmuJjYwhezVsrfc/TbqtZV4QcxOX1fOI=
 github.com/apache/thrift v0.20.0/go.mod h1:hOk1BQqcp2OLzGsyVXdfMk7YFlMxK3aoEVhjD06QhB8=
 github.com/aws/aws-sdk-go-v2 v1.25.1 h1:P7hU6A5qEdmajGwvae/zDkOq+ULLC9tQBTwqqiwFGpI=
@@ -192,8 +192,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240227224415-6ceb2ff114de/go.mod h1:H4O17MA/PE9BsGx3w+a+W2VOLLD1Qf7oJneAoU6WktY=
 google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
 google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
-google.golang.org/protobuf v1.34.0 h1:Qo/qEd2RZPCf2nKuorzksSknv0d3ERwp1vFG38gSmH4=
-google.golang.org/protobuf v1.34.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
+google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=


### PR DESCRIPTION
Reproduces and fixes: #1847 

Parquet files with empty row groups are valid per the spec, but Snowflake does not currently handle them properly. To mitigate this we buffer writes to the parquet file so that a row group is not written until some amount of data has been received.

The CheckedAllocator was enabled for all tests as part of this fix, which detected a leak in the BufferWriter that was fixed in: [https://github.com/apache/arrow/pull/41698](https://github.com/apache/arrow/pull/41698).

There was an unrelated test failure that surfaced once the CheckedAllocator was enabled which had to do with casting decimals of certain precision. The fix is included in this PR as well.