### PR TITLE
fix(c/driver/postgresql): Fix compiler warning on gcc14

### DIFF
--- a/c/driver/postgresql/copy/writer.h
+++ b/c/driver/postgresql/copy/writer.h
@@ -214,7 +214,7 @@ class PostgresCopyIntervalFieldWriter : public PostgresCopyFieldWriter {
 template <enum ArrowType T>
 class PostgresCopyNumericFieldWriter : public PostgresCopyFieldWriter {
  public:
-  PostgresCopyNumericFieldWriter<T>(int32_t precision, int32_t scale)
+  PostgresCopyNumericFieldWriter(int32_t precision, int32_t scale)
       : precision_{precision}, scale_{scale} {}
 
   ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {


### PR DESCRIPTION
As identified by the CRAN checks:

```
Version: 0.12.0
Check: whether package can be installed
Result: WARN
  Found the following significant warnings:
    c/driver/postgresql/copy/writer.h:218:37: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
  See ‘/data/gannet/ripley/R/packages/tests-devel/adbcpostgresql.Rcheck/00install.out’ for details.
  * used C++ compiler: ‘g++-14 (GCC) 14.1.0’
```

https://cran.r-project.org/web/checks/check_results_adbcpostgresql.html