### PR TITLE
fix(csharp/src/Drivers/Interop/Snowflake): Swapping PreBuildEvent to DispatchToInnerBuilds

### DIFF
--- a/csharp/src/Drivers/Interop/Snowflake/Apache.Arrow.Adbc.Drivers.Interop.Snowflake.csproj
+++ b/csharp/src/Drivers/Interop/Snowflake/Apache.Arrow.Adbc.Drivers.Interop.Snowflake.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <!-- use Build-SnowflakeDriver.ps1 to build the dll -->
-  <Target Name="PreBuild_Win" BeforeTargets="PreBuildEvent" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+  <Target Name="PreBuild_Win" BeforeTargets="DispatchToInnerBuilds" Condition="$([MSBuild]::IsOSPlatform('Windows'))">
     <Exec Command="powershell -ExecutionPolicy Unrestricted -File $(ProjectDir)Build-SnowflakeDriver.ps1" />
   </Target>
 
   <!-- use copySnowflakeDriver.sh to move all the platform binaries when used in the pipeline -->
-  <Target Name="PreBuild_Linux" BeforeTargets="PreBuildEvent" Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+  <Target Name="PreBuild_Linux" BeforeTargets="DispatchToInnerBuilds" Condition="$([MSBuild]::IsOSPlatform('Linux'))">
     <Exec Command="bash $(ProjectDir)copySnowflakeDriver.sh" />
   </Target>
 


### PR DESCRIPTION
Swapping PreBuildEvent to DispatchToInnerBuilds which accomplishes the same for multiple frameworks.
This will ensure the Snowflake build scripts are run only once during a dotnet pack.