### PR TITLE
fix(c/driver/postgresql): Ensure schema ordering is consisent and respects case sensitivity of table names

### DIFF
--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -1161,7 +1161,8 @@ AdbcStatusCode PostgresConnection::GetTableSchema(const char* catalog,
       "FROM pg_catalog.pg_class AS cls "
       "INNER JOIN pg_catalog.pg_attribute AS attr ON cls.oid = attr.attrelid "
       "INNER JOIN pg_catalog.pg_type AS typ ON attr.atttypid = typ.oid "
-      "WHERE attr.attnum >= 0 AND cls.oid = $1::regclass::oid";
+      "WHERE attr.attnum >= 0 AND cls.oid = $1::regclass::oid "
+      "ORDER BY attr.attnum";
 
   std::vector<std::string> params = {table_name_str};
 

--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -2065,15 +2065,15 @@ void StatementTest::TestSqlPrepareErrorParamCountMismatch() {
 void StatementTest::TestSqlQueryEmpty() {
   ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
 
-  ASSERT_THAT(quirks()->DropTable(&connection, "QUERYEMPTY", &error), IsOkStatus(&error));
+  ASSERT_THAT(quirks()->DropTable(&connection, "queryempty", &error), IsOkStatus(&error));
   ASSERT_THAT(
-      AdbcStatementSetSqlQuery(&statement, "CREATE TABLE QUERYEMPTY (FOO INT)", &error),
+      AdbcStatementSetSqlQuery(&statement, "CREATE TABLE queryempty (FOO INT)", &error),
       IsOkStatus(&error));
   ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
               IsOkStatus(&error));
 
   ASSERT_THAT(
-      AdbcStatementSetSqlQuery(&statement, "SELECT * FROM QUERYEMPTY WHERE 1=0", &error),
+      AdbcStatementSetSqlQuery(&statement, "SELECT * FROM queryempty WHERE 1=0", &error),
       IsOkStatus(&error));
   {
     StreamReader reader;


### PR DESCRIPTION
Fixes #2006.

I am not sure of the best way to test this...is there a reliable way to generate a schema whose columns will be out of order when queried in this way? Is case-sensitivity something that we should test across all backends or should this be a Postgres-specific test?