### PR TITLE
build(c): don't install adbc.h unless driver manager is enabled

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -35,10 +35,6 @@ add_subdirectory(vendor/nanoarrow)
 add_subdirectory(driver/common)
 add_subdirectory(driver/framework)
 
-install(FILES "${REPOSITORY_ROOT}/c/include/adbc.h" DESTINATION include)
-install(FILES "${REPOSITORY_ROOT}/c/include/arrow-adbc/adbc.h"
-        DESTINATION include/arrow-adbc)
-
 if(ADBC_BUILD_TESTS)
   add_subdirectory(validation)
 endif()

--- a/c/driver_manager/CMakeLists.txt
+++ b/c/driver_manager/CMakeLists.txt
@@ -35,6 +35,10 @@ include_directories(SYSTEM ${REPOSITORY_ROOT}/c/include/)
 include_directories(SYSTEM ${REPOSITORY_ROOT}/c/vendor)
 include_directories(SYSTEM ${REPOSITORY_ROOT}/c/driver)
 
+install(FILES "${REPOSITORY_ROOT}/c/include/adbc.h" DESTINATION include)
+install(FILES "${REPOSITORY_ROOT}/c/include/arrow-adbc/adbc.h"
+        DESTINATION include/arrow-adbc)
+
 foreach(LIB_TARGET ${ADBC_LIBRARIES})
   target_compile_definitions(${LIB_TARGET} PRIVATE ADBC_EXPORTING)
 endforeach()


### PR DESCRIPTION
We shouldn't install headers that weren't enabled (the conda-forge packages check for this).

Fixes #2126.