### PR TITLE
fix(ci): Pin r-lib actions as a workaround for latest action updates

### DIFF
--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -70,7 +70,7 @@ jobs:
           Rscript bootstrap.R
           popd
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
         with:
           extra-packages: any::rcmdcheck, local::../adbcdrivermanager
           needs: check

--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -117,6 +117,18 @@ jobs:
         run: |
           sudo apt-get install -y valgrind
 
+      # Usually, pak::pkg_install() will run bootstrap.R if it is included and is declared;
+      # however, this doesn't work for local:: for some reason (which is what
+      # setup-r-dependencies uses under the hood)
+      - name: Bootstrap R Package
+        run: |
+          pushd r/adbcdrivermanager
+          Rscript bootstrap.R
+          popd
+          pushd "r/${{ inputs.pkg }}"
+          Rscript bootstrap.R
+          popd
+
       - uses: r-lib/actions/setup-r-dependencies@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
         with:
           extra-packages: local::../adbcdrivermanager

--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           sudo apt-get install -y valgrind
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
         with:
           extra-packages: local::../adbcdrivermanager
           working-directory: r/${{ matrix.pkg }}

--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -125,7 +125,7 @@ jobs:
           pushd r/adbcdrivermanager
           Rscript bootstrap.R
           popd
-          pushd "r/${{ inputs.pkg }}"
+          pushd "r/${{ matrix.pkg }}"
           Rscript bootstrap.R
           popd
 


### PR DESCRIPTION
The R check actions are currently failing because an update to r-lib actions resulted in some quarto actions being invoked, and these have not yet been whitelisted for use in Apache repositories. We don't actually need quarto for anything in the R package; however, the action is written in such a way that even though the step is skipped, the action is still loaded (and therefore its name is checked against the whitelist).

Unrelatedly, the extended R check was failing because I forgot to copy a change from #1965 into one of the workflows that only runs once a week.