### PR TITLE
docs(r): fix some pkgdown website linking issues

### DIFF
--- a/r/adbcdrivermanager/DESCRIPTION
+++ b/r/adbcdrivermanager/DESCRIPTION
@@ -21,7 +21,7 @@ Suggests:
     withr
 Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
-URL: https://github.com/apache/arrow-adbc, https://arrow.apache.org/adbc/current/r/adbcdrivermanager/
+URL: https://arrow.apache.org/adbc/current/r/adbcdrivermanager/, https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports:
     nanoarrow (>= 0.3.0)

--- a/r/adbcdrivermanager/_pkgdown.yml
+++ b/r/adbcdrivermanager/_pkgdown.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-url: ~
+url: https://arrow.apache.org/adbc/current/r/adbcdrivermanager/
 template:
   bootstrap: 5
   # Link back to ADBC R documentation

--- a/r/adbcdrivermanager/man/adbcdrivermanager-package.Rd
+++ b/r/adbcdrivermanager/man/adbcdrivermanager-package.Rd
@@ -11,8 +11,8 @@ Provides a developer-facing interface to 'Arrow' Database Connectivity ('ADBC') 
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/apache/arrow-adbc}
   \item \url{https://arrow.apache.org/adbc/current/r/adbcdrivermanager/}
+  \item \url{https://github.com/apache/arrow-adbc}
   \item Report bugs at \url{https://github.com/apache/arrow-adbc/issues}
 }
 

--- a/r/adbcflightsql/DESCRIPTION
+++ b/r/adbcflightsql/DESCRIPTION
@@ -22,6 +22,6 @@ Suggests:
 SystemRequirements: GNU make, Go (>= 1.21)
 Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
-URL: https://github.com/apache/arrow-adbc, https://arrow.apache.org/adbc/current/r/adbcflightsql/
+URL: https://arrow.apache.org/adbc/current/r/adbcflightsql/, https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports: adbcdrivermanager

--- a/r/adbcflightsql/_pkgdown.yml
+++ b/r/adbcflightsql/_pkgdown.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-url: ~
+url: https://arrow.apache.org/adbc/current/r/adbcflightsql/
 template:
   bootstrap: 5
   # Link back to ADBC R documentation

--- a/r/adbcflightsql/man/adbcflightsql-package.Rd
+++ b/r/adbcflightsql/man/adbcflightsql-package.Rd
@@ -11,8 +11,8 @@ Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADB
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/apache/arrow-adbc}
   \item \url{https://arrow.apache.org/adbc/current/r/adbcflightsql/}
+  \item \url{https://github.com/apache/arrow-adbc}
   \item Report bugs at \url{https://github.com/apache/arrow-adbc/issues}
 }
 

--- a/r/adbcpostgresql/DESCRIPTION
+++ b/r/adbcpostgresql/DESCRIPTION
@@ -22,6 +22,6 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
-URL: https://github.com/apache/arrow-adbc, https://arrow.apache.org/adbc/current/r/adbcpostgresql/
+URL: https://arrow.apache.org/adbc/current/r/adbcpostgresql/, https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports: adbcdrivermanager

--- a/r/adbcpostgresql/_pkgdown.yml
+++ b/r/adbcpostgresql/_pkgdown.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-url: ~
+url: https://arrow.apache.org/adbc/current/r/adbcpostgresql/
 template:
   bootstrap: 5
   # Link back to ADBC R documentation

--- a/r/adbcpostgresql/man/adbcpostgresql-package.Rd
+++ b/r/adbcpostgresql/man/adbcpostgresql-package.Rd
@@ -11,8 +11,8 @@ Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADB
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/apache/arrow-adbc}
   \item \url{https://arrow.apache.org/adbc/current/r/adbcpostgresql/}
+  \item \url{https://github.com/apache/arrow-adbc}
   \item Report bugs at \url{https://github.com/apache/arrow-adbc/issues}
 }
 

--- a/r/adbcsnowflake/DESCRIPTION
+++ b/r/adbcsnowflake/DESCRIPTION
@@ -23,6 +23,6 @@ Suggests:
 SystemRequirements: GNU make, Go (>= 1.21)
 Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
-URL: https://github.com/apache/arrow-adbc, https://arrow.apache.org/adbc/current/r/adbcsnowflake/
+URL: https://arrow.apache.org/adbc/current/r/adbcsnowflake/, https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports: adbcdrivermanager

--- a/r/adbcsnowflake/_pkgdown.yml
+++ b/r/adbcsnowflake/_pkgdown.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-url: ~
+url: https://arrow.apache.org/adbc/current/r/adbcsnowflake/
 template:
   bootstrap: 5
   # Link back to ADBC R documentation

--- a/r/adbcsnowflake/man/adbcsnowflake-package.Rd
+++ b/r/adbcsnowflake/man/adbcsnowflake-package.Rd
@@ -11,8 +11,8 @@ Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADB
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/apache/arrow-adbc}
   \item \url{https://arrow.apache.org/adbc/current/r/adbcsnowflake/}
+  \item \url{https://github.com/apache/arrow-adbc}
   \item Report bugs at \url{https://github.com/apache/arrow-adbc/issues}
 }
 

--- a/r/adbcsqlite/DESCRIPTION
+++ b/r/adbcsqlite/DESCRIPTION
@@ -22,6 +22,6 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
-URL: https://github.com/apache/arrow-adbc, https://arrow.apache.org/adbc/current/r/adbcsqlite/
+URL: https://arrow.apache.org/adbc/current/r/adbcsqlite/, https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports: adbcdrivermanager

--- a/r/adbcsqlite/_pkgdown.yml
+++ b/r/adbcsqlite/_pkgdown.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-url: ~
+url: https://arrow.apache.org/adbc/current/r/adbcsqlite/
 template:
   bootstrap: 5
   # Link back to ADBC R documentation

--- a/r/adbcsqlite/man/adbcsqlite-package.Rd
+++ b/r/adbcsqlite/man/adbcsqlite-package.Rd
@@ -11,8 +11,8 @@ Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADB
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/apache/arrow-adbc}
   \item \url{https://arrow.apache.org/adbc/current/r/adbcsqlite/}
+  \item \url{https://github.com/apache/arrow-adbc}
   \item Report bugs at \url{https://github.com/apache/arrow-adbc/issues}
 }
 


### PR DESCRIPTION
- Fix base URL of each sites. Due to the base URLs, the site search does not appear to be working.
  For example, I searched "adbc" in <https://arrow.apache.org/adbc/current/r/adbcdrivermanager/index.html> returns <https://arrow.apache.org/reference/adbc_driver_log.html?q=adbc#ref-usage>
  (On a related note, the search feature seems to stop working when a new version is released and the base URL changes; we can confirm that the search does not work in previous versions of the `arrow` package.)
- It seems that pkgdown (downlit) uses the first value in the URL field of the DESCRIPTION file to autolinking, and bringing the pkgdown site first seems to be the expected use. (e.g. tidyverse/glue#300)