### PR TITLE
fix(c/vendor/nanoarrow): Fix -Wreorder warning

### DIFF
--- a/.github/workflows/r-standard.yml
+++ b/.github/workflows/r-standard.yml
@@ -17,8 +17,7 @@
 
 name: R (standard)
 
-# Runs on PRs that touch the R packages and when pushing files the R
-# package uses to main.
+# Runs on PRs that touch the R packages directly
 on:
   pull_request:
     branches:

--- a/c/vendor/nanoarrow/nanoarrow.hpp
+++ b/c/vendor/nanoarrow/nanoarrow.hpp
@@ -826,7 +826,7 @@ class ViewArrayAsFixedSizeBytes {
 class ViewArrayStream {
  public:
   ViewArrayStream(ArrowArrayStream* stream, ArrowErrorCode* code, ArrowError* error)
-      : range_{Next{this, stream, UniqueArray()}}, error_{error}, code_{code} {}
+      : range_{Next{this, stream, UniqueArray()}}, code_{code}, error_{error} {}
 
   ViewArrayStream(ArrowArrayStream* stream, ArrowError* error)
       : ViewArrayStream{stream, &internal_code_, error} {}
@@ -864,8 +864,8 @@ class ViewArrayStream {
   };
 
   internal::InputRange<Next> range_;
-  ArrowError* error_;
   ArrowErrorCode* code_;
+  ArrowError* error_;
   ArrowError internal_error_ = {};
   ArrowErrorCode internal_code_;
   bool code_was_accessed_ = false;

--- a/c/vendor/nanoarrow/nanoarrow.hpp
+++ b/c/vendor/nanoarrow/nanoarrow.hpp
@@ -826,7 +826,7 @@ class ViewArrayAsFixedSizeBytes {
 class ViewArrayStream {
  public:
   ViewArrayStream(ArrowArrayStream* stream, ArrowErrorCode* code, ArrowError* error)
-      : range_{Next{this, stream, UniqueArray()}}, code_{code}, error_{error} {}
+      : range_{Next{this, stream, UniqueArray()}}, error_{error}, code_{code} {}
 
   ViewArrayStream(ArrowArrayStream* stream, ArrowError* error)
       : ViewArrayStream{stream, &internal_code_, error} {}


### PR DESCRIPTION
In some of the R packages we get:

```
* checking whether package 'adbcsqlite' can be installed ... [35s] WARNING
Found the following significant warnings:
  ../src/c/vendor/nanoarrow/nanoarrow.hpp:868:19: warning: 'nanoarrow::ViewArrayStream::code_' will be initialized after [-Wreorder]
  ../src/c/vendor/nanoarrow/nanoarrow.hpp:867:15: warning:   'ArrowError* nanoarrow::ViewArrayStream::error_' [-Wreorder]
  ../src/c/vendor/nanoarrow/nanoarrow.hpp:828:3: warning:   when initialized here [-Wreorder]
See 'D:/a/arrow-adbc/arrow-adbc/r/adbcsqlite/check/adbcsqlite.Rcheck/00install.out' for details.
```

https://github.com/apache/arrow-adbc/actions/runs/9788345921/job/27026279250?pr=1965#step:10:166

This has already been fixed upstream:

https://github.com/apache/arrow-nanoarrow/blob/c74bb37b990541c82305b000b516f922db74d1f9/src/nanoarrow/nanoarrow.hpp#L846

