### PR TITLE
fix(c/driver/postgresql): Improve error reporting for queries that error before the COPY header is sent

### DIFF
--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1485,7 +1485,7 @@ TEST_F(PostgresStatementTest, SqlExecuteCopyZeroRowOutput) {
                                           &reader.rows_affected, &error),
                 IsOkStatus());
     ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
-    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.MaybeNext(), EINVAL);
     ASSERT_EQ(reader.array->release, nullptr);
   }
 }

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1436,6 +1436,60 @@ TEST_F(PostgresStatementTest, ExecuteParameterizedQueryWithRowsAffected) {
   }
 }
 
+TEST_F(PostgresStatementTest, SqlExecuteCopyZeroRowOutput) {
+  ASSERT_THAT(quirks()->DropTable(&connection, "adbc_test", &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+
+  {
+    ASSERT_THAT(AdbcStatementSetSqlQuery(
+                    &statement, "CREATE TABLE adbc_test (id int primary key, data jsonb)",
+                    &error),
+                IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+  }
+
+  {
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(
+            &statement, "insert into adbc_test (id, data) values (1, null)", &error),
+        IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+  }
+
+  {
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(
+            &statement, "insert into adbc_test (id, data) values (2, '1')", &error),
+        IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+  }
+
+  {
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(&statement,
+                                 "SELECT id, data from adbc_test JOIN "
+                                 "jsonb_array_elements(adbc_test.data) AS foo ON true",
+                                 &error),
+        IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus());
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.array->release, nullptr);
+  }
+}
+
 TEST_F(PostgresStatementTest, BatchSizeHint) {
   ASSERT_THAT(quirks()->EnsureSampleTable(&connection, "batch_size_hint_test", &error),
               IsOkStatus(&error));

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1486,7 +1486,13 @@ TEST_F(PostgresStatementTest, SqlExecuteCopyZeroRowOutputError) {
                 IsOkStatus());
     ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
     ASSERT_EQ(reader.MaybeNext(), EINVAL);
-    ASSERT_EQ(reader.array->release, nullptr);
+
+    AdbcStatusCode status = ADBC_STATUS_OK;
+    const struct AdbcError* detail =
+        AdbcErrorFromArrayStream(&reader.stream.value, &status);
+    ASSERT_NE(nullptr, detail);
+    ASSERT_EQ(ADBC_STATUS_INVALID_ARGUMENT, status);
+    ASSERT_EQ("22023", std::string_view(detail->sqlstate, 5));
   }
 }
 

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1436,7 +1436,7 @@ TEST_F(PostgresStatementTest, ExecuteParameterizedQueryWithRowsAffected) {
   }
 }
 
-TEST_F(PostgresStatementTest, SqlExecuteCopyZeroRowOutput) {
+TEST_F(PostgresStatementTest, SqlExecuteCopyZeroRowOutputError) {
   ASSERT_THAT(quirks()->DropTable(&connection, "adbc_test", &error), IsOkStatus(&error));
   ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
 

--- a/c/driver/postgresql/statement.h
+++ b/c/driver/postgresql/statement.h
@@ -52,6 +52,7 @@ class TupleReader final {
         row_id_(-1),
         batch_size_hint_bytes_(16777216),
         is_finished_(false) {
+    ArrowErrorInit(&na_error_);
     data_.data.as_char = nullptr;
     data_.size_bytes = 0;
   }
@@ -68,9 +69,9 @@ class TupleReader final {
  private:
   friend class PostgresStatement;
 
-  int InitQueryAndFetchFirst(struct ArrowError* error);
-  int AppendRowAndFetchNext(struct ArrowError* error);
-  int BuildOutput(struct ArrowArray* out, struct ArrowError* error);
+  int GetCopyData();
+  int AppendRowAndFetchNext();
+  int BuildOutput(struct ArrowArray* out);
 
   static int GetSchemaTrampoline(struct ArrowArrayStream* self, struct ArrowSchema* out);
   static int GetNextTrampoline(struct ArrowArrayStream* self, struct ArrowArray* out);
@@ -79,6 +80,7 @@ class TupleReader final {
 
   AdbcStatusCode status_;
   struct AdbcError error_;
+  struct ArrowError na_error_;
   PGconn* conn_;
   PGresult* result_;
   char* pgbuf_;


### PR DESCRIPTION
This PR updates the error handling such that we properly call `PQgetresult()` and report Postgres-generated errors that occur before Postgres sends the header information. This probably wasn't reported until now because most queries with errors will error in the "prepare" step or didn't specifically generate an execution error on the very first result.

Closes #2133.
