### PR TITLE
fix(csharp/src/Drivers/Interop/Snowflake): add test to demonstrate DEFAULT_ROLE behavior

### DIFF
--- a/csharp/test/Drivers/Interop/Snowflake/Resources/snowflakeconfig.json
+++ b/csharp/test/Drivers/Interop/Snowflake/Resources/snowflakeconfig.json
@@ -26,6 +26,10 @@
             "password": ""
         }
     },
+    "roleInfo": {
+        "defaultRole": "",
+        "newRole": ""
+    },
     "query": "",
     "expectedResults": 0
 }

--- a/csharp/test/Drivers/Interop/Snowflake/SnowflakeTestConfiguration.cs
+++ b/csharp/test/Drivers/Interop/Snowflake/SnowflakeTestConfiguration.cs
@@ -84,6 +84,11 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
         [JsonPropertyName("authentication")]
         public SnowflakeAuthentication Authentication { get; set; } = new SnowflakeAuthentication();
 
+        /// <summary>
+        /// The snowflake Authentication
+        /// </summary>
+        [JsonPropertyName("roleInfo")]
+        public RoleInfo? RoleInfo { get; set; }
     }
 
     public class SnowflakeAuthentication
@@ -133,5 +138,14 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
 
         [JsonPropertyName("password")]
         public string Password { get; set; } = string.Empty;
+    }
+
+    public class RoleInfo
+    {
+        [JsonPropertyName("defaultRole")]
+        public string DefaultRole { get; set; } = string.Empty;
+
+        [JsonPropertyName("newRole")]
+        public string NewRole { get; set; } = string.Empty;
     }
 }

--- a/csharp/test/Drivers/Interop/Snowflake/SnowflakeTestingUtils.cs
+++ b/csharp/test/Drivers/Interop/Snowflake/SnowflakeTestingUtils.cs
@@ -33,6 +33,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
         public const string ACCOUNT = "adbc.snowflake.sql.account";
         public const string USERNAME = "username";
         public const string PASSWORD = "password";
+        public const string ROLE = "adbc.snowflake.sql.role";
         public const string WAREHOUSE = "adbc.snowflake.sql.warehouse";
         public const string AUTH_TYPE = "adbc.snowflake.sql.auth_type";
         public const string AUTH_TOKEN = "adbc.snowflake.sql.client_option.auth_token";


### PR DESCRIPTION
- Introduces a test to demonstrate the behavior of using DEFAULT_ROLE for ADBC, and then changes the role using the `adbc.snowflake.sql.role` parameter and validates the user is executing in the new role context. 

- Closes https://github.com/apache/arrow-adbc/issues/2080 