### PR TITLE
feat(go/adbc/driver/snowflake): Keep track of all files copied and skip empty files in bulk_ingestion

### DIFF
--- a/go/adbc/driver/snowflake/bulk_ingestion.go
+++ b/go/adbc/driver/snowflake/bulk_ingestion.go
@@ -360,11 +360,10 @@ func writeParquet(
 			return err
 		}
 
+		bytesWritten += nbytes
 		if targetSize < 0 {
 			continue
 		}
-
-		bytesWritten += nbytes
 		if bytesWritten >= int64(targetSize) {
 			return nil
 		}
@@ -664,24 +663,22 @@ func (bp *bufferPool) PutBuffer(buf *bytes.Buffer) {
 	bp.Pool.Put(buf)
 }
 
-type fileSet struct {
-	data sync.Map
-}
+type fileSet sync.Map
 
 func (s *fileSet) Add(file string) {
 	basename := path.Base(file)
-	s.data.Store(basename, nil)
+	(*sync.Map)(s).Store(basename, nil)
 }
 
 func (s *fileSet) Remove(file string) {
 	basename := path.Base(file)
-	s.data.Delete(basename)
+	(*sync.Map)(s).Delete(basename)
 
 }
 
 func (s *fileSet) Len() int {
 	var items int
-	s.data.Range(func(key, value any) bool {
+	(*sync.Map)(s).Range(func(key, value any) bool {
 		items++
 		return true
 	})

--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/bluele/gcache v0.0.2
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
-	github.com/snowflakedb/gosnowflake v1.11.1-0.20240820132919-5649c7a3d6f6
+	github.com/snowflakedb/gosnowflake v1.11.1
 	github.com/stretchr/testify v1.9.0
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a
 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa

--- a/go/adbc/go.sum
+++ b/go/adbc/go.sum
@@ -200,8 +200,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/snowflakedb/gosnowflake v1.11.1-0.20240820132919-5649c7a3d6f6 h1:cNdbJtL8OMLwtQOWrprIHuJ/5egcfeQDrNBlF9f1cuE=
-github.com/snowflakedb/gosnowflake v1.11.1-0.20240820132919-5649c7a3d6f6/go.mod h1:WFe+8mpsapDaQjHX6BqJBKtfQCGlGD3lHKeDsKfpx2A=
+github.com/snowflakedb/gosnowflake v1.11.1 h1:E91s8vBOSroaSTLsyjO4QPkEuzGmZcCxEFQLg214mvk=
+github.com/snowflakedb/gosnowflake v1.11.1/go.mod h1:WFe+8mpsapDaQjHX6BqJBKtfQCGlGD3lHKeDsKfpx2A=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=


### PR DESCRIPTION
Fixes: #2094

Two primary changes:
- Skip uploading parquet files that never had any rows written to them
  - This reduces number of files Snowflake must keep track of, improving success rate of the COPY command
- Keep track of all files uploaded to stage and ensure they are actually copied
  - Retry the COPY command up to 5 times with backoff if files any files haven't been copied

**Snowflake Test Output**
```
➜  adbc git:(gh-2094) ✗ go test -v ./driver/snowflake/...
=== RUN   TestIngestBatchedParquetWithFileLimit
--- PASS: TestIngestBatchedParquetWithFileLimit (0.00s)
=== RUN   TestValidation
=== RUN   TestValidation/TestNewDatabase
=== RUN   TestValidation/TestAutocommitDefault
=== RUN   TestValidation/TestAutocommitToggle
=== RUN   TestValidation/TestCloseConnTwice
=== RUN   TestValidation/TestConcurrent
=== RUN   TestValidation/TestGetSetOptions
=== RUN   TestValidation/TestMetadataCurrentCatalog
=== RUN   TestValidation/TestMetadataCurrentDbSchema
=== RUN   TestValidation/TestMetadataGetInfo
=== RUN   TestValidation/TestMetadataGetObjectsColumns
=== RUN   TestValidation/TestMetadataGetObjectsColumns/depth_catalog_no_filter
=== RUN   TestValidation/TestMetadataGetObjectsColumns/depth_dbSchema_no_filter
=== RUN   TestValidation/TestMetadataGetObjectsColumns/depth_table_no_filter
=== RUN   TestValidation/TestMetadataGetObjectsColumns/depth_column_no_filter
=== RUN   TestValidation/TestMetadataGetObjectsColumns/filter_catalog_valid
=== RUN   TestValidation/TestMetadataGetObjectsColumns/filter_catalog_invalid
=== RUN   TestValidation/TestMetadataGetObjectsColumns/filter_dbSchema_valid
=== RUN   TestValidation/TestMetadataGetObjectsColumns/filter_dbSchema_invalid
=== RUN   TestValidation/TestMetadataGetObjectsColumns/filter_table_valid
=== RUN   TestValidation/TestMetadataGetObjectsColumns/filter_table_invalid
=== RUN   TestValidation/TestMetadataGetObjectsColumns/filter_column:_in%
=== RUN   TestValidation/TestMetadataGetStatistics
=== RUN   TestValidation/TestMetadataGetTableSchema
=== RUN   TestValidation/TestMetadataGetTableTypes
=== RUN   TestValidation/TestNewConn
=== RUN   TestValidation/TestNewStatement
=== RUN   TestValidation/TestSQLPrepareGetParameterSchema
=== RUN   TestValidation/TestSQLPrepareSelectNoParams
=== RUN   TestValidation/TestSQLPrepareSelectParams
=== RUN   TestValidation/TestSqlExecuteSchema
=== RUN   TestValidation/TestSqlExecuteSchema/no_query
=== RUN   TestValidation/TestSqlExecuteSchema/query
=== RUN   TestValidation/TestSqlExecuteSchema/prepared
=== RUN   TestValidation/TestSqlIngestAppend
=== RUN   TestValidation/TestSqlIngestCreateAppend
=== RUN   TestValidation/TestSqlIngestErrors
=== RUN   TestValidation/TestSqlIngestErrors/ingest_without_bind
=== RUN   TestValidation/TestSqlIngestErrors/append_to_nonexistent_table
time="2024-08-28T10:58:21-04:00" level=error msg="error: 002003 (42S02): SQL compilation error:\nObject '\"bulk_ingest\"' does not exist or not authorized." func="gosnowflake.(*snowflakeConn).queryContextInternal" file="connection.go:398"
=== RUN   TestValidation/TestSqlIngestErrors/overwrite_and_incompatible_schema
=== RUN   TestValidation/TestSqlIngestInts
=== RUN   TestValidation/TestSqlIngestReplace
=== RUN   TestValidation/TestSqlPartitionedInts
=== RUN   TestValidation/TestSqlPrepareErrorParamCountMismatch
--- PASS: TestValidation (80.67s)
    --- PASS: TestValidation/TestNewDatabase (0.00s)
    --- PASS: TestValidation/TestAutocommitDefault (0.33s)
    --- PASS: TestValidation/TestAutocommitToggle (1.03s)
    --- PASS: TestValidation/TestCloseConnTwice (0.33s)
    --- PASS: TestValidation/TestConcurrent (0.95s)
    --- PASS: TestValidation/TestGetSetOptions (0.29s)
    --- PASS: TestValidation/TestMetadataCurrentCatalog (0.45s)
    --- PASS: TestValidation/TestMetadataCurrentDbSchema (0.44s)
    --- PASS: TestValidation/TestMetadataGetInfo (0.29s)
    --- PASS: TestValidation/TestMetadataGetObjectsColumns (45.51s)
        --- PASS: TestValidation/TestMetadataGetObjectsColumns/depth_catalog_no_filter (0.88s)
        --- PASS: TestValidation/TestMetadataGetObjectsColumns/depth_dbSchema_no_filter (0.92s)
        --- PASS: TestValidation/TestMetadataGetObjectsColumns/depth_table_no_filter (3.05s)
        --- PASS: TestValidation/TestMetadataGetObjectsColumns/depth_column_no_filter (5.61s)
        --- PASS: TestValidation/TestMetadataGetObjectsColumns/filter_catalog_valid (4.90s)
        --- PASS: TestValidation/TestMetadataGetObjectsColumns/filter_catalog_invalid (4.23s)
        --- PASS: TestValidation/TestMetadataGetObjectsColumns/filter_dbSchema_valid (4.92s)
        --- PASS: TestValidation/TestMetadataGetObjectsColumns/filter_dbSchema_invalid (3.70s)
        --- PASS: TestValidation/TestMetadataGetObjectsColumns/filter_table_valid (5.59s)
        --- PASS: TestValidation/TestMetadataGetObjectsColumns/filter_table_invalid (4.42s)
        --- PASS: TestValidation/TestMetadataGetObjectsColumns/filter_column:_in% (5.65s)
    --- PASS: TestValidation/TestMetadataGetStatistics (0.33s)
    --- PASS: TestValidation/TestMetadataGetTableSchema (1.92s)
    --- PASS: TestValidation/TestMetadataGetTableTypes (0.29s)
    --- PASS: TestValidation/TestNewConn (0.30s)
    --- PASS: TestValidation/TestNewStatement (0.39s)
    --- PASS: TestValidation/TestSQLPrepareGetParameterSchema (0.30s)
    --- PASS: TestValidation/TestSQLPrepareSelectNoParams (0.38s)
    --- SKIP: TestValidation/TestSQLPrepareSelectParams (0.29s)
    --- PASS: TestValidation/TestSqlExecuteSchema (0.52s)
        --- PASS: TestValidation/TestSqlExecuteSchema/no_query (0.00s)
        --- PASS: TestValidation/TestSqlExecuteSchema/query (0.07s)
        --- PASS: TestValidation/TestSqlExecuteSchema/prepared (0.06s)
    --- PASS: TestValidation/TestSqlIngestAppend (5.82s)
    --- PASS: TestValidation/TestSqlIngestCreateAppend (5.72s)
    --- PASS: TestValidation/TestSqlIngestErrors (1.08s)
        --- PASS: TestValidation/TestSqlIngestErrors/ingest_without_bind (0.00s)
        --- PASS: TestValidation/TestSqlIngestErrors/append_to_nonexistent_table (0.48s)
        --- SKIP: TestValidation/TestSqlIngestErrors/overwrite_and_incompatible_schema (0.00s)
    --- PASS: TestValidation/TestSqlIngestInts (3.46s)
    --- PASS: TestValidation/TestSqlIngestReplace (6.82s)
    --- PASS: TestValidation/TestSqlPartitionedInts (0.29s)
    --- SKIP: TestValidation/TestSqlPrepareErrorParamCountMismatch (0.31s)
=== RUN   TestSnowflake
=== RUN   TestSnowflake/TestAdditionalDriverInfo
=== RUN   TestSnowflake/TestDecimalHighPrecision
=== RUN   TestSnowflake/TestDescribeOnly
=== RUN   TestSnowflake/TestEmptyResultSet
=== RUN   TestSnowflake/TestIngestEmptyChunk
=== RUN   TestSnowflake/TestIntDecimalLowPrecision
=== RUN   TestSnowflake/TestJwtPrivateKey
    driver_test.go:1888: apache/arrow-adbc#1364
=== RUN   TestSnowflake/TestMetadataGetObjectsColumnsXdbc
=== RUN   TestSnowflake/TestMetadataOnlyQuery
=== RUN   TestSnowflake/TestNewDatabaseGetSetOptions
=== RUN   TestSnowflake/TestNonIntDecimalLowPrecision
=== RUN   TestSnowflake/TestSqlIngestDate64Type
=== RUN   TestSnowflake/TestSqlIngestHighPrecision
=== RUN   TestSnowflake/TestSqlIngestListType
=== RUN   TestSnowflake/TestSqlIngestLowPrecision
=== RUN   TestSnowflake/TestSqlIngestMapType
=== RUN   TestSnowflake/TestSqlIngestRecordAndStreamAreEquivalent
=== RUN   TestSnowflake/TestSqlIngestRoundtripTypes
=== RUN   TestSnowflake/TestSqlIngestStructType
=== RUN   TestSnowflake/TestSqlIngestTimestamp
=== RUN   TestSnowflake/TestSqlIngestTimestampTypes
=== RUN   TestSnowflake/TestStatementEmptyResultSet
=== RUN   TestSnowflake/TestTimestampSnow
=== RUN   TestSnowflake/TestUseHighPrecision
--- PASS: TestSnowflake (110.63s)
    --- PASS: TestSnowflake/TestAdditionalDriverInfo (0.29s)
    --- PASS: TestSnowflake/TestDecimalHighPrecision (27.19s)
    --- PASS: TestSnowflake/TestDescribeOnly (0.53s)
    --- PASS: TestSnowflake/TestEmptyResultSet (0.47s)
    --- PASS: TestSnowflake/TestIngestEmptyChunk (4.00s)
    --- PASS: TestSnowflake/TestIntDecimalLowPrecision (7.97s)
    --- SKIP: TestSnowflake/TestJwtPrivateKey (0.50s)
    --- PASS: TestSnowflake/TestMetadataGetObjectsColumnsXdbc (10.51s)
    --- PASS: TestSnowflake/TestMetadataOnlyQuery (1.56s)
    --- PASS: TestSnowflake/TestNewDatabaseGetSetOptions (0.30s)
    --- PASS: TestSnowflake/TestNonIntDecimalLowPrecision (9.56s)
    --- PASS: TestSnowflake/TestSqlIngestDate64Type (3.50s)
    --- PASS: TestSnowflake/TestSqlIngestHighPrecision (3.63s)
    --- PASS: TestSnowflake/TestSqlIngestListType (3.67s)
    --- PASS: TestSnowflake/TestSqlIngestLowPrecision (3.46s)
    --- PASS: TestSnowflake/TestSqlIngestMapType (3.21s)
    --- PASS: TestSnowflake/TestSqlIngestRecordAndStreamAreEquivalent (6.89s)
    --- PASS: TestSnowflake/TestSqlIngestRoundtripTypes (5.33s)
    --- PASS: TestSnowflake/TestSqlIngestStructType (4.11s)
    --- PASS: TestSnowflake/TestSqlIngestTimestamp (5.05s)
    --- PASS: TestSnowflake/TestSqlIngestTimestampTypes (4.17s)
    --- PASS: TestSnowflake/TestStatementEmptyResultSet (0.66s)
    --- PASS: TestSnowflake/TestTimestampSnow (0.79s)
    --- PASS: TestSnowflake/TestUseHighPrecision (2.36s)
=== RUN   TestJwtAuthenticationUnencryptedValue
    driver_test.go:1810: Cannot find the `SNOWFLAKE_TEST_PKCS8_VALUE` value
--- SKIP: TestJwtAuthenticationUnencryptedValue (0.00s)
=== RUN   TestJwtAuthenticationEncryptedValue
    driver_test.go:1826: Cannot find the `SNOWFLAKE_TEST_PKCS8_EN_VALUE` value
--- SKIP: TestJwtAuthenticationEncryptedValue (0.00s)
=== RUN   TestIngestCancelContext
--- PASS: TestIngestCancelContext (6.40s)
PASS
ok      github.com/apache/arrow-adbc/go/adbc/driver/snowflake   198.525s
```