### PR TITLE
fix(csharp/src/Apache.Arrow.Adbc/C): do not set a default value for table types

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
+++ b/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
@@ -579,18 +579,20 @@ namespace Apache.Arrow.Adbc.C
 
             public unsafe override IArrowArrayStream GetObjects(GetObjectsDepth depth, string? catalogPattern, string? dbSchemaPattern, string? tableNamePattern, IReadOnlyList<string>? tableTypes, string? columnNamePattern)
             {
-                tableTypes = tableTypes ?? [];
                 byte** utf8TableTypes = null;
                 try
                 {
                     // need to terminate with a null entry per https://github.com/apache/arrow-adbc/blob/b97e22c4d6524b60bf261e1970155500645be510/adbc.h#L909-L911
-                    utf8TableTypes = (byte**)Marshal.AllocHGlobal(IntPtr.Size * (tableTypes.Count + 1));
-                    utf8TableTypes[tableTypes.Count] = null;
-
-                    for (int i = 0; i < tableTypes.Count; i++)
+                    if (tableTypes != null)
                     {
-                        string tableType = tableTypes[i];
-                        utf8TableTypes[i] = (byte*)MarshalExtensions.StringToCoTaskMemUTF8(tableType);
+                        utf8TableTypes = (byte**)Marshal.AllocHGlobal(IntPtr.Size * (tableTypes.Count + 1));
+                        utf8TableTypes[tableTypes.Count] = null;
+
+                        for (int i = 0; i < tableTypes.Count; i++)
+                        {
+                            string tableType = tableTypes[i];
+                            utf8TableTypes[i] = (byte*)MarshalExtensions.StringToCoTaskMemUTF8(tableType);
+                        }
                     }
 
                     using (Utf8Helper utf8Catalog = new Utf8Helper(catalogPattern))
@@ -614,10 +616,14 @@ namespace Apache.Arrow.Adbc.C
                 }
                 finally
                 {
-                    for (int i = 0; i < tableTypes.Count; i++)
+                    if (tableTypes != null)
                     {
-                        Marshal.FreeCoTaskMem((IntPtr)utf8TableTypes[i]);
+                        for (int i = 0; i < tableTypes.Count; i++)
+                        {
+                            Marshal.FreeCoTaskMem((IntPtr)utf8TableTypes[i]);
+                        }
                     }
+
                     Marshal.FreeHGlobal((IntPtr)utf8TableTypes);
                 }
             }

--- a/csharp/test/Apache.Arrow.Adbc.Tests/ImportedDuckDbTests.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/ImportedDuckDbTests.cs
@@ -69,6 +69,14 @@ namespace Apache.Arrow.Adbc.Tests
         }
 
         [Fact]
+        public void GetObjectsTest()
+        {
+            using var database = _duckDb.OpenDatabase("transactions.db");
+            using var connection = database.Connect(null);
+            connection.GetObjects(AdbcConnection.GetObjectsDepth.All, null, null, null, null, null);
+        }
+
+        [Fact]
         public void TransactionsTest()
         {
             using var database = _duckDb.OpenDatabase("transactions.db");


### PR DESCRIPTION
DuckDB throws an error if the tableTypes are set. This fix replaces setting the default values and leaving it as null.  