### PR TITLE
fix(go/adbc/driver/snowflake): fix setting database and schema context after initial connection

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/AdbcConnection.cs
+++ b/csharp/src/Apache.Arrow.Adbc/AdbcConnection.cs
@@ -31,6 +31,11 @@ namespace Apache.Arrow.Adbc
         private bool _readOnly = false;
         private IsolationLevel _isolationLevel = IsolationLevel.Default;
 
+        public static string CurrentCatalogOption = "adbc.connection.catalog";
+        public static string CurrentDbSchemaOption = "adbc.connection.db_schema";
+        public static string ReadOnlyOption = "adbc.connection.readonly";
+        public static string AutoCommitOption = "adbc.connection.autocommit";
+
         /// <summary>
         /// Commit the pending transaction.
         /// </summary>

--- a/csharp/src/Apache.Arrow.Adbc/AdbcConnection.cs
+++ b/csharp/src/Apache.Arrow.Adbc/AdbcConnection.cs
@@ -31,11 +31,6 @@ namespace Apache.Arrow.Adbc
         private bool _readOnly = false;
         private IsolationLevel _isolationLevel = IsolationLevel.Default;
 
-        public static string CurrentCatalogOption = "adbc.connection.catalog";
-        public static string CurrentDbSchemaOption = "adbc.connection.db_schema";
-        public static string ReadOnlyOption = "adbc.connection.readonly";
-        public static string AutoCommitOption = "adbc.connection.autocommit";
-
         /// <summary>
         /// Commit the pending transaction.
         /// </summary>

--- a/csharp/src/Apache.Arrow.Adbc/AdbcConnection11.cs
+++ b/csharp/src/Apache.Arrow.Adbc/AdbcConnection11.cs
@@ -32,10 +32,6 @@ namespace Apache.Arrow.Adbc
         , IAsyncDisposable
 #endif
     {
-        public static string CurrentCatalogOption = "adbc.connection.catalog";
-        public static string CurrentDbSchemaOption = "adbc.connection.db_schema";
-        public static string ReadOnlyOption = "adbc.connection.readonly";
-        public static string AutoCommitOption = "adbc.connection.autocommit";
 
         ~AdbcConnection11() => Dispose(false);
 

--- a/csharp/src/Apache.Arrow.Adbc/AdbcConnection11.cs
+++ b/csharp/src/Apache.Arrow.Adbc/AdbcConnection11.cs
@@ -32,6 +32,11 @@ namespace Apache.Arrow.Adbc
         , IAsyncDisposable
 #endif
     {
+        public static string CurrentCatalogOption = "adbc.connection.catalog";
+        public static string CurrentDbSchemaOption = "adbc.connection.db_schema";
+        public static string ReadOnlyOption = "adbc.connection.readonly";
+        public static string AutoCommitOption = "adbc.connection.autocommit";
+
         ~AdbcConnection11() => Dispose(false);
 
         /// <summary>

--- a/csharp/test/Drivers/Interop/Snowflake/DriverTests.cs
+++ b/csharp/test/Drivers/Interop/Snowflake/DriverTests.cs
@@ -139,7 +139,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Interop.Snowflake
             using AdbcDatabase localDatabase = localSnowflakeDriver.Open(parameters);
             using AdbcConnection localConnection = localDatabase.Connect(options);
 
-            localConnection.SetOption(AdbcConnection.CurrentCatalogOption, _testConfiguration.Metadata.Catalog);
+            localConnection.SetOption(AdbcOptions.Connection.CurrentCatalog, _testConfiguration.Metadata.Catalog);
 
             Assert.True(CurrentDatabaseIsExpectedCatalog(localConnection, _testConfiguration.Metadata.Catalog));
 

--- a/go/adbc/driver/snowflake/connection.go
+++ b/go/adbc/driver/snowflake/connection.go
@@ -165,7 +165,7 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 	// the connection that is used is not the same connection context where the database may have been set
 	// if the caller called SetCurrentCatalog() so need to ensure the database context is appropriate
 	if !isNilOrEmpty(catalog) {
-		_, e := conn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE %s;", quoteTblName(*catalog)), nil)
+		_, e := conn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE IDENTIFIER('%s');", *catalog), nil)
 		if e != nil {
 			return nil, errToAdbcErr(adbc.StatusIO, e)
 		}
@@ -174,7 +174,7 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 	// the connection that is used is not the same connection context where the schema may have been set
 	// if the caller called SetCurrentDbSchema() so need to ensure the schema context is appropriate
 	if !isNilOrEmpty(dbSchema) {
-		_, e2 := conn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA %s;", quoteTblName(*dbSchema)), nil)
+		_, e2 := conn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA IDENTIFIER('%s');", *dbSchema), nil)
 		if e2 != nil {
 			return nil, errToAdbcErr(adbc.StatusIO, e2)
 		}
@@ -261,13 +261,13 @@ func (c *connectionImpl) GetCurrentDbSchema() (string, error) {
 
 // SetCurrentCatalog implements driverbase.CurrentNamespacer.
 func (c *connectionImpl) SetCurrentCatalog(value string) error {
-	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE %s", quoteTblName(value)), nil)
+	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE IDENTIFIER('%s');", value), nil)
 	return err
 }
 
 // SetCurrentDbSchema implements driverbase.CurrentNamespacer.
 func (c *connectionImpl) SetCurrentDbSchema(value string) error {
-	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA %s", quoteTblName(value)), nil)
+	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA IDENTIFIER('%s')", value), nil)
 	return err
 }
 

--- a/go/adbc/driver/snowflake/connection.go
+++ b/go/adbc/driver/snowflake/connection.go
@@ -165,7 +165,7 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 	// the connection that is used is not the same connection context where the database may have been set
 	// if the caller called SetCurrentCatalog() so need to ensure the database context is appropriate
 	if !isNilOrEmpty(catalog) {
-		_, e := conn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE IDENTIFIER('%s');", *catalog), nil)
+		_, e := conn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE %s;", quoteTblName(*catalog)), nil)
 		if e != nil {
 			return nil, errToAdbcErr(adbc.StatusIO, e)
 		}
@@ -174,7 +174,7 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 	// the connection that is used is not the same connection context where the schema may have been set
 	// if the caller called SetCurrentDbSchema() so need to ensure the schema context is appropriate
 	if !isNilOrEmpty(dbSchema) {
-		_, e2 := conn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA IDENTIFIER('%s');", *dbSchema), nil)
+		_, e2 := conn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA %s;", quoteTblName(*dbSchema)), nil)
 		if e2 != nil {
 			return nil, errToAdbcErr(adbc.StatusIO, e2)
 		}
@@ -261,13 +261,13 @@ func (c *connectionImpl) GetCurrentDbSchema() (string, error) {
 
 // SetCurrentCatalog implements driverbase.CurrentNamespacer.
 func (c *connectionImpl) SetCurrentCatalog(value string) error {
-	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE IDENTIFIER('%s');", value), nil)
+	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE %s;", quoteTblName(value)), nil)
 	return err
 }
 
 // SetCurrentDbSchema implements driverbase.CurrentNamespacer.
 func (c *connectionImpl) SetCurrentDbSchema(value string) error {
-	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA IDENTIFIER('%s')", value), nil)
+	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA %s;", quoteTblName(value)), nil)
 	return err
 }
 

--- a/go/adbc/driver/snowflake/connection.go
+++ b/go/adbc/driver/snowflake/connection.go
@@ -165,7 +165,7 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 	// the connection that is used is not the same connection context where the database may have been set
 	// if the caller called SetCurrentCatalog() so need to ensure the database context is appropriate
 	if !isNilOrEmpty(catalog) {
-		_, e := conn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE %s;", *catalog), nil)
+		_, e := conn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE %s;", quoteTblName(*catalog)), nil)
 		if e != nil {
 			return nil, errToAdbcErr(adbc.StatusIO, e)
 		}
@@ -174,7 +174,7 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 	// the connection that is used is not the same connection context where the schema may have been set
 	// if the caller called SetCurrentDbSchema() so need to ensure the schema context is appropriate
 	if !isNilOrEmpty(dbSchema) {
-		_, e2 := conn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA %s;", *dbSchema), nil)
+		_, e2 := conn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA %s;", quoteTblName(*dbSchema)), nil)
 		if e2 != nil {
 			return nil, errToAdbcErr(adbc.StatusIO, e2)
 		}
@@ -261,13 +261,13 @@ func (c *connectionImpl) GetCurrentDbSchema() (string, error) {
 
 // SetCurrentCatalog implements driverbase.CurrentNamespacer.
 func (c *connectionImpl) SetCurrentCatalog(value string) error {
-	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE %s", value), nil)
+	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE DATABASE %s", quoteTblName(value)), nil)
 	return err
 }
 
 // SetCurrentDbSchema implements driverbase.CurrentNamespacer.
 func (c *connectionImpl) SetCurrentDbSchema(value string) error {
-	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA %s", value), nil)
+	_, err := c.cn.ExecContext(context.Background(), fmt.Sprintf("USE SCHEMA %s", quoteTblName(value)), nil)
 	return err
 }
 

--- a/go/adbc/driver/snowflake/driver_test.go
+++ b/go/adbc/driver/snowflake/driver_test.go
@@ -264,7 +264,6 @@ func createTempSchema(database string, uri string) string {
 }
 
 func dropTempSchema(uri, schema string) {
-
 	db, err := sql.Open("snowflake", uri)
 	if err != nil {
 		panic(err)
@@ -2137,12 +2136,11 @@ func (suite *SnowflakeTests) TestChangeDatabaseAndGetObjects() {
 	cfg, err := gosnowflake.ParseDSN(uri)
 	suite.NoError(err)
 
-	db := newCatalog
 	cnxnopt, ok := suite.cnxn.(adbc.PostInitOptions)
 	suite.True(ok)
-	err = cnxnopt.SetOption(adbc.OptionKeyCurrentCatalog, db)
+	err = cnxnopt.SetOption(adbc.OptionKeyCurrentCatalog, newCatalog)
 	suite.NoError(err)
 
-	_, err2 := suite.cnxn.GetObjects(suite.ctx, adbc.ObjectDepthAll, &db, &cfg.Schema, &getObjectsTable, nil, nil)
+	_, err2 := suite.cnxn.GetObjects(suite.ctx, adbc.ObjectDepthAll, &newCatalog, &cfg.Schema, &getObjectsTable, nil, nil)
 	suite.NoError(err2)
 }

--- a/go/adbc/driver/snowflake/driver_test.go
+++ b/go/adbc/driver/snowflake/driver_test.go
@@ -264,6 +264,7 @@ func createTempSchema(database string, uri string) string {
 }
 
 func dropTempSchema(uri, schema string) {
+
 	db, err := sql.Open("snowflake", uri)
 	if err != nil {
 		panic(err)
@@ -2110,4 +2111,38 @@ func TestIngestCancelContext(t *testing.T) {
 
 		require.Equal(t, "", buf.String())
 	})
+}
+
+func (suite *SnowflakeTests) TestChangeDatabaseAndGetObjects() {
+	// this test demonstrates:
+	// 1. changing the database context
+	// 2. being able to call GetObjects after changing the database context
+	//    (this uses a different connection context but still executes successfully)
+
+	uri, ok := os.LookupEnv("SNOWFLAKE_URI")
+	if !ok {
+		suite.T().Skip("Cannot find the `SNOWFLAKE_URI` value")
+	}
+
+	newCatalog, ok := os.LookupEnv("SNOWFLAKE_NEW_CATALOG")
+	if !ok {
+		suite.T().Skip("Cannot find the `SNOWFLAKE_NEW_CATALOG` value")
+	}
+
+	getObjectsTable, ok := os.LookupEnv("SNOWFLAKE_TABLE_GETOBJECTS")
+	if !ok {
+		suite.T().Skip("Cannot find the `SNOWFLAKE_TABLE_GETOBJECTS` value")
+	}
+
+	cfg, err := gosnowflake.ParseDSN(uri)
+	suite.NoError(err)
+
+	db := newCatalog
+	cnxnopt, ok := suite.cnxn.(adbc.PostInitOptions)
+	suite.True(ok)
+	err = cnxnopt.SetOption(adbc.OptionKeyCurrentCatalog, db)
+	suite.NoError(err)
+
+	_, err2 := suite.cnxn.GetObjects(suite.ctx, adbc.ObjectDepthAll, &db, &cfg.Schema, &getObjectsTable, nil, nil)
+	suite.NoError(err2)
 }


### PR DESCRIPTION
This PR removes the parameterization for calls to USE DATABASE and USE SCHEMA, which isn't supported for Snowflake DDL. It also modifies the GetObjects call to set the context to the database and schema, since the GetObjects call uses a sql.DB connection context instead of the snowflakeConn connection context. 

Fixes https://github.com/apache/arrow-adbc/issues/2167

Fixes https://github.com/apache/arrow-adbc/issues/2168

