### PR TITLE
feat(c/driver/postgresql): Implement consuming a PGresult via the copy reader

### DIFF
--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -145,11 +145,11 @@ class PqGetObjectsHelper {
         params.push_back(db_schema_);
       }
 
-      auto result_helper = PqResultHelper{conn_, std::string(query.buffer), error_};
+      auto result_helper = PqResultHelper{conn_, std::string(query.buffer)};
       StringBuilderReset(&query);
 
-      RAISE_ADBC(result_helper.Prepare(params.size()));
-      RAISE_ADBC(result_helper.ExecutePrepared(params));
+      RAISE_ADBC(result_helper.Prepare(error_, params.size()));
+      RAISE_ADBC(result_helper.ExecutePrepared(error_, params));
 
       for (PqResultRow row : result_helper) {
         const char* schema_name = row[0].data;
@@ -187,12 +187,11 @@ class PqGetObjectsHelper {
       params.push_back(catalog_);
     }
 
-    PqResultHelper result_helper =
-        PqResultHelper{conn_, std::string(query.buffer), error_};
+    PqResultHelper result_helper = PqResultHelper{conn_, std::string(query.buffer)};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare(params.size()));
-    RAISE_ADBC(result_helper.ExecutePrepared(params));
+    RAISE_ADBC(result_helper.Prepare(error_, params.size()));
+    RAISE_ADBC(result_helper.ExecutePrepared(error_, params));
 
     for (PqResultRow row : result_helper) {
       const char* db_name = row[0].data;
@@ -279,11 +278,11 @@ class PqGetObjectsHelper {
       }
     }
 
-    auto result_helper = PqResultHelper{conn_, query.buffer, error_};
+    auto result_helper = PqResultHelper{conn_, query.buffer};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare(params.size()));
-    RAISE_ADBC(result_helper.ExecutePrepared(params));
+    RAISE_ADBC(result_helper.Prepare(error_, params.size()));
+    RAISE_ADBC(result_helper.ExecutePrepared(error_, params));
     for (PqResultRow row : result_helper) {
       const char* table_name = row[0].data;
       const char* table_type = row[1].data;
@@ -340,11 +339,11 @@ class PqGetObjectsHelper {
       params.push_back(std::string(column_name_));
     }
 
-    auto result_helper = PqResultHelper{conn_, query.buffer, error_};
+    auto result_helper = PqResultHelper{conn_, query.buffer};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare(params.size()));
-    RAISE_ADBC(result_helper.ExecutePrepared(params));
+    RAISE_ADBC(result_helper.Prepare(error_, params.size()));
+    RAISE_ADBC(result_helper.ExecutePrepared(error_, params));
 
     for (PqResultRow row : result_helper) {
       const char* column_name = row[0].data;
@@ -492,11 +491,11 @@ class PqGetObjectsHelper {
       params.push_back(std::string(column_name_));
     }
 
-    auto result_helper = PqResultHelper{conn_, query.buffer, error_};
+    auto result_helper = PqResultHelper{conn_, query.buffer};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare(params.size()));
-    RAISE_ADBC(result_helper.ExecutePrepared(params));
+    RAISE_ADBC(result_helper.Prepare(error_, params.size()));
+    RAISE_ADBC(result_helper.ExecutePrepared(error_, params));
 
     for (PqResultRow row : result_helper) {
       const char* constraint_name = row[0].data;
@@ -654,9 +653,9 @@ AdbcStatusCode PostgresConnection::PostgresConnectionGetInfoImpl(
         break;
       case ADBC_INFO_VENDOR_VERSION: {
         const char* stmt = "SHOW server_version_num";
-        auto result_helper = PqResultHelper{conn_, std::string(stmt), error};
-        RAISE_ADBC(result_helper.Prepare());
-        RAISE_ADBC(result_helper.ExecutePrepared());
+        auto result_helper = PqResultHelper{conn_, std::string(stmt)};
+        RAISE_ADBC(result_helper.Prepare(error));
+        RAISE_ADBC(result_helper.ExecutePrepared(error));
         auto it = result_helper.begin();
         if (it == result_helper.end()) {
           SetError(error, "[libpq] PostgreSQL returned no rows for '%s'", stmt);
@@ -759,9 +758,9 @@ AdbcStatusCode PostgresConnection::GetOption(const char* option, char* value,
   if (std::strcmp(option, ADBC_CONNECTION_OPTION_CURRENT_CATALOG) == 0) {
     output = PQdb(conn_);
   } else if (std::strcmp(option, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
-    PqResultHelper result_helper{conn_, "SELECT CURRENT_SCHEMA", error};
-    RAISE_ADBC(result_helper.Prepare());
-    RAISE_ADBC(result_helper.ExecutePrepared());
+    PqResultHelper result_helper{conn_, "SELECT CURRENT_SCHEMA"};
+    RAISE_ADBC(result_helper.Prepare(error));
+    RAISE_ADBC(result_helper.ExecutePrepared(error));
     auto it = result_helper.begin();
     if (it == result_helper.end()) {
       SetError(error, "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA'");
@@ -930,9 +929,10 @@ AdbcStatusCode PostgresConnectionGetStatisticsImpl(PGconn* conn, const char* db_
   std::string prev_table;
 
   {
-    PqResultHelper result_helper{conn, query, error};
-    RAISE_ADBC(result_helper.Prepare(2));
-    RAISE_ADBC(result_helper.ExecutePrepared({db_schema, table_name ? table_name : "%"}));
+    PqResultHelper result_helper{conn, query};
+    RAISE_ADBC(result_helper.Prepare(error, 2));
+    RAISE_ADBC(
+        result_helper.ExecutePrepared(error, {db_schema, table_name ? table_name : "%"}));
 
     for (PqResultRow row : result_helper) {
       auto reltuples = row[5].ParseDouble();
@@ -1164,10 +1164,10 @@ AdbcStatusCode PostgresConnection::GetTableSchema(const char* catalog,
 
   std::vector<std::string> params = {table_name_str};
 
-  PqResultHelper result_helper = PqResultHelper{conn_, std::string(query.c_str()), error};
+  PqResultHelper result_helper = PqResultHelper{conn_, std::string(query.c_str())};
 
-  RAISE_ADBC(result_helper.Prepare(params.size()));
-  auto result = result_helper.ExecutePrepared(params);
+  RAISE_ADBC(result_helper.Prepare(error, params.size()));
+  auto result = result_helper.ExecutePrepared(error, params);
   if (result != ADBC_STATUS_OK) {
     auto error_code = std::string(error->sqlstate, 5);
     if ((error_code == "42P01") || (error_code == "42602")) {
@@ -1334,10 +1334,9 @@ AdbcStatusCode PostgresConnection::SetOption(const char* key, const char* value,
     return ADBC_STATUS_OK;
   } else if (std::strcmp(key, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
     // PostgreSQL doesn't accept a parameter here
-    PqResultHelper result_helper{conn_, std::string("SET search_path TO ") + value,
-                                 error};
-    RAISE_ADBC(result_helper.Prepare());
-    RAISE_ADBC(result_helper.ExecutePrepared());
+    PqResultHelper result_helper{conn_, std::string("SET search_path TO ") + value};
+    RAISE_ADBC(result_helper.Prepare(error));
+    RAISE_ADBC(result_helper.ExecutePrepared(error));
     return ADBC_STATUS_OK;
   }
   SetError(error, "%s%s", "[libpq] Unknown option ", key);

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -148,8 +148,7 @@ class PqGetObjectsHelper {
       auto result_helper = PqResultHelper{conn_, std::string(query.buffer)};
       StringBuilderReset(&query);
 
-      RAISE_ADBC(result_helper.Prepare(error_, params.size()));
-      RAISE_ADBC(result_helper.ExecutePrepared(error_, params));
+      RAISE_ADBC(result_helper.Execute(error_, params));
 
       for (PqResultRow row : result_helper) {
         const char* schema_name = row[0].data;
@@ -190,8 +189,7 @@ class PqGetObjectsHelper {
     PqResultHelper result_helper = PqResultHelper{conn_, std::string(query.buffer)};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare(error_, params.size()));
-    RAISE_ADBC(result_helper.ExecutePrepared(error_, params));
+    RAISE_ADBC(result_helper.Execute(error_, params));
 
     for (PqResultRow row : result_helper) {
       const char* db_name = row[0].data;
@@ -281,8 +279,7 @@ class PqGetObjectsHelper {
     auto result_helper = PqResultHelper{conn_, query.buffer};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare(error_, params.size()));
-    RAISE_ADBC(result_helper.ExecutePrepared(error_, params));
+    RAISE_ADBC(result_helper.Execute(error_, params));
     for (PqResultRow row : result_helper) {
       const char* table_name = row[0].data;
       const char* table_type = row[1].data;
@@ -342,8 +339,7 @@ class PqGetObjectsHelper {
     auto result_helper = PqResultHelper{conn_, query.buffer};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare(error_, params.size()));
-    RAISE_ADBC(result_helper.ExecutePrepared(error_, params));
+    RAISE_ADBC(result_helper.Execute(error_, params));
 
     for (PqResultRow row : result_helper) {
       const char* column_name = row[0].data;
@@ -494,8 +490,7 @@ class PqGetObjectsHelper {
     auto result_helper = PqResultHelper{conn_, query.buffer};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare(error_, params.size()));
-    RAISE_ADBC(result_helper.ExecutePrepared(error_, params));
+    RAISE_ADBC(result_helper.Execute(error_, params));
 
     for (PqResultRow row : result_helper) {
       const char* constraint_name = row[0].data;
@@ -654,8 +649,7 @@ AdbcStatusCode PostgresConnection::PostgresConnectionGetInfoImpl(
       case ADBC_INFO_VENDOR_VERSION: {
         const char* stmt = "SHOW server_version_num";
         auto result_helper = PqResultHelper{conn_, std::string(stmt)};
-        RAISE_ADBC(result_helper.Prepare(error));
-        RAISE_ADBC(result_helper.ExecutePrepared(error));
+        RAISE_ADBC(result_helper.Execute(error));
         auto it = result_helper.begin();
         if (it == result_helper.end()) {
           SetError(error, "[libpq] PostgreSQL returned no rows for '%s'", stmt);
@@ -759,8 +753,7 @@ AdbcStatusCode PostgresConnection::GetOption(const char* option, char* value,
     output = PQdb(conn_);
   } else if (std::strcmp(option, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
     PqResultHelper result_helper{conn_, "SELECT CURRENT_SCHEMA"};
-    RAISE_ADBC(result_helper.Prepare(error));
-    RAISE_ADBC(result_helper.ExecutePrepared(error));
+    RAISE_ADBC(result_helper.Execute(error));
     auto it = result_helper.begin();
     if (it == result_helper.end()) {
       SetError(error, "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA'");
@@ -930,9 +923,7 @@ AdbcStatusCode PostgresConnectionGetStatisticsImpl(PGconn* conn, const char* db_
 
   {
     PqResultHelper result_helper{conn, query};
-    RAISE_ADBC(result_helper.Prepare(error, 2));
-    RAISE_ADBC(
-        result_helper.ExecutePrepared(error, {db_schema, table_name ? table_name : "%"}));
+    RAISE_ADBC(result_helper.Execute(error, {db_schema, table_name ? table_name : "%"}));
 
     for (PqResultRow row : result_helper) {
       auto reltuples = row[5].ParseDouble();
@@ -1166,8 +1157,7 @@ AdbcStatusCode PostgresConnection::GetTableSchema(const char* catalog,
 
   PqResultHelper result_helper = PqResultHelper{conn_, std::string(query.c_str())};
 
-  RAISE_ADBC(result_helper.Prepare(error, params.size()));
-  auto result = result_helper.ExecutePrepared(error, params);
+  auto result = result_helper.Execute(error, params);
   if (result != ADBC_STATUS_OK) {
     auto error_code = std::string(error->sqlstate, 5);
     if ((error_code == "42P01") || (error_code == "42602")) {
@@ -1335,8 +1325,7 @@ AdbcStatusCode PostgresConnection::SetOption(const char* key, const char* value,
   } else if (std::strcmp(key, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
     // PostgreSQL doesn't accept a parameter here
     PqResultHelper result_helper{conn_, std::string("SET search_path TO ") + value};
-    RAISE_ADBC(result_helper.Prepare(error));
-    RAISE_ADBC(result_helper.ExecutePrepared(error));
+    RAISE_ADBC(result_helper.Execute(error));
     return ADBC_STATUS_OK;
   }
   SetError(error, "%s%s", "[libpq] Unknown option ", key);

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -145,12 +145,11 @@ class PqGetObjectsHelper {
         params.push_back(db_schema_);
       }
 
-      auto result_helper =
-          PqResultHelper{conn_, std::string(query.buffer), params, error_};
+      auto result_helper = PqResultHelper{conn_, std::string(query.buffer), error_};
       StringBuilderReset(&query);
 
-      RAISE_ADBC(result_helper.Prepare());
-      RAISE_ADBC(result_helper.Execute());
+      RAISE_ADBC(result_helper.Prepare(params.size()));
+      RAISE_ADBC(result_helper.ExecutePrepared(params));
 
       for (PqResultRow row : result_helper) {
         const char* schema_name = row[0].data;
@@ -189,11 +188,11 @@ class PqGetObjectsHelper {
     }
 
     PqResultHelper result_helper =
-        PqResultHelper{conn_, std::string(query.buffer), params, error_};
+        PqResultHelper{conn_, std::string(query.buffer), error_};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare());
-    RAISE_ADBC(result_helper.Execute());
+    RAISE_ADBC(result_helper.Prepare(params.size()));
+    RAISE_ADBC(result_helper.ExecutePrepared(params));
 
     for (PqResultRow row : result_helper) {
       const char* db_name = row[0].data;
@@ -280,11 +279,11 @@ class PqGetObjectsHelper {
       }
     }
 
-    auto result_helper = PqResultHelper{conn_, query.buffer, params, error_};
+    auto result_helper = PqResultHelper{conn_, query.buffer, error_};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare());
-    RAISE_ADBC(result_helper.Execute());
+    RAISE_ADBC(result_helper.Prepare(params.size()));
+    RAISE_ADBC(result_helper.ExecutePrepared(params));
     for (PqResultRow row : result_helper) {
       const char* table_name = row[0].data;
       const char* table_type = row[1].data;
@@ -341,11 +340,11 @@ class PqGetObjectsHelper {
       params.push_back(std::string(column_name_));
     }
 
-    auto result_helper = PqResultHelper{conn_, query.buffer, params, error_};
+    auto result_helper = PqResultHelper{conn_, query.buffer, error_};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare());
-    RAISE_ADBC(result_helper.Execute());
+    RAISE_ADBC(result_helper.Prepare(params.size()));
+    RAISE_ADBC(result_helper.ExecutePrepared(params));
 
     for (PqResultRow row : result_helper) {
       const char* column_name = row[0].data;
@@ -493,11 +492,11 @@ class PqGetObjectsHelper {
       params.push_back(std::string(column_name_));
     }
 
-    auto result_helper = PqResultHelper{conn_, query.buffer, params, error_};
+    auto result_helper = PqResultHelper{conn_, query.buffer, error_};
     StringBuilderReset(&query);
 
-    RAISE_ADBC(result_helper.Prepare());
-    RAISE_ADBC(result_helper.Execute());
+    RAISE_ADBC(result_helper.Prepare(params.size()));
+    RAISE_ADBC(result_helper.ExecutePrepared(params));
 
     for (PqResultRow row : result_helper) {
       const char* constraint_name = row[0].data;
@@ -657,7 +656,7 @@ AdbcStatusCode PostgresConnection::PostgresConnectionGetInfoImpl(
         const char* stmt = "SHOW server_version_num";
         auto result_helper = PqResultHelper{conn_, std::string(stmt), error};
         RAISE_ADBC(result_helper.Prepare());
-        RAISE_ADBC(result_helper.Execute());
+        RAISE_ADBC(result_helper.ExecutePrepared());
         auto it = result_helper.begin();
         if (it == result_helper.end()) {
           SetError(error, "[libpq] PostgreSQL returned no rows for '%s'", stmt);
@@ -760,9 +759,9 @@ AdbcStatusCode PostgresConnection::GetOption(const char* option, char* value,
   if (std::strcmp(option, ADBC_CONNECTION_OPTION_CURRENT_CATALOG) == 0) {
     output = PQdb(conn_);
   } else if (std::strcmp(option, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
-    PqResultHelper result_helper{conn_, "SELECT CURRENT_SCHEMA", {}, error};
+    PqResultHelper result_helper{conn_, "SELECT CURRENT_SCHEMA", error};
     RAISE_ADBC(result_helper.Prepare());
-    RAISE_ADBC(result_helper.Execute());
+    RAISE_ADBC(result_helper.ExecutePrepared());
     auto it = result_helper.begin();
     if (it == result_helper.end()) {
       SetError(error, "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA'");
@@ -931,10 +930,9 @@ AdbcStatusCode PostgresConnectionGetStatisticsImpl(PGconn* conn, const char* db_
   std::string prev_table;
 
   {
-    PqResultHelper result_helper{
-        conn, query, {db_schema, table_name ? table_name : "%"}, error};
-    RAISE_ADBC(result_helper.Prepare());
-    RAISE_ADBC(result_helper.Execute());
+    PqResultHelper result_helper{conn, query, error};
+    RAISE_ADBC(result_helper.Prepare(2));
+    RAISE_ADBC(result_helper.ExecutePrepared({db_schema, table_name ? table_name : "%"}));
 
     for (PqResultRow row : result_helper) {
       auto reltuples = row[5].ParseDouble();
@@ -1166,11 +1164,10 @@ AdbcStatusCode PostgresConnection::GetTableSchema(const char* catalog,
 
   std::vector<std::string> params = {table_name_str};
 
-  PqResultHelper result_helper =
-      PqResultHelper{conn_, std::string(query.c_str()), params, error};
+  PqResultHelper result_helper = PqResultHelper{conn_, std::string(query.c_str()), error};
 
-  RAISE_ADBC(result_helper.Prepare());
-  auto result = result_helper.Execute();
+  RAISE_ADBC(result_helper.Prepare(params.size()));
+  auto result = result_helper.ExecutePrepared(params);
   if (result != ADBC_STATUS_OK) {
     auto error_code = std::string(error->sqlstate, 5);
     if ((error_code == "42P01") || (error_code == "42602")) {
@@ -1337,10 +1334,10 @@ AdbcStatusCode PostgresConnection::SetOption(const char* key, const char* value,
     return ADBC_STATUS_OK;
   } else if (std::strcmp(key, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
     // PostgreSQL doesn't accept a parameter here
-    PqResultHelper result_helper{
-        conn_, std::string("SET search_path TO ") + value, {}, error};
+    PqResultHelper result_helper{conn_, std::string("SET search_path TO ") + value,
+                                 error};
     RAISE_ADBC(result_helper.Prepare());
-    RAISE_ADBC(result_helper.Execute());
+    RAISE_ADBC(result_helper.ExecutePrepared());
     return ADBC_STATUS_OK;
   }
   SetError(error, "%s%s", "[libpq] Unknown option ", key);

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1247,7 +1247,7 @@ TEST_F(PostgresStatementTest, UpdateInExecuteQuery) {
     ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
                                           &reader.rows_affected, &error),
                 IsOkStatus(&error));
-    ASSERT_EQ(reader.rows_affected, -1);
+    ASSERT_EQ(reader.rows_affected, 2);
     ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
     ASSERT_NO_FATAL_FAILURE(reader.Next());
     ASSERT_EQ(reader.array->release, nullptr);

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1371,16 +1371,13 @@ TEST_F(PostgresStatementTest, AdbcErrorBackwardsCompatibility) {
 TEST_F(PostgresStatementTest, Cancel) {
   ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
 
-  for (const char* query : {
-           "DROP TABLE IF EXISTS test_cancel",
-           "CREATE TABLE test_cancel (ints INT)",
-           R"(INSERT INTO test_cancel (ints)
-              SELECT g :: INT FROM GENERATE_SERIES(1, 65536) temp(g))",
-       }) {
-    ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, query, &error), IsOkStatus(&error));
-    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
-                IsOkStatus(&error));
-  }
+  const char* query = R"(DROP TABLE IF EXISTS test_cancel;
+            CREATE TABLE test_cancel (ints INT);
+            INSERT INTO test_cancel (ints)
+            SELECT g :: INT FROM GENERATE_SERIES(1, 65536) temp(g);)";
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, query, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
+              IsOkStatus(&error));
 
   ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT * FROM test_cancel", &error),
               IsOkStatus(&error));

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1429,6 +1429,66 @@ TEST_F(PostgresStatementTest, MultipleStatementsSingleQuery) {
   ASSERT_EQ(reader.array->length, 3);
 }
 
+TEST_F(PostgresStatementTest, SetUseCopyFalse) {
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+
+  const char* query = R"(DROP TABLE IF EXISTS test_query_set_copy_false;
+            CREATE TABLE test_query_set_copy_false (ints INT);
+            INSERT INTO test_query_set_copy_false VALUES((1));
+            INSERT INTO test_query_set_copy_false VALUES((NULL));
+            INSERT INTO test_query_set_copy_false VALUES((3));)";
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, query, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
+              IsOkStatus(&error));
+
+  // Check option setting/getting
+  ASSERT_EQ(
+      adbc_validation::StatementGetOption(&statement, "adbc.postgresql.use_copy", &error),
+      "true");
+
+  ASSERT_THAT(AdbcStatementSetOption(&statement, "adbc.postgresql.use_copy",
+                                     "not true or false", &error),
+              IsStatus(ADBC_STATUS_INVALID_ARGUMENT));
+
+  ASSERT_THAT(AdbcStatementSetOption(&statement, "adbc.postgresql.use_copy",
+                                     ADBC_OPTION_VALUE_ENABLED, &error),
+              IsOkStatus(&error));
+  ASSERT_EQ(
+      adbc_validation::StatementGetOption(&statement, "adbc.postgresql.use_copy", &error),
+      "true");
+
+  ASSERT_THAT(AdbcStatementSetOption(&statement, "adbc.postgresql.use_copy",
+                                     ADBC_OPTION_VALUE_DISABLED, &error),
+              IsOkStatus(&error));
+  ASSERT_EQ(
+      adbc_validation::StatementGetOption(&statement, "adbc.postgresql.use_copy", &error),
+      "false");
+
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement,
+                                       "SELECT * FROM test_query_set_copy_false", &error),
+              IsOkStatus(&error));
+
+  adbc_validation::StreamReader reader;
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                        &reader.rows_affected, &error),
+              IsOkStatus(&error));
+
+  ASSERT_EQ(reader.rows_affected, 3);
+
+  reader.GetSchema();
+  ASSERT_EQ(reader.schema->n_children, 1);
+  ASSERT_STREQ(reader.schema->children[0]->format, "i");
+  ASSERT_STREQ(reader.schema->children[0]->name, "ints");
+
+  ASSERT_THAT(reader.MaybeNext(), adbc_validation::IsOkErrno());
+  ASSERT_EQ(reader.array->length, 3);
+  ASSERT_EQ(reader.array->n_children, 1);
+  ASSERT_EQ(reader.array->children[0]->null_count, 1);
+
+  ASSERT_THAT(reader.MaybeNext(), adbc_validation::IsOkErrno());
+  ASSERT_EQ(reader.array->release, nullptr);
+}
+
 struct TypeTestCase {
   std::string name;
   std::string sql_type;

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -17,6 +17,8 @@
 
 #include "result_helper.h"
 
+#include <memory>
+
 #include "copy/reader.h"
 #include "driver/common/utils.h"
 #include "error.h"

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -17,6 +17,7 @@
 
 #include "result_helper.h"
 
+#include "copy/reader.h"
 #include "driver/common/utils.h"
 #include "error.h"
 
@@ -44,15 +45,15 @@ AdbcStatusCode PqResultHelper::Prepare() {
   return ADBC_STATUS_OK;
 }
 
-AdbcStatusCode PqResultHelper::Execute() {
+AdbcStatusCode PqResultHelper::Execute(int output_format) {
   std::vector<const char*> param_c_strs;
 
   for (size_t index = 0; index < param_values_.size(); index++) {
     param_c_strs.push_back(param_values_[index].c_str());
   }
 
-  result_ =
-      PQexecPrepared(conn_, "", param_values_.size(), param_c_strs.data(), NULL, NULL, 0);
+  result_ = PQexecPrepared(conn_, "", param_values_.size(), param_c_strs.data(), NULL,
+                           NULL, output_format);
 
   ExecStatusType status = PQresultStatus(result_);
   if (status != PGRES_TUPLES_OK && status != PGRES_COMMAND_OK) {
@@ -60,6 +61,97 @@ AdbcStatusCode PqResultHelper::Execute() {
         SetError(error_, result_, "[libpq] Failed to execute query '%s': %s",
                  query_.c_str(), PQerrorMessage(conn_));
     return error;
+  }
+
+  return ADBC_STATUS_OK;
+}
+
+int PqResultArrayReader::GetSchema(struct ArrowSchema* out) {
+  ResetErrors();
+
+  if (schema_->release == nullptr) {
+    AdbcStatusCode status = Initialize();
+    if (status != ADBC_STATUS_OK) {
+      return EINVAL;
+    }
+  }
+
+  return ArrowSchemaDeepCopy(schema_.get(), out);
+}
+
+int PqResultArrayReader::GetNext(struct ArrowArray* out) {
+  ResetErrors();
+
+  if (schema_->release == nullptr) {
+    AdbcStatusCode status = Initialize();
+    if (status != ADBC_STATUS_OK) {
+      return EINVAL;
+    }
+  }
+
+  nanoarrow::UniqueArray tmp;
+  NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromSchema(tmp.get(), schema_.get(), &na_error_));
+  for (int i = 0; i < helper_.NumColumns(); i++) {
+    NANOARROW_RETURN_NOT_OK(field_readers_[i]->InitArray(tmp->children[i]));
+  }
+
+  // TODO: If we get an EOVERFLOW here (e.g., big string data), we
+  // would need to keep track of what row number we're on and start
+  // from there instead of begin() on the next call
+  struct ArrowBufferView item;
+  for (auto it = helper_.begin(); it != helper_.end(); it++) {
+    auto row = *it;
+    for (int i = 0; i < helper_.NumColumns(); i++) {
+      auto pg_item = row[i];
+      item.data.data = pg_item.data;
+      item.size_bytes = pg_item.len;
+      NANOARROW_RETURN_NOT_OK(
+          field_readers_[i]->Read(&item, item.size_bytes, tmp->children[i], &na_error_));
+    }
+  }
+
+  for (int i = 0; i < helper_.NumColumns(); i++) {
+    NANOARROW_RETURN_NOT_OK(field_readers_[i]->FinishArray(tmp->children[i], &na_error_));
+  }
+
+  NANOARROW_RETURN_NOT_OK(ArrowArrayFinishBuildingDefault(tmp.get(), &na_error_));
+
+  ArrowArrayMove(tmp.get(), out);
+  return NANOARROW_OK;
+}
+
+const char* PqResultArrayReader::GetLastError() {
+  if (error_.message != nullptr) {
+    return error_.message;
+  } else {
+    return na_error_.message;
+  }
+}
+
+AdbcStatusCode PqResultArrayReader::Initialize() {
+  RAISE_ADBC(helper_.Prepare());
+  RAISE_ADBC(helper_.Execute(1));
+
+  ArrowSchemaInit(schema_.get());
+  CHECK_NA_DETAIL(INTERNAL, ArrowSchemaSetTypeStruct(schema_.get(), helper_.NumColumns()),
+                  &na_error_, &error_);
+
+  for (int i = 0; i < helper_.NumColumns(); i++) {
+    PostgresType child_type;
+    CHECK_NA_DETAIL(INTERNAL,
+                    type_resolver_->Find(helper_.FieldType(i), &child_type, &na_error_),
+                    &na_error_, &error_);
+
+    std::unique_ptr<PostgresCopyFieldReader> child_reader;
+    CHECK_NA_DETAIL(
+        INTERNAL,
+        MakeCopyFieldReader(child_type, schema_->children[i], &child_reader, &na_error_),
+        &na_error_, &error_);
+
+    CHECK_NA_DETAIL(INTERNAL, child_reader->InitSchema(schema_->children[i]), &na_error_,
+                    &error_);
+
+    field_readers_.push_back(std::move(child_reader));
   }
 
   return ADBC_STATUS_OK;

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -289,7 +289,13 @@ int PqResultArrayReader::GetNext(struct ArrowArray* out) {
     for (int i = 0; i < helper_.NumColumns(); i++) {
       auto pg_item = row[i];
       item.data.data = pg_item.data;
-      item.size_bytes = pg_item.len;
+
+      if (pg_item.is_null) {
+        item.size_bytes = -1;
+      } else {
+        item.size_bytes = pg_item.len;
+      }
+
       NANOARROW_RETURN_NOT_OK(
           field_readers_[i]->Read(&item, item.size_bytes, tmp->children[i], &na_error_));
     }

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -275,9 +275,9 @@ int PqResultArrayReader::GetNext(struct ArrowArray* out) {
 
   nanoarrow::UniqueArray tmp;
   NANOARROW_RETURN_NOT_OK(ArrowArrayInitFromSchema(tmp.get(), schema_.get(), &na_error_));
+  NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(tmp.get()));
   for (int i = 0; i < helper_.NumColumns(); i++) {
     NANOARROW_RETURN_NOT_OK(field_readers_[i]->InitArray(tmp->children[i]));
-    NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(tmp.get()));
   }
 
   // TODO: If we get an EOVERFLOW here (e.g., big string data), we

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -339,6 +339,8 @@ AdbcStatusCode PqResultArrayReader::Initialize(struct AdbcError* error) {
                     &na_error_, error);
 
     CHECK_NA(INTERNAL, child_type.SetSchema(schema_->children[i]), error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetName(schema_->children[i], helper_.FieldName(i)),
+             error);
 
     std::unique_ptr<PostgresCopyFieldReader> child_reader;
     CHECK_NA_DETAIL(

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -253,7 +253,8 @@ int PqResultArrayReader::GetNext(struct ArrowArray* out) {
 
   // TODO: If we get an EOVERFLOW here (e.g., big string data), we
   // would need to keep track of what row number we're on and start
-  // from there instead of begin() on the next call
+  // from there instead of begin() on the next call. We could also
+  // respect the size hint here to chunk the batches.
   struct ArrowBufferView item;
   for (auto it = helper_.begin(); it != helper_.end(); it++) {
     auto row = *it;

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -76,20 +76,21 @@ class PqResultRow {
 // prior to iterating
 class PqResultHelper {
  public:
-  explicit PqResultHelper(PGconn* conn, std::string query, struct AdbcError* error)
-      : conn_(conn), query_(std::move(query)), error_(error) {}
+  enum class Format {
+    kText = 0,
+    kBinary = 1,
+  };
 
   explicit PqResultHelper(PGconn* conn, std::string query,
-                          std::vector<std::string> param_values, struct AdbcError* error)
-      : conn_(conn),
-        query_(std::move(query)),
-        param_values_(std::move(param_values)),
-        error_(error) {}
+                          struct AdbcError* error) : conn_(conn),
+      query_(std::move(query)), error_(error) {}
 
   ~PqResultHelper();
 
-  AdbcStatusCode Prepare();
-  AdbcStatusCode Execute(int output_format = 0);
+  void set_output_format(Format format) { format_ = format; }
+
+  AdbcStatusCode Prepare(int n_params = 0);
+  AdbcStatusCode ExecutePrepared(const std::vector<std::string>& params = {});
 
   int NumRows() const { return PQntuples(result_); }
 
@@ -132,7 +133,7 @@ class PqResultHelper {
   PGresult* result_ = nullptr;
   PGconn* conn_;
   std::string query_;
-  std::vector<std::string> param_values_;
+  Format format_ = Format::kText;
   struct AdbcError* error_;
 };
 

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -152,6 +152,11 @@ class PqResultHelper {
   Format param_format_ = Format::kText;
   Format output_format_ = Format::kText;
   struct AdbcError* error_;
+
+  void ClearResult() {
+    PQclear(result_);
+    result_ = nullptr;
+  }
 };
 
 class PqResultArrayReader {

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -96,11 +96,8 @@ class PqResultHelper {
   void set_output_format(Format format) { output_format_ = format; }
 
   AdbcStatusCode Prepare(struct AdbcError* error);
-  AdbcStatusCode Prepare(int n_params, struct AdbcError* error);
   AdbcStatusCode Prepare(const std::vector<Oid>& param_oids, struct AdbcError* error);
   AdbcStatusCode DescribePrepared(struct AdbcError* error);
-  AdbcStatusCode ExecutePrepared(struct AdbcError* error,
-                                 const std::vector<std::string>& params = {});
   AdbcStatusCode Execute(struct AdbcError* error,
                          const std::vector<std::string>& params = {},
                          PostgresType* param_types = nullptr);

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -163,6 +163,8 @@ class PqResultArrayReader {
   int GetNext(struct ArrowArray* out);
   const char* GetLastError();
 
+  AdbcStatusCode ToArrayStream(struct ArrowArrayStream* out, struct AdbcError* error);
+
   AdbcStatusCode Initialize(struct AdbcError* error);
 
  private:

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -92,10 +92,15 @@ class PqResultHelper {
   AdbcStatusCode Prepare(int n_params = 0, PostgresType* param_types = nullptr);
   AdbcStatusCode DescribePrepared();
   AdbcStatusCode ExecutePrepared(const std::vector<std::string>& params = {});
+  AdbcStatusCode Execute(const std::vector<std::string>& params = {},
+                         PostgresType* param_types = nullptr);
+  AdbcStatusCode ExecuteCopy();
   AdbcStatusCode ResolveParamTypes(PostgresTypeResolver& type_resolver,
                                    PostgresType* param_types);
   AdbcStatusCode ResolveOutputTypes(PostgresTypeResolver& type_resolver,
                                     PostgresType* result_types);
+
+  PGresult* ReleaseResult();
 
   int NumRows() const { return PQntuples(result_); }
 

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cassert>
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -86,7 +86,8 @@ class PqResultHelper {
 
   ~PqResultHelper();
 
-  void set_output_format(Format format) { format_ = format; }
+  void set_param_format(Format format) { param_format_ = format; }
+  void set_output_format(Format format) { output_format_ = format; }
 
   AdbcStatusCode Prepare(int n_params = 0);
   AdbcStatusCode DescribePrepared();
@@ -137,7 +138,8 @@ class PqResultHelper {
   PGresult* result_ = nullptr;
   PGconn* conn_;
   std::string query_;
-  Format format_ = Format::kText;
+  Format param_format_ = Format::kText;
+  Format output_format_ = Format::kText;
   struct AdbcError* error_;
 };
 

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -124,6 +124,9 @@ class PqResultHelper {
 
   int NumColumns() const { return PQnfields(result_); }
 
+  const char* FieldName(int column_number) const {
+    return PQfname(result_, column_number);
+  }
   Oid FieldType(int column_number) const { return PQftype(result_, column_number); }
 
   class iterator {

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -95,8 +95,9 @@ class PqResultHelper {
   void set_param_format(Format format) { param_format_ = format; }
   void set_output_format(Format format) { output_format_ = format; }
 
-  AdbcStatusCode Prepare(struct AdbcError* error, int n_params = 0,
-                         PostgresType* param_types = nullptr);
+  AdbcStatusCode Prepare(struct AdbcError* error);
+  AdbcStatusCode Prepare(int n_params, struct AdbcError* error);
+  AdbcStatusCode Prepare(const std::vector<Oid>& param_oids, struct AdbcError* error);
   AdbcStatusCode DescribePrepared(struct AdbcError* error);
   AdbcStatusCode ExecutePrepared(struct AdbcError* error,
                                  const std::vector<std::string>& params = {});
@@ -166,6 +167,9 @@ class PqResultHelper {
   std::string query_;
   Format param_format_ = Format::kText;
   Format output_format_ = Format::kText;
+
+  AdbcStatusCode PrepareInternal(int n_params, const Oid* param_oids,
+                                 struct AdbcError* error);
 };
 
 class PqResultArrayReader {

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -151,6 +151,8 @@ class PqResultArrayReader {
   int GetNext(struct ArrowArray* out);
   const char* GetLastError();
 
+  AdbcStatusCode Initialize(struct AdbcError* error);
+
  private:
   PqResultHelper helper_;
   std::shared_ptr<PostgresTypeResolver> type_resolver_;
@@ -158,8 +160,6 @@ class PqResultArrayReader {
   nanoarrow::UniqueSchema schema_;
   struct AdbcError error_;
   struct ArrowError na_error_;
-
-  AdbcStatusCode Initialize();
 
   void ResetErrors() {
     ArrowErrorInit(&na_error_);

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -89,10 +89,12 @@ class PqResultHelper {
   void set_output_format(Format format) { format_ = format; }
 
   AdbcStatusCode Prepare(int n_params = 0);
-  AdbcStatusCode DescribePrepared(PostgresTypeResolver& type_resolver,
-                                  PostgresType* result_types,
-                                  PostgresType* param_types);
+  AdbcStatusCode DescribePrepared();
   AdbcStatusCode ExecutePrepared(const std::vector<std::string>& params = {});
+  AdbcStatusCode ResolveParamTypes(PostgresTypeResolver& type_resolver,
+                                   PostgresType* param_types);
+  AdbcStatusCode ResolveOutputTypes(PostgresTypeResolver& type_resolver,
+                                    PostgresType* result_types);
 
   int NumRows() const { return PQntuples(result_); }
 

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -95,19 +95,19 @@ class PqResultHelper {
   void set_param_format(Format format) { param_format_ = format; }
   void set_output_format(Format format) { output_format_ = format; }
 
-  AdbcStatusCode Prepare(struct AdbcError* error, int n_params = 0, PostgresType* param_types = nullptr);
+  AdbcStatusCode Prepare(struct AdbcError* error, int n_params = 0,
+                         PostgresType* param_types = nullptr);
   AdbcStatusCode DescribePrepared(struct AdbcError* error);
-  AdbcStatusCode ExecutePrepared(struct AdbcError* error, const std::vector<std::string>& params = {});
+  AdbcStatusCode ExecutePrepared(struct AdbcError* error,
+                                 const std::vector<std::string>& params = {});
   AdbcStatusCode Execute(struct AdbcError* error,
                          const std::vector<std::string>& params = {},
                          PostgresType* param_types = nullptr);
   AdbcStatusCode ExecuteCopy(struct AdbcError* error);
   AdbcStatusCode ResolveParamTypes(PostgresTypeResolver& type_resolver,
-                                   PostgresType* param_types,
-                                   struct AdbcError* error);
+                                   PostgresType* param_types, struct AdbcError* error);
   AdbcStatusCode ResolveOutputTypes(PostgresTypeResolver& type_resolver,
-                                    PostgresType* result_types,
-                                    struct AdbcError* error);
+                                    PostgresType* result_types, struct AdbcError* error);
 
   bool HasResult() { return result_ != nullptr; }
 
@@ -165,7 +165,6 @@ class PqResultHelper {
   Format output_format_ = Format::kText;
 };
 
-
 class PqResultArrayReader {
  public:
   PqResultArrayReader(PGconn* conn, std::shared_ptr<PostgresTypeResolver> type_resolver,
@@ -194,7 +193,7 @@ class PqResultArrayReader {
   struct AdbcError error_;
   struct ArrowError na_error_;
 
-  PqResultArrayReader(PqResultArrayReader* other)
+  explicit PqResultArrayReader(PqResultArrayReader* other)
       : helper_(std::move(other->helper_)),
         type_resolver_(std::move(other->type_resolver_)),
         field_readers_(std::move(other->field_readers_)),

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -140,12 +140,11 @@ class PqResultArrayReader {
   PqResultArrayReader(PGconn* conn, std::shared_ptr<PostgresTypeResolver> type_resolver,
                       std::string query)
       : helper_(conn, std::move(query), &error_), type_resolver_(type_resolver) {
-    ResetErrors();
+    ArrowErrorInit(&na_error_);
+    error_ = ADBC_ERROR_INIT;
   }
 
-  ~PqResultArrayReader() {
-    ResetErrors();
-  }
+  ~PqResultArrayReader() { ResetErrors(); }
 
   int GetSchema(struct ArrowSchema* out);
   int GetNext(struct ArrowArray* out);

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -81,15 +81,17 @@ class PqResultHelper {
     kBinary = 1,
   };
 
-  explicit PqResultHelper(PGconn* conn, std::string query,
-                          struct AdbcError* error) : conn_(conn),
-      query_(std::move(query)), error_(error) {}
+  explicit PqResultHelper(PGconn* conn, std::string query, struct AdbcError* error)
+      : conn_(conn), query_(std::move(query)), error_(error) {}
 
   ~PqResultHelper();
 
   void set_output_format(Format format) { format_ = format; }
 
   AdbcStatusCode Prepare(int n_params = 0);
+  AdbcStatusCode DescribePrepared(PostgresTypeResolver& type_resolver,
+                                  PostgresType* result_types,
+                                  PostgresType* param_types);
   AdbcStatusCode ExecutePrepared(const std::vector<std::string>& params = {});
 
   int NumRows() const { return PQntuples(result_); }

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -89,7 +89,7 @@ class PqResultHelper {
   void set_param_format(Format format) { param_format_ = format; }
   void set_output_format(Format format) { output_format_ = format; }
 
-  AdbcStatusCode Prepare(int n_params = 0);
+  AdbcStatusCode Prepare(int n_params = 0, PostgresType* param_types = nullptr);
   AdbcStatusCode DescribePrepared();
   AdbcStatusCode ExecutePrepared(const std::vector<std::string>& params = {});
   AdbcStatusCode ResolveParamTypes(PostgresTypeResolver& type_resolver,

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -106,7 +106,16 @@ class PqResultHelper {
   AdbcStatusCode ResolveOutputTypes(PostgresTypeResolver& type_resolver,
                                     PostgresType* result_types);
 
+  bool HasResult() { return result_ != nullptr; }
+
   PGresult* ReleaseResult();
+
+  void ClearResult() {
+    PQclear(result_);
+    result_ = nullptr;
+  }
+
+  int64_t AffectedRows();
 
   int NumRows() const { return PQntuples(result_); }
 
@@ -152,11 +161,6 @@ class PqResultHelper {
   Format param_format_ = Format::kText;
   Format output_format_ = Format::kText;
   struct AdbcError* error_;
-
-  void ClearResult() {
-    PQclear(result_);
-    result_ = nullptr;
-  }
 };
 
 class PqResultArrayReader {

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -1224,14 +1224,14 @@ AdbcStatusCode PostgresStatement::ExecuteQuery(struct ArrowArrayStream* stream,
 
     // If the caller did not request a result set or if there are no
     // inferred output columns (e.g. a CREATE or UPDATE), then don't
-    // use COPY (which would fail anyways)
+    // use COPY (which would fail in many cases)
     if (!stream || reader_.copy_reader_->pg_type().n_children() == 0) {
       RAISE_ADBC(ExecuteNoResultSet(rows_affected, error));
       if (stream) {
         struct ArrowSchema schema;
         std::memset(&schema, 0, sizeof(schema));
         RAISE_NA(reader_.copy_reader_->GetSchema(&schema));
-        nanoarrow::EmptyArrayStream::MakeUnique(&schema).move(stream);
+        nanoarrow::EmptyArrayStream(&schema).ToArrayStream(stream);
       }
       return ADBC_STATUS_OK;
     }

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -1298,9 +1298,9 @@ AdbcStatusCode PostgresStatement::ExecuteUpdateBulk(int64_t* rows_affected,
   // This is a little unfortunate; we need another DB roundtrip
   std::string current_schema;
   {
-    PqResultHelper result_helper{connection_->conn(), "SELECT CURRENT_SCHEMA", {}, error};
+    PqResultHelper result_helper{connection_->conn(), "SELECT CURRENT_SCHEMA", error};
     RAISE_ADBC(result_helper.Prepare());
-    RAISE_ADBC(result_helper.Execute());
+    RAISE_ADBC(result_helper.ExecutePrepared());
     auto it = result_helper.begin();
     if (it == result_helper.end()) {
       SetError(error, "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA'");

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -1282,8 +1282,7 @@ AdbcStatusCode PostgresStatement::ExecuteIngest(struct ArrowArrayStream* stream,
   std::string current_schema;
   {
     PqResultHelper result_helper{connection_->conn(), "SELECT CURRENT_SCHEMA"};
-    RAISE_ADBC(result_helper.Prepare(error));
-    RAISE_ADBC(result_helper.ExecutePrepared(error));
+    RAISE_ADBC(result_helper.Execute(error));
     auto it = result_helper.begin();
     if (it == result_helper.end()) {
       SetError(error, "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA'");

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -1528,10 +1528,10 @@ AdbcStatusCode PostgresStatement::SetOptionInt(const char* key, int64_t value,
 AdbcStatusCode PostgresStatement::SetupReader(struct AdbcError* error) {
   PqResultHelper helper(connection_->conn(), query_, error);
   RAISE_ADBC(helper.Prepare());
+  RAISE_ADBC(helper.DescribePrepared());
 
   PostgresType root_type;
-  RAISE_ADBC(
-      helper.DescribePrepared(*type_resolver_, &root_type, /*param_types*/ nullptr));
+  RAISE_ADBC(helper.ResolveOutputTypes(*type_resolver_, &root_type));
 
   // Initialize the copy reader and infer the output schema (i.e., error for
   // unsupported types before issuing the COPY query)

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -1238,6 +1238,8 @@ AdbcStatusCode PostgresStatement::ExecuteSchema(struct ArrowSchema* schema,
       return ADBC_STATUS_INVALID_STATE;
     }
 
+    // This won't work...we'll need to use a std::vector<Oid> for Prepare() instead of
+    // a PostgresType (because arbitrary structs are not valid postgres types)
     CHECK_NA_DETAIL(
         INTERNAL,
         PostgresType::FromSchema(*type_resolver_, schema.get(), &param_types, &na_error),

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -1160,6 +1160,7 @@ AdbcStatusCode PostgresStatement::ExecutePreparedStatement(
     // TODO:
     SetError(error, "%s",
              "[libpq] Prepared statements returning result sets are not implemented");
+
     return ADBC_STATUS_NOT_IMPLEMENTED;
   }
 
@@ -1214,7 +1215,7 @@ AdbcStatusCode PostgresStatement::ExecuteQuery(struct ArrowArrayStream* stream,
     // inferred output columns (e.g. a CREATE or UPDATE), then don't
     // use COPY (which would fail anyways)
     if (!stream || reader_.copy_reader_->pg_type().n_children() == 0) {
-      RAISE_ADBC(ExecuteUpdateQuery(rows_affected, error));
+      RAISE_ADBC(ExecuteNoResultSet(rows_affected, error));
       if (stream) {
         struct ArrowSchema schema;
         std::memset(&schema, 0, sizeof(schema));
@@ -1329,7 +1330,7 @@ AdbcStatusCode PostgresStatement::ExecuteUpdateBulk(int64_t* rows_affected,
   return ADBC_STATUS_OK;
 }
 
-AdbcStatusCode PostgresStatement::ExecuteUpdateQuery(int64_t* rows_affected,
+AdbcStatusCode PostgresStatement::ExecuteNoResultSet(int64_t* rows_affected,
                                                      struct AdbcError* error) {
   // NOTE: must prepare first (used in ExecuteQuery)
   PGresult* result =

--- a/c/driver/postgresql/statement.h
+++ b/c/driver/postgresql/statement.h
@@ -33,7 +33,7 @@
 #define ADBC_POSTGRESQL_OPTION_BATCH_SIZE_HINT_BYTES \
   "adbc.postgresql.batch_size_hint_bytes"
 
-#define ADBC_POSTGRESQL_OPTION_USE_COPY "adbc.postgresql.batch_size_hint_bytes"
+#define ADBC_POSTGRESQL_OPTION_USE_COPY "adbc.postgresql.use_copy"
 
 namespace adbcpq {
 class PostgresConnection;
@@ -136,6 +136,7 @@ class PostgresStatement {
                                struct AdbcError* error);
   AdbcStatusCode ExecuteBind(struct ArrowArrayStream* stream, int64_t* rows_affected,
                              struct AdbcError* error);
+  bool UseCopyIfPossible();
 
  private:
   std::shared_ptr<PostgresTypeResolver> type_resolver_;

--- a/c/driver/postgresql/statement.h
+++ b/c/driver/postgresql/statement.h
@@ -33,8 +33,7 @@
 #define ADBC_POSTGRESQL_OPTION_BATCH_SIZE_HINT_BYTES \
   "adbc.postgresql.batch_size_hint_bytes"
 
-#define ADBC_POSTGRESQL_OPTION_USE_COPY \
-  "adbc.postgresql.batch_size_hint_bytes"
+#define ADBC_POSTGRESQL_OPTION_USE_COPY "adbc.postgresql.batch_size_hint_bytes"
 
 namespace adbcpq {
 class PostgresConnection;

--- a/c/driver/postgresql/statement.h
+++ b/c/driver/postgresql/statement.h
@@ -33,6 +33,9 @@
 #define ADBC_POSTGRESQL_OPTION_BATCH_SIZE_HINT_BYTES \
   "adbc.postgresql.batch_size_hint_bytes"
 
+#define ADBC_POSTGRESQL_OPTION_USE_COPY \
+  "adbc.postgresql.batch_size_hint_bytes"
+
 namespace adbcpq {
 class PostgresConnection;
 class PostgresStatement;

--- a/c/driver/postgresql/statement.h
+++ b/c/driver/postgresql/statement.h
@@ -92,7 +92,11 @@ class TupleReader final {
 class PostgresStatement {
  public:
   PostgresStatement()
-      : connection_(nullptr), query_(), prepared_(false), reader_(nullptr) {
+      : connection_(nullptr),
+        query_(),
+        prepared_(false),
+        use_copy_(true),
+        reader_(nullptr) {
     std::memset(&bind_, 0, sizeof(bind_));
   }
 
@@ -136,7 +140,6 @@ class PostgresStatement {
                                struct AdbcError* error);
   AdbcStatusCode ExecuteBind(struct ArrowArrayStream* stream, int64_t* rows_affected,
                              struct AdbcError* error);
-  bool UseCopyIfPossible();
 
  private:
   std::shared_ptr<PostgresTypeResolver> type_resolver_;
@@ -154,6 +157,9 @@ class PostgresStatement {
     kReplace,
     kCreateAppend,
   };
+
+  // Options
+  bool use_copy_;
 
   struct {
     std::string db_schema;

--- a/c/driver/postgresql/statement.h
+++ b/c/driver/postgresql/statement.h
@@ -131,7 +131,7 @@ class PostgresStatement {
       std::string* escaped_table, std::string* escaped_field_list,
       struct AdbcError* error);
   AdbcStatusCode ExecuteUpdateBulk(int64_t* rows_affected, struct AdbcError* error);
-  AdbcStatusCode ExecuteUpdateQuery(int64_t* rows_affected, struct AdbcError* error);
+  AdbcStatusCode ExecuteNoResultSet(int64_t* rows_affected, struct AdbcError* error);
   AdbcStatusCode ExecutePreparedStatement(struct ArrowArrayStream* stream,
                                           int64_t* rows_affected,
                                           struct AdbcError* error);

--- a/c/driver/postgresql/statement.h
+++ b/c/driver/postgresql/statement.h
@@ -130,12 +130,10 @@ class PostgresStatement {
       const std::vector<struct ArrowSchemaView>& source_schema_fields,
       std::string* escaped_table, std::string* escaped_field_list,
       struct AdbcError* error);
-  AdbcStatusCode ExecuteUpdateBulk(int64_t* rows_affected, struct AdbcError* error);
-  AdbcStatusCode ExecuteNoResultSet(int64_t* rows_affected, struct AdbcError* error);
-  AdbcStatusCode ExecutePreparedStatement(struct ArrowArrayStream* stream,
-                                          int64_t* rows_affected,
-                                          struct AdbcError* error);
-  AdbcStatusCode SetupReader(struct AdbcError* error);
+  AdbcStatusCode ExecuteIngest(struct ArrowArrayStream* stream, int64_t* rows_affected,
+                               struct AdbcError* error);
+  AdbcStatusCode ExecuteBind(struct ArrowArrayStream* stream, int64_t* rows_affected,
+                             struct AdbcError* error);
 
  private:
   std::shared_ptr<PostgresTypeResolver> type_resolver_;

--- a/c/validation/adbc_validation_util.cc
+++ b/c/validation/adbc_validation_util.cc
@@ -36,6 +36,20 @@ std::optional<std::string> ConnectionGetOption(struct AdbcConnection* connection
   return std::string(buffer, buffer_size - 1);
 }
 
+std::optional<std::string> StatementGetOption(struct AdbcStatement* statement,
+                                               std::string_view option,
+                                               struct AdbcError* error) {
+  char buffer[128];
+  size_t buffer_size = sizeof(buffer);
+  AdbcStatusCode status =
+      AdbcStatementGetOption(statement, option.data(), buffer, &buffer_size, error);
+  EXPECT_THAT(status, IsOkStatus(error));
+  if (status != ADBC_STATUS_OK) return std::nullopt;
+  EXPECT_GT(buffer_size, 0);
+  if (buffer_size == 0) return std::nullopt;
+  return std::string(buffer, buffer_size - 1);
+}
+
 std::string StatusCodeToString(AdbcStatusCode code) {
 #define CASE(CONSTANT)         \
   case ADBC_STATUS_##CONSTANT: \

--- a/c/validation/adbc_validation_util.cc
+++ b/c/validation/adbc_validation_util.cc
@@ -37,8 +37,8 @@ std::optional<std::string> ConnectionGetOption(struct AdbcConnection* connection
 }
 
 std::optional<std::string> StatementGetOption(struct AdbcStatement* statement,
-                                               std::string_view option,
-                                               struct AdbcError* error) {
+                                              std::string_view option,
+                                              struct AdbcError* error) {
   char buffer[128];
   size_t buffer_size = sizeof(buffer);
   AdbcStatusCode status =

--- a/c/validation/adbc_validation_util.h
+++ b/c/validation/adbc_validation_util.h
@@ -43,6 +43,10 @@ std::optional<std::string> ConnectionGetOption(struct AdbcConnection* connection
                                                std::string_view option,
                                                struct AdbcError* error);
 
+std::optional<std::string> StatementGetOption(struct AdbcStatement* statement,
+                                               std::string_view option,
+                                               struct AdbcError* error);
+
 // ------------------------------------------------------------
 // Helpers to print values
 

--- a/c/validation/adbc_validation_util.h
+++ b/c/validation/adbc_validation_util.h
@@ -44,8 +44,8 @@ std::optional<std::string> ConnectionGetOption(struct AdbcConnection* connection
                                                struct AdbcError* error);
 
 std::optional<std::string> StatementGetOption(struct AdbcStatement* statement,
-                                               std::string_view option,
-                                               struct AdbcError* error);
+                                              std::string_view option,
+                                              struct AdbcError* error);
 
 // ------------------------------------------------------------
 // Helpers to print values

--- a/python/adbc_driver_postgresql/tests/test_dbapi.py
+++ b/python/adbc_driver_postgresql/tests/test_dbapi.py
@@ -148,7 +148,7 @@ def test_query_execute_schema(postgres: dbapi.Connection) -> None:
 def test_query_invalid(postgres: dbapi.Connection) -> None:
     with postgres.cursor() as cur:
         with pytest.raises(
-            postgres.ProgrammingError, match="Failed to execute query"
+            postgres.ProgrammingError, match="Failed to prepare query"
         ) as excinfo:
             cur.execute("SELECT * FROM tabledoesnotexist")
 

--- a/python/adbc_driver_postgresql/tests/test_dbapi.py
+++ b/python/adbc_driver_postgresql/tests/test_dbapi.py
@@ -148,7 +148,7 @@ def test_query_execute_schema(postgres: dbapi.Connection) -> None:
 def test_query_invalid(postgres: dbapi.Connection) -> None:
     with postgres.cursor() as cur:
         with pytest.raises(
-            postgres.ProgrammingError, match="failed to prepare query"
+            postgres.ProgrammingError, match="Failed to execute query"
         ) as excinfo:
             cur.execute("SELECT * FROM tabledoesnotexist")
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adbc_core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arrow",
  "libloading",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "adbc_dummy"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "adbc_core",
  "arrow",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adbc_core"
-version = "0.14.0"
+version = "0.13.0"
 dependencies = [
  "arrow",
  "libloading",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "adbc_dummy"
-version = "0.14.0"
+version = "0.13.0"
 dependencies = [
  "adbc_core",
  "arrow",


### PR DESCRIPTION
I started this PR wanting to get queries with parameters able to return their results; however, this turned into a PR leaning in to the `PqResultHelper` because it was helpful to export arrays from the `PGresult*` but wasn't quite general enough. I did a second bit of shuffling to make it (possibly, or maybe just for me) easier to understand what path gets taken on `ExecuteQuery()`.

Some side effects of these changes are that we can now support multiple statements in the same query (by using `PQexec()` instead of `PQexecParams()` when there is no output requested) and that we can `ExecuteSchema()` for all parameterized queries.

The actual feature is that a user can set `adbc.postgresql.use_copy = FALSE` to force a non-COPY path for queries that aren't supported there. Because we request binary data, we can use all the same infrastructure for converting the results! I have only one test for this although I did run the whole test suite in C++ and Python...there are still a few missing features (batch size hint, large string overflow, error detail, cancel) but most tests pass using either path.

I'm happy to split this up if that is easier! I'm also planning to document the helper (but wanted a first round of review before documenting the behaviour to make sure it's behaviour we actually want).

Closes #855, Closes #2035.

``` r
library(adbcdrivermanager)
#> Warning: package 'adbcdrivermanager' was built under R version 4.3.3

con <- adbc_database_init(
  adbcpostgresql::adbcpostgresql(),
  uri = "postgresql://localhost:5432/postgres?user=postgres&password=password"
) |> 
  adbc_connection_init()

nycflights13::flights |> 
  write_adbc(con, "flights")

stream <- nanoarrow::nanoarrow_allocate_array_stream()
rows <- con |> 
  adbc_statement_init(adbc.postgresql.use_copy = FALSE) |> 
  adbc_statement_set_sql_query(
    "SELECT * from flights where month = 1 AND day = 1"
  ) |> 
  adbc_statement_prepare() |>
  adbc_statement_execute_query(stream)

rows
#> [1] 842

tibble::as_tibble(stream)
#> # A tibble: 842 × 19
#>     year month   day dep_time sched_dep_time dep_delay arr_time sched_arr_time
#>    <int> <int> <int>    <int>          <int>     <dbl>    <int>          <int>
#>  1  2013     1     1      517            515         2      830            819
#>  2  2013     1     1      533            529         4      850            830
#>  3  2013     1     1      542            540         2      923            850
#>  4  2013     1     1      544            545        -1     1004           1022
#>  5  2013     1     1      554            600        -6      812            837
#>  6  2013     1     1      554            558        -4      740            728
#>  7  2013     1     1      555            600        -5      913            854
#>  8  2013     1     1      557            600        -3      709            723
#>  9  2013     1     1      557            600        -3      838            846
#> 10  2013     1     1      558            600        -2      753            745
#> # ℹ 832 more rows
#> # ℹ 11 more variables: arr_delay <dbl>, carrier <chr>, flight <int>,
#> #   tailnum <chr>, origin <chr>, dest <chr>, air_time <dbl>, distance <dbl>,
#> #   hour <dbl>, minute <dbl>, time_hour <dttm>

con |> 
  execute_adbc("DROP TABLE flights")
```

<sup>Created on 2024-07-25 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>