### PR TITLE
refactor(c/driver/postgresql): Use copy writer in BindStream for parameter binding

### DIFF
--- a/c/driver/postgresql/bind_stream.h
+++ b/c/driver/postgresql/bind_stream.h
@@ -259,6 +259,7 @@ struct BindStream {
       }
 
       param_lengths[col] = static_cast<int>(param_length);
+      last_offset = param_buffer->size_bytes;
     }
 
     last_offset = 0;

--- a/c/driver/postgresql/bind_stream.h
+++ b/c/driver/postgresql/bind_stream.h
@@ -17,8 +17,13 @@
 
 #pragma once
 
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/c/driver/postgresql/bind_stream.h
+++ b/c/driver/postgresql/bind_stream.h
@@ -17,12 +17,8 @@
 
 #pragma once
 
-#if !defined(NOMINMAX)
-#define NOMINMAX
-#endif
-
 #include <algorithm>
-#include <climits>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -253,7 +249,7 @@ struct BindStream {
       }
 
       int64_t param_length = param_buffer->size_bytes - last_offset - sizeof(int32_t);
-      if (param_length > INT32_MAX) {
+      if (param_length > (std::numeric_limits<int>::max)()) {
         SetError(error, "Parameter %" PRId64 " serialized to >2GB of binary", col);
         return ADBC_STATUS_INTERNAL;
       }

--- a/c/driver/postgresql/bind_stream.h
+++ b/c/driver/postgresql/bind_stream.h
@@ -22,7 +22,7 @@
 #endif
 
 #include <algorithm>
-#include <limits>
+#include <climits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -253,7 +253,7 @@ struct BindStream {
       }
 
       int64_t param_length = param_buffer->size_bytes - last_offset - sizeof(int32_t);
-      if (param_length > std::numeric_limits<int>::max()) {
+      if (param_length > INT32_MAX) {
         SetError(error, "Parameter %" PRId64 " serialized to >2GB of binary", col);
         return ADBC_STATUS_INTERNAL;
       }

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1139,10 +1139,11 @@ TEST_F(PostgresStatementTest, SqlIngestTimestampOverflow) {
                 IsOkStatus(&error));
     ASSERT_THAT(AdbcStatementPrepare(&statement, &error), IsOkStatus(&error));
     ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
-                IsStatus(ADBC_STATUS_INVALID_ARGUMENT, &error));
-    ASSERT_THAT(error.message,
-                ::testing::HasSubstr("Row #1 has value '9223372036854775807' which "
-                                     "exceeds PostgreSQL timestamp limits"));
+                IsStatus(ADBC_STATUS_INTERNAL, &error));
+    ASSERT_THAT(
+        error.message,
+        ::testing::HasSubstr(
+            "Row 0 timestamp value 9223372036854775807 with unit 0 would overflow"));
   }
 
   {
@@ -1169,10 +1170,11 @@ TEST_F(PostgresStatementTest, SqlIngestTimestampOverflow) {
                 IsOkStatus(&error));
     ASSERT_THAT(AdbcStatementPrepare(&statement, &error), IsOkStatus(&error));
     ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
-                IsStatus(ADBC_STATUS_INVALID_ARGUMENT, &error));
-    ASSERT_THAT(error.message,
-                ::testing::HasSubstr("Row #1 has value '-9223372036854775808' which "
-                                     "exceeds PostgreSQL timestamp limits"));
+                IsStatus(ADBC_STATUS_INTERNAL, &error));
+    ASSERT_THAT(
+        error.message,
+        ::testing::HasSubstr(
+            "Row 0 timestamp value -9223372036854775808 with unit 0 would overflow"));
   }
 }
 

--- a/c/driver/postgresql/result_reader.cc
+++ b/c/driver/postgresql/result_reader.cc
@@ -142,7 +142,7 @@ AdbcStatusCode PqResultArrayReader::Initialize(int64_t* rows_affected,
   // there is a result with more than zero rows to populate.
   if (bind_stream_) {
     RAISE_ADBC(bind_stream_->Begin([] { return ADBC_STATUS_OK; }, error));
-    RAISE_ADBC(bind_stream_->SetParamTypes(*type_resolver_, error));
+    RAISE_ADBC(bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_, error));
     RAISE_ADBC(helper_.Prepare(bind_stream_->param_types, error));
 
     RAISE_ADBC(BindNextAndExecute(nullptr, error));
@@ -251,7 +251,7 @@ AdbcStatusCode PqResultArrayReader::ExecuteAll(int64_t* affected_rows, AdbcError
   // stream (if there is one) or execute the query without binding.
   if (bind_stream_) {
     RAISE_ADBC(bind_stream_->Begin([] { return ADBC_STATUS_OK; }, error));
-    RAISE_ADBC(bind_stream_->SetParamTypes(*type_resolver_, error));
+    RAISE_ADBC(bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_, error));
     RAISE_ADBC(helper_.Prepare(bind_stream_->param_types, error));
 
     // Reset affected rows to zero before binding and executing any

--- a/c/driver/postgresql/result_reader.h
+++ b/c/driver/postgresql/result_reader.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+
 #include <memory>
 #include <string>
 #include <utility>

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -456,6 +456,7 @@ AdbcStatusCode PostgresStatement::ExecuteBind(struct ArrowArrayStream* stream,
                                               int64_t* rows_affected,
                                               struct AdbcError* error) {
   PqResultArrayReader reader(connection_->conn(), type_resolver_, query_);
+  reader.SetAutocommit(connection_->autocommit());
   reader.SetBind(&bind_);
   RAISE_ADBC(reader.ToArrayStream(rows_affected, stream, error));
   return ADBC_STATUS_OK;

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -534,8 +534,8 @@ class StatementTest {
   TEST_F(FIXTURE, SqlPrepareErrorNoQuery) { TestSqlPrepareErrorNoQuery(); }             \
   TEST_F(FIXTURE, SqlPrepareErrorParamCountMismatch) {                                  \
     TestSqlPrepareErrorParamCountMismatch();                                            \
-  }   \
-  TEST_F(FIXTURE, SqlBind) { TestSqlBind(); }                               \
+  }                                                                                     \
+  TEST_F(FIXTURE, SqlBind) { TestSqlBind(); }                                           \
   TEST_F(FIXTURE, SqlQueryEmpty) { TestSqlQueryEmpty(); }                               \
   TEST_F(FIXTURE, SqlQueryInts) { TestSqlQueryInts(); }                                 \
   TEST_F(FIXTURE, SqlQueryFloats) { TestSqlQueryFloats(); }                             \

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -358,7 +358,7 @@ class StatementTest {
   void TestNewInit();
   void TestRelease();
 
-  // ---- Type-specific tests --------------------
+  // ---- Type-specific ingest tests -------------
 
   void TestSqlIngestBool();
 
@@ -426,6 +426,8 @@ class StatementTest {
   void TestSqlPrepareUpdateStream();
   void TestSqlPrepareErrorNoQuery();
   void TestSqlPrepareErrorParamCountMismatch();
+
+  void TestSqlBind();
 
   void TestSqlQueryEmpty();
   void TestSqlQueryInts();
@@ -532,7 +534,8 @@ class StatementTest {
   TEST_F(FIXTURE, SqlPrepareErrorNoQuery) { TestSqlPrepareErrorNoQuery(); }             \
   TEST_F(FIXTURE, SqlPrepareErrorParamCountMismatch) {                                  \
     TestSqlPrepareErrorParamCountMismatch();                                            \
-  }                                                                                     \
+  }   \
+  TEST_F(FIXTURE, SqlBind) { TestSqlBind(); }                               \
   TEST_F(FIXTURE, SqlQueryEmpty) { TestSqlQueryEmpty(); }                               \
   TEST_F(FIXTURE, SqlQueryInts) { TestSqlQueryInts(); }                                 \
   TEST_F(FIXTURE, SqlQueryFloats) { TestSqlQueryFloats(); }                             \

--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -2137,6 +2137,10 @@ void StatementTest::TestSqlPrepareErrorParamCountMismatch() {
 }
 
 void StatementTest::TestSqlBind() {
+  if (!quirks()->supports_dynamic_parameter_binding()) {
+    GTEST_SKIP();
+  }
+
   ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
 
   ASSERT_THAT(quirks()->DropTable(&connection, "bindtest", &error), IsOkStatus(&error));

--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -2166,6 +2166,7 @@ void StatementTest::TestSqlBind() {
                       ")";
   ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, insert_query.c_str(), &error),
               IsOkStatus(&error));
+  ASSERT_THAT(AdbcStatementPrepare(&statement, &error), IsOkStatus(&error));
   ASSERT_THAT(AdbcStatementBind(&statement, &array.value, &schema.value, &error),
               IsOkStatus(&error));
   int64_t rows_affected = -10;

--- a/c/validation/adbc_validation_util.h
+++ b/c/validation/adbc_validation_util.h
@@ -401,42 +401,22 @@ void CompareArray(struct ArrowArrayView* array,
     SCOPED_TRACE("Array index " + std::to_string(i));
     if (v.has_value()) {
       ASSERT_FALSE(ArrowArrayViewIsNull(array, i));
-      if constexpr (std::is_same<T, float>::value) {
+      if constexpr (std::is_same<T, float>::value || std::is_same<T, double>::value) {
         ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, array->buffer_views[1].data.as_float[i]);
-      } else if constexpr (std::is_same<T, double>::value) {
+        ASSERT_EQ(ArrowArrayViewGetDoubleUnsafe(array, i), *v);
+      } else if constexpr (std::is_same<T, bool>::value ||
+                           std::is_same<T, int8_t>::value ||
+                           std::is_same<T, int16_t>::value ||
+                           std::is_same<T, int32_t>::value ||
+                           std::is_same<T, int64_t>::value) {
         ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, array->buffer_views[1].data.as_double[i]);
-      } else if constexpr (std::is_same<T, float>::value) {
+        ASSERT_EQ(ArrowArrayViewGetIntUnsafe(array, i), *v);
+      } else if constexpr (std::is_same<T, uint8_t>::value ||
+                           std::is_same<T, uint16_t>::value ||
+                           std::is_same<T, uint32_t>::value ||
+                           std::is_same<T, uint64_t>::value) {
         ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, array->buffer_views[1].data.as_float[i]);
-      } else if constexpr (std::is_same<T, bool>::value) {
-        ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, ArrowBitGet(array->buffer_views[1].data.as_uint8, i));
-      } else if constexpr (std::is_same<T, int8_t>::value) {
-        ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, array->buffer_views[1].data.as_int8[i]);
-      } else if constexpr (std::is_same<T, int16_t>::value) {
-        ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, array->buffer_views[1].data.as_int16[i]);
-      } else if constexpr (std::is_same<T, int32_t>::value) {
-        ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, array->buffer_views[1].data.as_int32[i]);
-      } else if constexpr (std::is_same<T, int64_t>::value) {
-        ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, array->buffer_views[1].data.as_int64[i]);
-      } else if constexpr (std::is_same<T, uint8_t>::value) {
-        ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, array->buffer_views[1].data.as_uint8[i]);
-      } else if constexpr (std::is_same<T, uint16_t>::value) {
-        ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, array->buffer_views[1].data.as_uint16[i]);
-      } else if constexpr (std::is_same<T, uint32_t>::value) {
-        ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, array->buffer_views[1].data.as_uint32[i]);
-      } else if constexpr (std::is_same<T, uint64_t>::value) {
-        ASSERT_NE(array->buffer_views[1].data.data, nullptr);
-        ASSERT_EQ(*v, array->buffer_views[1].data.as_uint64[i]);
+        ASSERT_EQ(ArrowArrayViewGetUIntUnsafe(array, i), *v);
       } else if constexpr (std::is_same<T, std::string>::value) {
         struct ArrowStringView view = ArrowArrayViewGetStringUnsafe(array, i);
         std::string str(view.data, view.size_bytes);


### PR DESCRIPTION
This PR refactors the `BindStream` to use the COPY writer instead of its own serialization logic. This logic is the same between insertion and binding, although the API used to send it to the database is slightly different. This is a helpful consolidation of logic and means that adding type support on the Arrow or Postgresql side (or fixing bugs in the inference or serialization) is slightly easier. It also means we can bind parameters that are lists and is a workaround for inserting into a table with a schema where Postgres knows how to cast the types (but ADBC might not yet).

``` r
library(adbcdrivermanager)
library(nanoarrow)

con <- adbc_database_init(
  adbcpostgresql::adbcpostgresql(),
  uri = "postgresql://localhost:5432/postgres?user=postgres&password=password"
) |> 
  adbc_connection_init()

# Create an array with a uint32 column
df <- tibble::tibble(uint32_col = 1:5)
array <- df |> 
  nanoarrow::as_nanoarrow_array(
    schema = na_struct(list(uint32_col = na_uint32()))
  )

# Create a table with an integer column
con |> execute_adbc("DROP TABLE IF EXISTS adbc_test")
con |> execute_adbc("CREATE TABLE adbc_test (uint32_col int4)")

# This will fail (types not identical)
array |> write_adbc(con, "adbc_test", mode = "append")
#> Error in adbc_statement_execute_query(stmt): INVALID_ARGUMENT: [libpq] Failed to execute COPY statement: PGRES_FATAL_ERROR ERROR:  incorrect binary data format
#> CONTEXT:  COPY adbc_test, line 1, column uint32_col

con |> 
  execute_adbc("INSERT INTO adbc_test VALUES ($1)", bind = array)
con |> 
  read_adbc("SELECT * FROM adbc_test") |> 
  tibble::as_tibble()
#> # A tibble: 5 × 1
#>   uint32_col
#>        <int>
#> 1          1
#> 2          2
#> 3          3
#> 4          4
#> 5          5
```

<sup>Created on 2024-09-12 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>