### PR TITLE
docs(r): enable dark mode on pkgdown sites

### DIFF
--- a/r/adbcdrivermanager/_pkgdown.yml
+++ b/r/adbcdrivermanager/_pkgdown.yml
@@ -18,6 +18,7 @@
 url: ~
 template:
   bootstrap: 5
+  light-switch: true
   # Link back to ADBC R documentation
   includes:
     before_title: |

--- a/r/adbcflightsql/_pkgdown.yml
+++ b/r/adbcflightsql/_pkgdown.yml
@@ -18,6 +18,7 @@
 url: ~
 template:
   bootstrap: 5
+  light-switch: true
   # Link back to ADBC R documentation
   includes:
     before_title: |

--- a/r/adbcpostgresql/_pkgdown.yml
+++ b/r/adbcpostgresql/_pkgdown.yml
@@ -18,6 +18,7 @@
 url: ~
 template:
   bootstrap: 5
+  light-switch: true
   # Link back to ADBC R documentation
   includes:
     before_title: |

--- a/r/adbcsnowflake/_pkgdown.yml
+++ b/r/adbcsnowflake/_pkgdown.yml
@@ -18,6 +18,7 @@
 url: ~
 template:
   bootstrap: 5
+  light-switch: true
   # Link back to ADBC R documentation
   includes:
     before_title: |

--- a/r/adbcsqlite/_pkgdown.yml
+++ b/r/adbcsqlite/_pkgdown.yml
@@ -18,6 +18,7 @@
 url: ~
 template:
   bootstrap: 5
+  light-switch: true
   # Link back to ADBC R documentation
   includes:
     before_title: |


### PR DESCRIPTION
This is a new feature in the latest version of pkgdown. I think it looks great.
<https://www.tidyverse.org/blog/2024/07/pkgdown-2-1-0/#light-switch>