### PR TITLE
docs: clarify that PyArrow is required for DBAPI

### DIFF
--- a/ci/conda_env_docs.txt
+++ b/ci/conda_env_docs.txt
@@ -24,7 +24,8 @@ make
 nodejs
 numpydoc
 pytest
-sphinx>=5.0
+# XXX: we're stuck until we can get rid of Breathe
+sphinx=6.*
 sphinx-autobuild
 sphinx-copybutton
 sphinx-design

--- a/docs/source/driver/installation.rst
+++ b/docs/source/driver/installation.rst
@@ -128,6 +128,8 @@ Python
 
 Install the appropriate driver package.
 
+.. note:: To use the DBAPI interface, ``pyarrow`` is also required.
+
 For example, from PyPI:
 
 - ``pip install adbc-driver-flightsql``


### PR DESCRIPTION
Fixes #1908.