### PR TITLE
fix(r): Fix _WIN32 define that should be _MSC_VER

### DIFF
--- a/adbc.h
+++ b/adbc.h
@@ -152,7 +152,7 @@ struct ArrowArrayStream {
 // Storage class macros for Windows
 // Allow overriding/aliasing with application-defined macros
 #if !defined(ADBC_EXPORT)
-#if defined(_WIN32)
+#if defined(_MSC_VER)
 #if defined(ADBC_EXPORTING)
 #define ADBC_EXPORT __declspec(dllexport)
 #else
@@ -160,7 +160,7 @@ struct ArrowArrayStream {
 #endif  // defined(ADBC_EXPORTING)
 #else
 #define ADBC_EXPORT
-#endif  // defined(_WIN32)
+#endif  // defined(_MSC_VER)
 #endif  // !defined(ADBC_EXPORT)
 
 /// \defgroup adbc-error-handling Error Handling

--- a/r/adbcdrivermanager/src/Makevars
+++ b/r/adbcdrivermanager/src/Makevars
@@ -16,4 +16,4 @@
 # under the License.
 
 CXX_STD = CXX17
-PKG_CPPFLAGS=-I../src -DADBC_EXPORT=""
+PKG_CPPFLAGS=-I../src

--- a/r/adbcflightsql/src/Makevars.in
+++ b/r/adbcflightsql/src/Makevars.in
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-PKG_CPPFLAGS=-I$(CURDIR)/src -DADBC_EXPORT=""
+PKG_CPPFLAGS=-I$(CURDIR)/src
 PKG_LIBS=-L$(CURDIR)/go -ladbc_driver_flightsql -lresolv @libs@
 
 CGO_CC = @cc@

--- a/r/adbcflightsql/src/Makevars.win
+++ b/r/adbcflightsql/src/Makevars.win
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-PKG_CPPFLAGS=-I$(CURDIR) -DADBC_EXPORT=""
+PKG_CPPFLAGS=-I$(CURDIR)
 PKG_LIBS=-L$(CURDIR)/go -ladbc_driver_flightsql
 
 CGO_CC = `"${R_HOME}/bin${R_ARCH_BIN}/R.exe" CMD config CC`

--- a/r/adbcpostgresql/src/Makevars.in
+++ b/r/adbcpostgresql/src/Makevars.in
@@ -16,7 +16,7 @@
 # under the License.
 
 CXX_STD = CXX17
-PKG_CPPFLAGS=-I../src -I../src/c/ -I../src/c/vendor/ -I../src/c/vendor/fmt/include/ @cppflags@ -DADBC_EXPORT="" -DFMT_HEADER_ONLY=1
+PKG_CPPFLAGS=-I../src -I../src/c/ -I../src/c/vendor/ -I../src/c/vendor/fmt/include/ @cppflags@ -DFMT_HEADER_ONLY=1
 PKG_LIBS=@libs@
 
 OBJECTS = init.o \

--- a/r/adbcpostgresql/src/Makevars.ucrt
+++ b/r/adbcpostgresql/src/Makevars.ucrt
@@ -16,7 +16,7 @@
 # under the License.
 
 CXX_STD = CXX17
-PKG_CPPFLAGS = -I../src -I../src/c/ -I../src/c/vendor/ -I../src/c/vendor/fmt/include/ -DADBC_EXPORT="" -D__USE_MINGW_ANSI_STDIO -DFMT_HEADER_ONLY=1
+PKG_CPPFLAGS = -I../src -I../src/c/ -I../src/c/vendor/ -I../src/c/vendor/fmt/include/ -D__USE_MINGW_ANSI_STDIO -DFMT_HEADER_ONLY=1
 
 PKG_LIBS = -lpq -lpgcommon -lpgport -lssl -lcrypto -lz -lsecur32 -lws2_32 -lwldap32 -lcrypt32
 

--- a/r/adbcpostgresql/src/Makevars.win
+++ b/r/adbcpostgresql/src/Makevars.win
@@ -18,7 +18,7 @@
 VERSION = 13.2.0
 RWINLIB = ../windows/libpq-$(VERSION)
 CXX_STD = CXX17
-PKG_CPPFLAGS = -I$(RWINLIB)/include -I../src -I../src/c/ -I../src/c/vendor/ -I../src/c/vendor/fmt/include/ -DADBC_EXPORT="" -D__USE_MINGW_ANSI_STDIO -DFMT_HEADER_ONLY=1
+PKG_CPPFLAGS = -I$(RWINLIB)/include -I../src -I../src/c/ -I../src/c/vendor/ -I../src/c/vendor/fmt/include/ -D__USE_MINGW_ANSI_STDIO -DFMT_HEADER_ONLY=1
 PKG_LIBS = -L$(RWINLIB)/lib${R_ARCH}${CRT} \
 	-lpq -lpgport -lpgcommon -lssl -lcrypto -lwsock32 -lsecur32 -lws2_32 -lgdi32 -lcrypt32 -lwldap32
 

--- a/r/adbcsnowflake/src/Makevars.in
+++ b/r/adbcsnowflake/src/Makevars.in
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-PKG_CPPFLAGS=-DADBC_EXPORT="" @cflags@
+PKG_CPPFLAGS=@cflags@
 PKG_LIBS=-L$(CURDIR)/go -ladbc_driver_snowflake @libs@
 
 CGO_CC = @cc@

--- a/r/adbcsqlite/src/Makevars.in
+++ b/r/adbcsqlite/src/Makevars.in
@@ -16,7 +16,7 @@
 # under the License.
 
 CXX_STD = CXX17
-PKG_CPPFLAGS=-I../src/ -I../src/c/ -I../src/c/vendor/ -I../src/c/vendor/fmt/include/ @cppflags@ -DADBC_EXPORT="" -DFMT_HEADER_ONLY=1 -D_LIBCPP_DISABLE_AVAILABILITY
+PKG_CPPFLAGS=-I../src/ -I../src/c/ -I../src/c/vendor/ -I../src/c/vendor/fmt/include/ @cppflags@ -DFMT_HEADER_ONLY=1 -D_LIBCPP_DISABLE_AVAILABILITY
 PKG_LIBS=@libs@
 
 OBJECTS = init.o \


### PR DESCRIPTION
I'd been using `-DADBC_EXPORT=""` to work around this in the R package: I think that the `_WIN32` guard in the ADBC header resulted in `__declspec(dllexport/import)` ending up in gcc on mys2 which resulted in a compiler error. I think that `_MSC_VER` is the right thing to check here but I am not all that familiar with the details of this works on Windows (although I am perhaps about to be: https://github.com/apache/arrow-nanoarrow/issues/495 ).