### PR TITLE
chore(java): use property for checkerframework versions

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,6 +29,7 @@
 
   <properties>
     <dep.arrow.version>15.0.0</dep.arrow.version>
+    <dep.org.checkerframework.version>3.47.0</dep.org.checkerframework.version>
     <adbc.version>0.15.0-SNAPSHOT</adbc.version>
   </properties>
 
@@ -139,7 +140,7 @@
       <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
-        <version>3.46.0</version>
+        <version>${dep.org.checkerframework.version}</version>
       </dependency>
 
       <!-- Testing -->
@@ -319,7 +320,7 @@
                 <path>
                   <groupId>org.checkerframework</groupId>
                   <artifactId>checker</artifactId>
-                  <version>3.46.0</version>
+                  <version>${dep.org.checkerframework.version}</version>
                 </path>
               </annotationProcessorPaths>
               <annotationProcessors>


### PR DESCRIPTION
That way dependabot can bump them together and keep it consistent