### PR TITLE
fix(c/driver/sqlite): Make SQLite driver C99 compliant

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -23,6 +23,7 @@ include(BuildUtils)
 project(adbc
         VERSION "${ADBC_BASE_VERSION}"
         LANGUAGES C CXX)
+set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/c/driver/common/utils.c
+++ b/c/driver/common/utils.c
@@ -193,8 +193,10 @@ void AppendErrorDetail(struct AdbcError* error, const char* key, const uint8_t* 
     details->capacity = new_capacity;
   }
 
-  char* key_data = strdup(key);
+  char* key_data = malloc(strlen(key) + 1);
   if (!key_data) return;
+  memcpy(key_data, key, strlen(key) + 1);
+
   uint8_t* value_data = malloc(detail_length);
   if (!value_data) {
     free(key_data);

--- a/c/meson.build
+++ b/c/meson.build
@@ -23,11 +23,14 @@ project(
     meson_version: '>=1.3.0',
     default_options: [
         'buildtype=release',
-        'c_std=gnu99',  # TODO: gmtime_r is gnu99 - likely unintentional std
+        'c_std=c99',
         'warning_level=2',
         'cpp_std=c++17',
     ]
 )
+
+add_project_arguments('-Wno-int-conversion', '-Wno-unused-parameter', language: 'c')
+add_project_arguments('-Wno-unused-parameter', '-Wno-reorder', language: 'cpp')
 
 root_dir = include_directories('..')
 driver_dir = include_directories('driver')

--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -187,6 +187,10 @@ void StatementTest::TestSqlIngestNumericType(ArrowType type) {
     // values. Likely a bug on our side, but for now, avoid them.
     values.push_back(static_cast<CType>(-1.5));
     values.push_back(static_cast<CType>(1.5));
+  } else if (type == ArrowType::NANOARROW_TYPE_DATE32) {
+    // Windows does not seem to support negative date values
+    values.push_back(static_cast<CType>(0));
+    values.push_back(static_cast<CType>(42));
   } else {
     values.push_back(std::numeric_limits<CType>::lowest());
     values.push_back(std::numeric_limits<CType>::max());

--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -187,10 +187,6 @@ void StatementTest::TestSqlIngestNumericType(ArrowType type) {
     // values. Likely a bug on our side, but for now, avoid them.
     values.push_back(static_cast<CType>(-1.5));
     values.push_back(static_cast<CType>(1.5));
-  } else if (type == ArrowType::NANOARROW_TYPE_DATE32) {
-    // Windows does not seem to support negative date values
-    values.push_back(static_cast<CType>(0));
-    values.push_back(static_cast<CType>(42));
   } else {
     values.push_back(std::numeric_limits<CType>::lowest());
     values.push_back(std::numeric_limits<CType>::max());


### PR DESCRIPTION
closes https://github.com/apache/arrow-adbc/issues/1944

In its current state this fails cpplint, which (for arguably good reason) discourages use of gmtime in favor of gmtime_r. The macros are inspired by similar code in the vendored sqlite.c source however, so I think reasonably accommodate that concern. 

Not sure if its worth trying to work around that with cpplint or just disable it for C sources