### PR TITLE
fix(docs): update broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ CMake or other build tool appropriately.  However, we primarily
 develop and support Conda users.
 
 [conda]: https://docs.conda.io/en/latest/
-[mambaforge]: https://mamba.readthedocs.io/en/latest/installation.html
+[mambaforge]: https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html
 
 ### Running Integration Tests
 


### PR DESCRIPTION
Fix broken link for Mambaforge installation in `CONTRIBUTING.md`.