### PR TITLE
feat(c/driver/postgresql): add `arrow.opaque` type metadata

### DIFF
--- a/c/driver/postgresql/postgres_type_test.cc
+++ b/c/driver/postgresql/postgres_type_test.cc
@@ -174,6 +174,14 @@ TEST(PostgresTypeTest, PostgresTypeSetSchema) {
                         &typnameMetadataValue);
   EXPECT_EQ(std::string(typnameMetadataValue.data, typnameMetadataValue.size_bytes),
             "numeric");
+  ArrowMetadataGetValue(schema->metadata, ArrowCharView("ARROW:extension:name"),
+                        &typnameMetadataValue);
+  EXPECT_EQ(std::string(typnameMetadataValue.data, typnameMetadataValue.size_bytes),
+            "arrow.opaque");
+  ArrowMetadataGetValue(schema->metadata, ArrowCharView("ARROW:extension:metadata"),
+                        &typnameMetadataValue);
+  EXPECT_EQ(std::string(typnameMetadataValue.data, typnameMetadataValue.size_bytes),
+            R"({"type_name": "numeric", "vendor_name": "PostgreSQL"})");
   schema.reset();
 
   ArrowSchemaInit(schema.get());

--- a/docs/source/driver/postgresql.rst
+++ b/docs/source/driver/postgresql.rst
@@ -329,6 +329,23 @@ being read or written.
                 overflow/underflow; an error will be returned if this would be
                 the case.
 
+Unknown Types
+~~~~~~~~~~~~~
+
+Types without direct Arrow equivalents can still be returned by the driver.
+In this case, the Arrow type will be binary, and the contents will be the raw
+bytes as provided by the PostgreSQL wire protocol.
+
+For Arrow implementations that support the :external:doc:`Opaque canonical
+extension type <format/CanonicalExtensions>`, the extension type metadata is
+also always present.  This helps differentiate when the driver intentionally
+returned a binary column from when it returned a binary column as a fallback.
+
+.. warning:: Currently, the driver also attaches a metadata key named
+             ``ADBC:posgresql:typname`` to the schema field of the unknown
+             column, but this has been deprecated in favor of the Opaque type
+             and you should not rely on this key continuing to exist.
+
 Software Versions
 =================
 


### PR DESCRIPTION
Fixes #2099.