### PR TITLE
fix(go/adbc/pkg): guard against potential crash

### DIFF
--- a/go/adbc/pkg/_tmpl/driver.go.tmpl
+++ b/go/adbc/pkg/_tmpl/driver.go.tmpl
@@ -98,7 +98,7 @@ func setErrWithDetails(err *C.struct_AdbcError, adbcError adbc.Error) {
 		return
 	}
 
-	cErrPtr := C.malloc(C.sizeof_struct_{{.Prefix}}Error)
+	cErrPtr := C.calloc(C.sizeof_struct_{{.Prefix}}Error, C.size_t(1))
 	cErr := (*C.struct_{{.Prefix}}Error)(cErrPtr)
 	cErr.message = C.CString(adbcError.Msg)
 	err.message = cErr.message
@@ -209,7 +209,7 @@ func printLoggingHelp() {
 // handle.
 func createHandle(hndl cgo.Handle) unsafe.Pointer {
 	// uintptr_t* hptr = malloc(sizeof(uintptr_t));
-	hptr := (*C.uintptr_t)(C.malloc(C.sizeof_uintptr_t))
+	hptr := (*C.uintptr_t)(C.calloc(C.sizeof_uintptr_t, C.size_t(1)))
 	// *hptr = (uintptr)hndl;
 	*hptr = C.uintptr_t(uintptr(hndl))
 	return unsafe.Pointer(hptr)

--- a/go/adbc/pkg/flightsql/driver.go
+++ b/go/adbc/pkg/flightsql/driver.go
@@ -102,7 +102,7 @@ func setErrWithDetails(err *C.struct_AdbcError, adbcError adbc.Error) {
 		return
 	}
 
-	cErrPtr := C.malloc(C.sizeof_struct_FlightSQLError)
+	cErrPtr := C.calloc(C.sizeof_struct_FlightSQLError, C.size_t(1))
 	cErr := (*C.struct_FlightSQLError)(cErrPtr)
 	cErr.message = C.CString(adbcError.Msg)
 	err.message = cErr.message
@@ -212,7 +212,7 @@ func printLoggingHelp() {
 // handle.
 func createHandle(hndl cgo.Handle) unsafe.Pointer {
 	// uintptr_t* hptr = malloc(sizeof(uintptr_t));
-	hptr := (*C.uintptr_t)(C.malloc(C.sizeof_uintptr_t))
+	hptr := (*C.uintptr_t)(C.calloc(C.sizeof_uintptr_t, C.size_t(1)))
 	// *hptr = (uintptr)hndl;
 	*hptr = C.uintptr_t(uintptr(hndl))
 	return unsafe.Pointer(hptr)

--- a/go/adbc/pkg/flightsql/utils.h
+++ b/go/adbc/pkg/flightsql/utils.h
@@ -19,7 +19,7 @@
 
 // clang-format off
 //go:build driverlib
-//  clang-format on
+// clang-format on
 
 #pragma once
 

--- a/go/adbc/pkg/panicdummy/driver.go
+++ b/go/adbc/pkg/panicdummy/driver.go
@@ -102,7 +102,7 @@ func setErrWithDetails(err *C.struct_AdbcError, adbcError adbc.Error) {
 		return
 	}
 
-	cErrPtr := C.malloc(C.sizeof_struct_PanicDummyError)
+	cErrPtr := C.calloc(C.sizeof_struct_PanicDummyError, C.size_t(1))
 	cErr := (*C.struct_PanicDummyError)(cErrPtr)
 	cErr.message = C.CString(adbcError.Msg)
 	err.message = cErr.message
@@ -212,7 +212,7 @@ func printLoggingHelp() {
 // handle.
 func createHandle(hndl cgo.Handle) unsafe.Pointer {
 	// uintptr_t* hptr = malloc(sizeof(uintptr_t));
-	hptr := (*C.uintptr_t)(C.malloc(C.sizeof_uintptr_t))
+	hptr := (*C.uintptr_t)(C.calloc(C.sizeof_uintptr_t, C.size_t(1)))
 	// *hptr = (uintptr)hndl;
 	*hptr = C.uintptr_t(uintptr(hndl))
 	return unsafe.Pointer(hptr)

--- a/go/adbc/pkg/panicdummy/utils.h
+++ b/go/adbc/pkg/panicdummy/utils.h
@@ -19,7 +19,7 @@
 
 // clang-format off
 //go:build driverlib
-//  clang-format on
+// clang-format on
 
 #pragma once
 

--- a/go/adbc/pkg/snowflake/driver.go
+++ b/go/adbc/pkg/snowflake/driver.go
@@ -102,7 +102,7 @@ func setErrWithDetails(err *C.struct_AdbcError, adbcError adbc.Error) {
 		return
 	}
 
-	cErrPtr := C.malloc(C.sizeof_struct_SnowflakeError)
+	cErrPtr := C.calloc(C.sizeof_struct_SnowflakeError, C.size_t(1))
 	cErr := (*C.struct_SnowflakeError)(cErrPtr)
 	cErr.message = C.CString(adbcError.Msg)
 	err.message = cErr.message
@@ -212,7 +212,7 @@ func printLoggingHelp() {
 // handle.
 func createHandle(hndl cgo.Handle) unsafe.Pointer {
 	// uintptr_t* hptr = malloc(sizeof(uintptr_t));
-	hptr := (*C.uintptr_t)(C.malloc(C.sizeof_uintptr_t))
+	hptr := (*C.uintptr_t)(C.calloc(C.sizeof_uintptr_t, C.size_t(1)))
 	// *hptr = (uintptr)hndl;
 	*hptr = C.uintptr_t(uintptr(hndl))
 	return unsafe.Pointer(hptr)

--- a/go/adbc/pkg/snowflake/utils.h
+++ b/go/adbc/pkg/snowflake/utils.h
@@ -19,7 +19,7 @@
 
 // clang-format off
 //go:build driverlib
-//  clang-format on
+// clang-format on
 
 #pragma once
 


### PR DESCRIPTION
We think malloc'ing a C struct is one possible way the Go garbage collector may still be seeing invalid Go pointers.  See #1931.