### PR TITLE
refactor(c/driver/postgresql): Use Status instead of AdbcStatusCode/AdbcError in result helper

### DIFF
--- a/c/driver/common/utils.c
+++ b/c/driver/common/utils.c
@@ -235,6 +235,10 @@ struct AdbcErrorDetail CommonErrorGetDetail(const struct AdbcError* error, int i
   };
 }
 
+bool IsCommonError(const struct AdbcError* error) {
+  return error->release == ReleaseErrorWithDetails || error->release == ReleaseError;
+}
+
 int StringBuilderInit(struct StringBuilder* builder, size_t initial_size) {
   builder->buffer = (char*)malloc(initial_size);
   if (builder->buffer == NULL) return errno;

--- a/c/driver/common/utils.h
+++ b/c/driver/common/utils.h
@@ -53,6 +53,7 @@ void AppendErrorDetail(struct AdbcError* error, const char* key, const uint8_t* 
 
 int CommonErrorGetDetailCount(const struct AdbcError* error);
 struct AdbcErrorDetail CommonErrorGetDetail(const struct AdbcError* error, int index);
+bool IsCommonError(const struct AdbcError* error);
 
 struct StringBuilder {
   char* buffer;

--- a/c/driver/framework/status.h
+++ b/c/driver/framework/status.h
@@ -126,7 +126,7 @@ class Status {
   }
 
   // Helpers to create statuses with known codes
-  static Status Ok() { return driver::Status(); }
+  static Status Ok() { return Status(); }
 
 #define STATUS_CTOR(NAME, CODE)                  \
   template <typename... Args>                    \

--- a/c/driver/framework/status.h
+++ b/c/driver/framework/status.h
@@ -69,6 +69,19 @@ class Status {
     impl_->details.push_back({std::move(key), std::move(value)});
   }
 
+  /// \brief Set the sqlstate of this status
+  void SetSqlState(std::string sqlstate) {
+    assert(impl_ != nullptr);
+    std::memset(impl_->sql_state, 0, sizeof(impl_->sql_state));
+    for (size_t i = 0; i < sqlstate.size(); i++) {
+      if (i >= sizeof(impl_->sql_state)) {
+        break;
+      }
+
+      impl_->sql_state[i] = sqlstate[i];
+    }
+  }
+
   /// \brief Export this status to an AdbcError.
   AdbcStatusCode ToAdbc(AdbcError* adbc_error) const {
     if (impl_ == nullptr) return ADBC_STATUS_OK;

--- a/c/driver/framework/status.h
+++ b/c/driver/framework/status.h
@@ -125,6 +125,27 @@ class Status {
     return status;
   }
 
+  // Helpers to create statuses with known codes
+  static Status Ok() { return driver::Status(); }
+
+#define STATUS_CTOR(NAME, CODE)                  \
+  template <typename... Args>                    \
+  static Status NAME(Args&&... args) {           \
+    std::stringstream ss;                        \
+    ([&] { ss << args; }(), ...);                \
+    return Status(ADBC_STATUS_##CODE, ss.str()); \
+  }
+
+  STATUS_CTOR(Internal, INTERNAL)
+  STATUS_CTOR(InvalidArgument, INVALID_ARGUMENT)
+  STATUS_CTOR(InvalidState, INVALID_STATE)
+  STATUS_CTOR(IO, IO)
+  STATUS_CTOR(NotFound, NOT_FOUND)
+  STATUS_CTOR(NotImplemented, NOT_IMPLEMENTED)
+  STATUS_CTOR(Unknown, UNKNOWN)
+
+#undef STATUS_CTOR
+
  private:
   struct Impl {
     // invariant: code is never OK

--- a/c/driver/framework/status.h
+++ b/c/driver/framework/status.h
@@ -146,6 +146,8 @@ class Status {
   template <typename DatabaseT, typename ConnectionT, typename StatementT>
   friend class Driver;
 
+  // Allow access to these for drivers transitioning to the framework
+ public:
   int CDetailCount() const { return impl_ ? static_cast<int>(impl_->details.size()) : 0; }
 
   AdbcErrorDetail CDetail(int index) const {
@@ -157,6 +159,7 @@ class Status {
             detail.second.size()};
   }
 
+ private:
   static void CRelease(AdbcError* error) {
     if (error->vendor_code == ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA) {
       auto* error_obj = reinterpret_cast<Status*>(error->private_data);

--- a/c/driver/postgresql/error.cc
+++ b/c/driver/postgresql/error.cc
@@ -17,8 +17,8 @@
 
 #include "error.h"
 
-#include <postgres_ext.h>
 #include <stdarg.h>
+#include <stdio.h>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -31,46 +31,25 @@ namespace adbcpq {
 
 AdbcStatusCode SetError(struct AdbcError* error, PGresult* result, const char* format,
                         ...) {
+  if (!error && error->release) {
+    // TODO: combine the errors if possible
+    error->release(error);
+  }
+
   va_list args;
   va_start(args, format);
-  SetErrorVariadic(error, format, args);
+  std::string message;
+  message.resize(1024);
+  int chars_needed = vsnprintf(message.data(), message.size(), format, args);
   va_end(args);
 
-  AdbcStatusCode code = ADBC_STATUS_IO;
-
-  const char* sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
-  if (sqlstate) {
-    // https://www.postgresql.org/docs/current/errcodes-appendix.html
-    // This can be extended in the future
-    if (std::strcmp(sqlstate, "57014") == 0) {
-      code = ADBC_STATUS_CANCELLED;
-    } else if (std::strcmp(sqlstate, "42P01") == 0 ||
-               std::strcmp(sqlstate, "42602") == 0) {
-      code = ADBC_STATUS_NOT_FOUND;
-    } else if (std::strncmp(sqlstate, "42", 0) == 0) {
-      // Class 42 — Syntax Error or Access Rule Violation
-      code = ADBC_STATUS_INVALID_ARGUMENT;
-    }
-
-    static_assert(sizeof(error->sqlstate) == 5, "");
-    // N.B. strncpy generates warnings when used for this purpose
-    int i = 0;
-    for (; sqlstate[i] != '\0' && i < 5; i++) {
-      error->sqlstate[i] = sqlstate[i];
-    }
-    for (; i < 5; i++) {
-      error->sqlstate[i] = '\0';
-    }
+  if (chars_needed > 0) {
+    message.resize(chars_needed);
+  } else {
+    message.resize(0);
   }
 
-  for (const auto& field : kDetailFields) {
-    const char* value = PQresultErrorField(result, field.code);
-    if (value) {
-      AppendErrorDetail(error, field.key.c_str(), reinterpret_cast<const uint8_t*>(value),
-                        std::strlen(value));
-    }
-  }
-  return code;
+  return MakeStatus(result, "{}", message).ToAdbc(error);
 }
 
 }  // namespace adbcpq

--- a/c/driver/postgresql/error.cc
+++ b/c/driver/postgresql/error.cc
@@ -31,7 +31,7 @@ namespace adbcpq {
 
 AdbcStatusCode SetError(struct AdbcError* error, PGresult* result, const char* format,
                         ...) {
-  if (!error && error->release) {
+  if (error && error->release) {
     // TODO: combine the errors if possible
     error->release(error);
   }

--- a/c/driver/postgresql/error.cc
+++ b/c/driver/postgresql/error.cc
@@ -29,30 +29,6 @@
 
 namespace adbcpq {
 
-namespace {
-struct DetailField {
-  int code;
-  std::string key;
-};
-
-static const std::vector<DetailField> kDetailFields = {
-    {PG_DIAG_COLUMN_NAME, "PG_DIAG_COLUMN_NAME"},
-    {PG_DIAG_CONTEXT, "PG_DIAG_CONTEXT"},
-    {PG_DIAG_CONSTRAINT_NAME, "PG_DIAG_CONSTRAINT_NAME"},
-    {PG_DIAG_DATATYPE_NAME, "PG_DIAG_DATATYPE_NAME"},
-    {PG_DIAG_INTERNAL_POSITION, "PG_DIAG_INTERNAL_POSITION"},
-    {PG_DIAG_INTERNAL_QUERY, "PG_DIAG_INTERNAL_QUERY"},
-    {PG_DIAG_MESSAGE_PRIMARY, "PG_DIAG_MESSAGE_PRIMARY"},
-    {PG_DIAG_MESSAGE_DETAIL, "PG_DIAG_MESSAGE_DETAIL"},
-    {PG_DIAG_MESSAGE_HINT, "PG_DIAG_MESSAGE_HINT"},
-    {PG_DIAG_SEVERITY_NONLOCALIZED, "PG_DIAG_SEVERITY_NONLOCALIZED"},
-    {PG_DIAG_SQLSTATE, "PG_DIAG_SQLSTATE"},
-    {PG_DIAG_STATEMENT_POSITION, "PG_DIAG_STATEMENT_POSITION"},
-    {PG_DIAG_SCHEMA_NAME, "PG_DIAG_SCHEMA_NAME"},
-    {PG_DIAG_TABLE_NAME, "PG_DIAG_TABLE_NAME"},
-};
-}  // namespace
-
 AdbcStatusCode SetError(struct AdbcError* error, PGresult* result, const char* format,
                         ...) {
   va_list args;

--- a/c/driver/postgresql/error.h
+++ b/c/driver/postgresql/error.h
@@ -88,19 +88,10 @@ Status MakeStatus(PGresult* result, const char* format_string, Args&&... args) {
       // Class 42 — Syntax Error or Access Rule Violation
       code = ADBC_STATUS_INVALID_ARGUMENT;
     }
-
-    static_assert(sizeof(sqlstate_out) == 5, "");
-    // N.B. strncpy generates warnings when used for this purpose
-    int i = 0;
-    for (; sqlstate[i] != '\0' && i < 5; i++) {
-      sqlstate_out[i] = sqlstate[i];
-    }
-    for (; i < 5; i++) {
-      sqlstate_out[i] = '\0';
-    }
   }
 
   Status status(code, message);
+  status.SetSqlState(sqlstate);
   for (const auto& field : kDetailFields) {
     const char* value = PQresultErrorField(result, field.code);
     if (value) {

--- a/c/driver/postgresql/error.h
+++ b/c/driver/postgresql/error.h
@@ -22,7 +22,35 @@
 #include <arrow-adbc/adbc.h>
 #include <libpq-fe.h>
 
+#include <fmt/core.h>
+
+#include "driver/framework/status.h"
+
+using adbc::driver::Status;
+
 namespace adbcpq {
+
+struct DetailField {
+  int code;
+  std::string key;
+};
+
+static const std::vector<DetailField> kDetailFields = {
+    {PG_DIAG_COLUMN_NAME, "PG_DIAG_COLUMN_NAME"},
+    {PG_DIAG_CONTEXT, "PG_DIAG_CONTEXT"},
+    {PG_DIAG_CONSTRAINT_NAME, "PG_DIAG_CONSTRAINT_NAME"},
+    {PG_DIAG_DATATYPE_NAME, "PG_DIAG_DATATYPE_NAME"},
+    {PG_DIAG_INTERNAL_POSITION, "PG_DIAG_INTERNAL_POSITION"},
+    {PG_DIAG_INTERNAL_QUERY, "PG_DIAG_INTERNAL_QUERY"},
+    {PG_DIAG_MESSAGE_PRIMARY, "PG_DIAG_MESSAGE_PRIMARY"},
+    {PG_DIAG_MESSAGE_DETAIL, "PG_DIAG_MESSAGE_DETAIL"},
+    {PG_DIAG_MESSAGE_HINT, "PG_DIAG_MESSAGE_HINT"},
+    {PG_DIAG_SEVERITY_NONLOCALIZED, "PG_DIAG_SEVERITY_NONLOCALIZED"},
+    {PG_DIAG_SQLSTATE, "PG_DIAG_SQLSTATE"},
+    {PG_DIAG_STATEMENT_POSITION, "PG_DIAG_STATEMENT_POSITION"},
+    {PG_DIAG_SCHEMA_NAME, "PG_DIAG_SCHEMA_NAME"},
+    {PG_DIAG_TABLE_NAME, "PG_DIAG_TABLE_NAME"},
+};
 
 // The printf checking attribute doesn't work properly on gcc 4.8
 // and results in spurious compiler warnings
@@ -38,5 +66,49 @@ AdbcStatusCode SetError(struct AdbcError* error, PGresult* result, const char* f
                         ...) ADBC_CHECK_PRINTF_ATTRIBUTE(3, 4);
 
 #undef ADBC_CHECK_PRINTF_ATTRIBUTE
+
+template <typename... Args>
+Status MakeStatus(PGresult* result, const char* format_string, Args&&... args) {
+  auto message = ::fmt::vformat(format_string, ::fmt::make_format_args(args...));
+
+  AdbcStatusCode code = ADBC_STATUS_IO;
+  char sqlstate_out[5];
+  std::memset(sqlstate_out, 0, sizeof(sqlstate_out));
+
+  const char* sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
+  if (sqlstate) {
+    // https://www.postgresql.org/docs/current/errcodes-appendix.html
+    // This can be extended in the future
+    if (std::strcmp(sqlstate, "57014") == 0) {
+      code = ADBC_STATUS_CANCELLED;
+    } else if (std::strcmp(sqlstate, "42P01") == 0 ||
+               std::strcmp(sqlstate, "42602") == 0) {
+      code = ADBC_STATUS_NOT_FOUND;
+    } else if (std::strncmp(sqlstate, "42", 0) == 0) {
+      // Class 42 — Syntax Error or Access Rule Violation
+      code = ADBC_STATUS_INVALID_ARGUMENT;
+    }
+
+    static_assert(sizeof(sqlstate_out) == 5, "");
+    // N.B. strncpy generates warnings when used for this purpose
+    int i = 0;
+    for (; sqlstate[i] != '\0' && i < 5; i++) {
+      sqlstate_out[i] = sqlstate[i];
+    }
+    for (; i < 5; i++) {
+      sqlstate_out[i] = '\0';
+    }
+  }
+
+  Status status(code, message);
+  for (const auto& field : kDetailFields) {
+    const char* value = PQresultErrorField(result, field.code);
+    if (value) {
+      status.AddDetail(field.key, value);
+    }
+  }
+
+  return status;
+}
 
 }  // namespace adbcpq

--- a/c/driver/postgresql/error.h
+++ b/c/driver/postgresql/error.h
@@ -19,6 +19,9 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include <arrow-adbc/adbc.h>
 #include <libpq-fe.h>
 

--- a/c/driver/postgresql/error.h
+++ b/c/driver/postgresql/error.h
@@ -64,7 +64,8 @@ static const std::vector<DetailField> kDetailFields = {
 #endif
 
 /// \brief Set an error based on a PGresult, inferring the proper ADBC status
-///   code from the PGresult.
+///   code from the PGresult. Deprecated and is currently a thin wrapper around
+///   MakeStatus() below.
 AdbcStatusCode SetError(struct AdbcError* error, PGresult* result, const char* format,
                         ...) ADBC_CHECK_PRINTF_ATTRIBUTE(3, 4);
 
@@ -77,6 +78,10 @@ Status MakeStatus(PGresult* result, const char* format_string, Args&&... args) {
   AdbcStatusCode code = ADBC_STATUS_IO;
   char sqlstate_out[5];
   std::memset(sqlstate_out, 0, sizeof(sqlstate_out));
+
+  if (result == nullptr) {
+    return Status(code, message);
+  }
 
   const char* sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
   if (sqlstate) {

--- a/c/driver/postgresql/postgresql.cc
+++ b/c/driver/postgresql/postgresql.cc
@@ -58,9 +58,8 @@ const struct AdbcError* PostgresErrorFromArrayStream(struct ArrowArrayStream* st
   // Currently only valid for TupleReader
   return adbcpq::TupleReader::ErrorFromArrayStream(stream, status);
 }
-}  // namespace
 
-int AdbcErrorGetDetailCount(const struct AdbcError* error) {
+int PostgresErrorGetDetailCount(const struct AdbcError* error) {
   if (IsCommonError(error)) {
     return CommonErrorGetDetailCount(error);
   }
@@ -73,13 +72,22 @@ int AdbcErrorGetDetailCount(const struct AdbcError* error) {
   return error_obj->CDetailCount();
 }
 
-struct AdbcErrorDetail AdbcErrorGetDetail(const struct AdbcError* error, int index) {
+struct AdbcErrorDetail PostgresErrorGetDetail(const struct AdbcError* error, int index) {
   if (IsCommonError(error)) {
     return CommonErrorGetDetail(error, index);
   }
 
   auto error_obj = reinterpret_cast<Status*>(error->private_data);
   return error_obj->CDetail(index);
+}
+}  // namespace
+
+int AdbcErrorGetDetailCount(const struct AdbcError* error) {
+  return PostgresErrorGetDetailCount(error);
+}
+
+struct AdbcErrorDetail AdbcErrorGetDetail(const struct AdbcError* error, int index) {
+  return PostgresErrorGetDetail(error, index);
 }
 
 const struct AdbcError* AdbcErrorFromArrayStream(struct ArrowArrayStream* stream,
@@ -876,8 +884,8 @@ AdbcStatusCode PostgresqlDriverInit(int version, void* raw_driver,
   if (version >= ADBC_VERSION_1_1_0) {
     std::memset(driver, 0, ADBC_DRIVER_1_1_0_SIZE);
 
-    driver->ErrorGetDetailCount = CommonErrorGetDetailCount;
-    driver->ErrorGetDetail = CommonErrorGetDetail;
+    driver->ErrorGetDetailCount = PostgresErrorGetDetailCount;
+    driver->ErrorGetDetail = PostgresErrorGetDetail;
     driver->ErrorFromArrayStream = PostgresErrorFromArrayStream;
 
     driver->DatabaseGetOption = PostgresDatabaseGetOption;

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -64,9 +64,8 @@ Status PqResultHelper::DescribePrepared() {
   return adbc::driver::status::Ok();
 }
 
-AdbcStatusCode PqResultHelper::Execute(struct AdbcError* error,
-                                       const std::vector<std::string>& params,
-                                       PostgresType* param_types) {
+Status PqResultHelper::Execute(const std::vector<std::string>& params,
+                               PostgresType* param_types) {
   if (params.size() == 0 && param_types == nullptr && output_format_ == Format::kText) {
     ClearResult();
     result_ = PQexec(conn_, query_.c_str());
@@ -99,13 +98,11 @@ AdbcStatusCode PqResultHelper::Execute(struct AdbcError* error,
 
   ExecStatusType status = PQresultStatus(result_);
   if (status != PGRES_TUPLES_OK && status != PGRES_COMMAND_OK) {
-    AdbcStatusCode status =
-        SetError(error, result_, "[libpq] Failed to execute query '%s': %s",
-                 query_.c_str(), PQerrorMessage(conn_));
-    return status;
+    return MakeStatus(result_, "[libpq] Failed to execute query '{}': {}", query_.c_str(),
+                      PQerrorMessage(conn_));
   }
 
-  return ADBC_STATUS_OK;
+  return adbc::driver::status::Ok();
 }
 
 AdbcStatusCode PqResultHelper::ExecuteCopy(struct AdbcError* error) {

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -20,37 +20,34 @@
 #include <charconv>
 #include <memory>
 
+#define ADBC_FRAMEWORK_USE_FMT
 #include "driver/common/utils.h"
+#include "driver/framework/status.h"
 #include "error.h"
 
 namespace adbcpq {
 
 PqResultHelper::~PqResultHelper() { ClearResult(); }
 
-AdbcStatusCode PqResultHelper::PrepareInternal(int n_params, const Oid* param_oids,
-                                               struct AdbcError* error) {
+Status PqResultHelper::PrepareInternal(int n_params, const Oid* param_oids) {
   // TODO: make stmtName a unique identifier?
   PGresult* result =
       PQprepare(conn_, /*stmtName=*/"", query_.c_str(), n_params, param_oids);
   if (PQresultStatus(result) != PGRES_COMMAND_OK) {
-    AdbcStatusCode code =
-        SetError(error, result, "[libpq] Failed to prepare query: %s\nQuery was:%s",
-                 PQerrorMessage(conn_), query_.c_str());
+    auto status = MakeStatus(result, "Failed to prepare query: {}\nQuery was:{}",
+                             PQerrorMessage(conn_), query_.c_str());
     PQclear(result);
-    return code;
+    return status;
   }
 
   PQclear(result);
-  return ADBC_STATUS_OK;
+  return adbc::driver::status::Ok();
 }
 
-AdbcStatusCode PqResultHelper::Prepare(struct AdbcError* error) {
-  return PrepareInternal(0, nullptr, error);
-}
+Status PqResultHelper::Prepare() { return PrepareInternal(0, nullptr); }
 
-AdbcStatusCode PqResultHelper::Prepare(const std::vector<Oid>& param_oids,
-                                       struct AdbcError* error) {
-  return PrepareInternal(param_oids.size(), param_oids.data(), error);
+Status PqResultHelper::Prepare(const std::vector<Oid>& param_oids) {
+  return PrepareInternal(param_oids.size(), param_oids.data());
 }
 
 AdbcStatusCode PqResultHelper::DescribePrepared(struct AdbcError* error) {

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -105,7 +105,7 @@ Status PqResultHelper::Execute(const std::vector<std::string>& params,
   return adbc::driver::status::Ok();
 }
 
-AdbcStatusCode PqResultHelper::ExecuteCopy(struct AdbcError* error) {
+Status PqResultHelper::ExecuteCopy() {
   // Remove trailing semicolon(s) from the query before feeding it into COPY
   while (!query_.empty() && query_.back() == ';') {
     query_.pop_back();
@@ -119,15 +119,15 @@ AdbcStatusCode PqResultHelper::ExecuteCopy(struct AdbcError* error) {
                          static_cast<int>(Format::kBinary));
 
   if (PQresultStatus(result_) != PGRES_COPY_OUT) {
-    AdbcStatusCode code = SetError(
-        error, result_,
-        "[libpq] Failed to execute query: could not begin COPY: %s\nQuery was: %s",
+    Status status = MakeStatus(
+        result_,
+        "[libpq] Failed to execute query: could not begin COPY: {}\nQuery was: {}",
         PQerrorMessage(conn_), copy_query.c_str());
     ClearResult();
-    return code;
+    return status;
   }
 
-  return ADBC_STATUS_OK;
+  return adbc::driver::status::Ok();
 }
 
 AdbcStatusCode PqResultHelper::ResolveParamTypes(PostgresTypeResolver& type_resolver,

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -50,18 +50,18 @@ Status PqResultHelper::Prepare(const std::vector<Oid>& param_oids) {
   return PrepareInternal(param_oids.size(), param_oids.data());
 }
 
-AdbcStatusCode PqResultHelper::DescribePrepared(struct AdbcError* error) {
+Status PqResultHelper::DescribePrepared() {
   ClearResult();
   result_ = PQdescribePrepared(conn_, /*stmtName=*/"");
   if (PQresultStatus(result_) != PGRES_COMMAND_OK) {
-    AdbcStatusCode code = SetError(
-        error, result_, "[libpq] Failed to describe prepared statement: %s\nQuery was:%s",
+    Status status = MakeStatus(
+        result_, "[libpq] Failed to describe prepared statement: {}\nQuery was:{}",
         PQerrorMessage(conn_), query_.c_str());
     ClearResult();
-    return code;
+    return status;
   }
 
-  return ADBC_STATUS_OK;
+  return adbc::driver::status::Ok();
 }
 
 AdbcStatusCode PqResultHelper::Execute(struct AdbcError* error,

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -156,9 +156,8 @@ Status PqResultHelper::ResolveParamTypes(PostgresTypeResolver& type_resolver,
   return adbc::driver::status::Ok();
 }
 
-AdbcStatusCode PqResultHelper::ResolveOutputTypes(PostgresTypeResolver& type_resolver,
-                                                  PostgresType* result_types,
-                                                  struct AdbcError* error) {
+Status PqResultHelper::ResolveOutputTypes(PostgresTypeResolver& type_resolver,
+                                          PostgresType* result_types) {
   struct ArrowError na_error;
   ArrowErrorInit(&na_error);
 
@@ -169,17 +168,18 @@ AdbcStatusCode PqResultHelper::ResolveOutputTypes(PostgresTypeResolver& type_res
     const Oid pg_oid = PQftype(result_, i);
     PostgresType pg_type;
     if (type_resolver.Find(pg_oid, &pg_type, &na_error) != NANOARROW_OK) {
-      SetError(error, "%s%d%s%s%s%d", "[libpq] Column #", i + 1, " (\"",
-               PQfname(result_, i), "\") has unknown type code ", pg_oid);
+      Status status = adbc::driver::status::NotImplemented(
+          "[libpq] Column #", i + 1, " (\"", PQfname(result_, i),
+          "\") has unknown type code ", pg_oid);
       ClearResult();
-      return ADBC_STATUS_NOT_IMPLEMENTED;
+      return status;
     }
 
     root_type.AppendChild(PQfname(result_, i), pg_type);
   }
 
   *result_types = root_type;
-  return ADBC_STATUS_OK;
+  return adbc::driver::status::Ok();
 }
 
 PGresult* PqResultHelper::ReleaseResult() {

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -40,7 +40,7 @@ Status PqResultHelper::PrepareInternal(int n_params, const Oid* param_oids) {
   }
 
   PQclear(result);
-  return adbc::driver::status::Ok();
+  return Status::Ok();
 }
 
 Status PqResultHelper::Prepare() { return PrepareInternal(0, nullptr); }
@@ -60,7 +60,7 @@ Status PqResultHelper::DescribePrepared() {
     return status;
   }
 
-  return adbc::driver::status::Ok();
+  return Status::Ok();
 }
 
 Status PqResultHelper::Execute(const std::vector<std::string>& params,
@@ -101,7 +101,7 @@ Status PqResultHelper::Execute(const std::vector<std::string>& params,
                       PQerrorMessage(conn_));
   }
 
-  return adbc::driver::status::Ok();
+  return Status::Ok();
 }
 
 Status PqResultHelper::ExecuteCopy() {
@@ -126,7 +126,7 @@ Status PqResultHelper::ExecuteCopy() {
     return status;
   }
 
-  return adbc::driver::status::Ok();
+  return Status::Ok();
 }
 
 Status PqResultHelper::ResolveParamTypes(PostgresTypeResolver& type_resolver,
@@ -141,9 +141,9 @@ Status PqResultHelper::ResolveParamTypes(PostgresTypeResolver& type_resolver,
     const Oid pg_oid = PQparamtype(result_, i);
     PostgresType pg_type;
     if (type_resolver.Find(pg_oid, &pg_type, &na_error) != NANOARROW_OK) {
-      Status status = adbc::driver::status::NotImplemented(
-          "[libpq] Parameter #", i + 1, " (\"", PQfname(result_, i),
-          "\") has unknown type code ", pg_oid);
+      Status status = Status::NotImplemented("[libpq] Parameter #", i + 1, " (\"",
+                                             PQfname(result_, i),
+                                             "\") has unknown type code ", pg_oid);
       ClearResult();
       return status;
     }
@@ -152,7 +152,7 @@ Status PqResultHelper::ResolveParamTypes(PostgresTypeResolver& type_resolver,
   }
 
   *param_types = root_type;
-  return adbc::driver::status::Ok();
+  return Status::Ok();
 }
 
 Status PqResultHelper::ResolveOutputTypes(PostgresTypeResolver& type_resolver,
@@ -167,9 +167,9 @@ Status PqResultHelper::ResolveOutputTypes(PostgresTypeResolver& type_resolver,
     const Oid pg_oid = PQftype(result_, i);
     PostgresType pg_type;
     if (type_resolver.Find(pg_oid, &pg_type, &na_error) != NANOARROW_OK) {
-      Status status = adbc::driver::status::NotImplemented(
-          "[libpq] Column #", i + 1, " (\"", PQfname(result_, i),
-          "\") has unknown type code ", pg_oid);
+      Status status =
+          Status::NotImplemented("[libpq] Column #", i + 1, " (\"", PQfname(result_, i),
+                                 "\") has unknown type code ", pg_oid);
       ClearResult();
       return status;
     }
@@ -178,7 +178,7 @@ Status PqResultHelper::ResolveOutputTypes(PostgresTypeResolver& type_resolver,
   }
 
   *result_types = root_type;
-  return adbc::driver::status::Ok();
+  return Status::Ok();
 }
 
 PGresult* PqResultHelper::ReleaseResult() {

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -21,7 +21,6 @@
 #include <memory>
 
 #define ADBC_FRAMEWORK_USE_FMT
-#include "driver/common/utils.h"
 #include "driver/framework/status.h"
 #include "error.h"
 

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -101,9 +101,8 @@ class PqResultHelper {
   Status Prepare();
   Status Prepare(const std::vector<Oid>& param_oids);
   Status DescribePrepared();
-  AdbcStatusCode Execute(struct AdbcError* error,
-                         const std::vector<std::string>& params = {},
-                         PostgresType* param_types = nullptr);
+  Status Execute(const std::vector<std::string>& params = {},
+                 PostgresType* param_types = nullptr);
   AdbcStatusCode ExecuteCopy(struct AdbcError* error);
   AdbcStatusCode ResolveParamTypes(PostgresTypeResolver& type_resolver,
                                    PostgresType* param_types, struct AdbcError* error);

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -104,8 +104,8 @@ class PqResultHelper {
   Status Execute(const std::vector<std::string>& params = {},
                  PostgresType* param_types = nullptr);
   Status ExecuteCopy();
-  AdbcStatusCode ResolveParamTypes(PostgresTypeResolver& type_resolver,
-                                   PostgresType* param_types, struct AdbcError* error);
+  Status ResolveParamTypes(PostgresTypeResolver& type_resolver,
+                           PostgresType* param_types);
   AdbcStatusCode ResolveOutputTypes(PostgresTypeResolver& type_resolver,
                                     PostgresType* result_types, struct AdbcError* error);
 

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -28,6 +28,9 @@
 #include <libpq-fe.h>
 
 #include "copy/reader.h"
+#include "driver/framework/status.h"
+
+using adbc::driver::Status;
 
 namespace adbcpq {
 
@@ -95,8 +98,8 @@ class PqResultHelper {
   void set_param_format(Format format) { param_format_ = format; }
   void set_output_format(Format format) { output_format_ = format; }
 
-  AdbcStatusCode Prepare(struct AdbcError* error);
-  AdbcStatusCode Prepare(const std::vector<Oid>& param_oids, struct AdbcError* error);
+  Status Prepare();
+  Status Prepare(const std::vector<Oid>& param_oids);
   AdbcStatusCode DescribePrepared(struct AdbcError* error);
   AdbcStatusCode Execute(struct AdbcError* error,
                          const std::vector<std::string>& params = {},
@@ -170,8 +173,7 @@ class PqResultHelper {
   Format param_format_ = Format::kText;
   Format output_format_ = Format::kText;
 
-  AdbcStatusCode PrepareInternal(int n_params, const Oid* param_oids,
-                                 struct AdbcError* error);
+  Status PrepareInternal(int n_params, const Oid* param_oids);
 };
 
 }  // namespace adbcpq

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -103,7 +103,7 @@ class PqResultHelper {
   Status DescribePrepared();
   Status Execute(const std::vector<std::string>& params = {},
                  PostgresType* param_types = nullptr);
-  AdbcStatusCode ExecuteCopy(struct AdbcError* error);
+  Status ExecuteCopy();
   AdbcStatusCode ResolveParamTypes(PostgresTypeResolver& type_resolver,
                                    PostgresType* param_types, struct AdbcError* error);
   AdbcStatusCode ResolveOutputTypes(PostgresTypeResolver& type_resolver,

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -100,7 +100,7 @@ class PqResultHelper {
 
   Status Prepare();
   Status Prepare(const std::vector<Oid>& param_oids);
-  AdbcStatusCode DescribePrepared(struct AdbcError* error);
+  Status DescribePrepared();
   AdbcStatusCode Execute(struct AdbcError* error,
                          const std::vector<std::string>& params = {},
                          PostgresType* param_types = nullptr);

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -106,8 +106,8 @@ class PqResultHelper {
   Status ExecuteCopy();
   Status ResolveParamTypes(PostgresTypeResolver& type_resolver,
                            PostgresType* param_types);
-  AdbcStatusCode ResolveOutputTypes(PostgresTypeResolver& type_resolver,
-                                    PostgresType* result_types, struct AdbcError* error);
+  Status ResolveOutputTypes(PostgresTypeResolver& type_resolver,
+                            PostgresType* result_types);
 
   bool HasResult() { return result_ != nullptr; }
 

--- a/c/driver/postgresql/result_reader.cc
+++ b/c/driver/postgresql/result_reader.cc
@@ -143,7 +143,7 @@ AdbcStatusCode PqResultArrayReader::Initialize(int64_t* rows_affected,
   if (bind_stream_) {
     RAISE_ADBC(bind_stream_->Begin([] { return ADBC_STATUS_OK; }, error));
     RAISE_ADBC(bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_, error));
-    RAISE_ADBC(helper_.Prepare(bind_stream_->param_types, error));
+    RAISE_STATUS(error, helper_.Prepare(bind_stream_->param_types));
 
     RAISE_ADBC(BindNextAndExecute(nullptr, error));
 
@@ -252,7 +252,7 @@ AdbcStatusCode PqResultArrayReader::ExecuteAll(int64_t* affected_rows, AdbcError
   if (bind_stream_) {
     RAISE_ADBC(bind_stream_->Begin([] { return ADBC_STATUS_OK; }, error));
     RAISE_ADBC(bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_, error));
-    RAISE_ADBC(helper_.Prepare(bind_stream_->param_types, error));
+    RAISE_STATUS(error, helper_.Prepare(bind_stream_->param_types));
 
     // Reset affected rows to zero before binding and executing any
     if (affected_rows) {

--- a/c/driver/postgresql/result_reader.cc
+++ b/c/driver/postgresql/result_reader.cc
@@ -151,7 +151,7 @@ AdbcStatusCode PqResultArrayReader::Initialize(int64_t* rows_affected,
     // to populate the schema. If there were any arrays in the bind stream,
     // the last one will still be in helper_ even if it had zero rows.
     if (!helper_.HasResult()) {
-      RAISE_ADBC(helper_.DescribePrepared(error));
+      RAISE_STATUS(error, helper_.DescribePrepared());
     }
 
     // We can't provide affected row counts if there is a bind stream and

--- a/c/driver/postgresql/result_reader.cc
+++ b/c/driver/postgresql/result_reader.cc
@@ -161,7 +161,7 @@ AdbcStatusCode PqResultArrayReader::Initialize(int64_t* rows_affected,
       *rows_affected = -1;
     }
   } else {
-    RAISE_ADBC(helper_.Execute(error));
+    RAISE_STATUS(error, helper_.Execute());
     if (rows_affected != nullptr) {
       *rows_affected = helper_.AffectedRows();
     }
@@ -263,7 +263,7 @@ AdbcStatusCode PqResultArrayReader::ExecuteAll(int64_t* affected_rows, AdbcError
       RAISE_ADBC(BindNextAndExecute(affected_rows, error));
     } while (bind_stream_);
   } else {
-    RAISE_ADBC(helper_.Execute(error));
+    RAISE_STATUS(error, helper_.Execute());
 
     if (affected_rows != nullptr) {
       *affected_rows = helper_.AffectedRows();

--- a/c/driver/postgresql/result_reader.cc
+++ b/c/driver/postgresql/result_reader.cc
@@ -21,9 +21,7 @@
 #include <utility>
 
 #include "copy/reader.h"
-#include "driver/common/utils.h"
-
-#include "error.h"
+#include "driver/framework/status.h"
 
 namespace adbcpq {
 
@@ -31,8 +29,9 @@ int PqResultArrayReader::GetSchema(struct ArrowSchema* out) {
   ResetErrors();
 
   if (schema_->release == nullptr) {
-    AdbcStatusCode status = Initialize(nullptr, &error_);
-    if (status != ADBC_STATUS_OK) {
+    Status status = Initialize(nullptr);
+    if (!status.ok()) {
+      status.ToAdbc(&error_);
       return EINVAL;
     }
   }
@@ -43,10 +42,11 @@ int PqResultArrayReader::GetSchema(struct ArrowSchema* out) {
 int PqResultArrayReader::GetNext(struct ArrowArray* out) {
   ResetErrors();
 
-  AdbcStatusCode status;
+  Status status;
   if (schema_->release == nullptr) {
-    AdbcStatusCode status = Initialize(nullptr, &error_);
-    if (status != ADBC_STATUS_OK) {
+    status = Initialize(nullptr);
+    if (!status.ok()) {
+      status.ToAdbc(&error_);
       return EINVAL;
     }
   }
@@ -63,8 +63,9 @@ int PqResultArrayReader::GetNext(struct ArrowArray* out) {
     }
 
     // Keep binding and executing until we have a result to return
-    status = BindNextAndExecute(nullptr, &error_);
-    if (status != ADBC_STATUS_OK) {
+    status = BindNextAndExecute(nullptr);
+    if (!status.ok()) {
+      status.ToAdbc(&error_);
       return EIO;
     }
 
@@ -133,25 +134,33 @@ const char* PqResultArrayReader::GetLastError() {
   }
 }
 
-AdbcStatusCode PqResultArrayReader::Initialize(int64_t* rows_affected,
-                                               struct AdbcError* error) {
+Status PqResultArrayReader::Initialize(int64_t* rows_affected) {
   helper_.set_output_format(PqResultHelper::Format::kBinary);
   helper_.set_param_format(PqResultHelper::Format::kBinary);
 
   // If we have to do binding, set up the bind stream an execute until
   // there is a result with more than zero rows to populate.
+  AdbcStatusCode status_code;
   if (bind_stream_) {
-    RAISE_ADBC(bind_stream_->Begin([] { return ADBC_STATUS_OK; }, error));
-    RAISE_ADBC(bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_, error));
-    RAISE_STATUS(error, helper_.Prepare(bind_stream_->param_types));
+    status_code = bind_stream_->Begin([] { return ADBC_STATUS_OK; }, &error_);
+    if (status_code != ADBC_STATUS_OK) {
+      return Status::FromAdbc(status_code, error_);
+    }
+    status_code =
+        bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_, &error_);
+    if (status_code != ADBC_STATUS_OK) {
+      return Status::FromAdbc(status_code, error_);
+    }
 
-    RAISE_ADBC(BindNextAndExecute(nullptr, error));
+    UNWRAP_STATUS(helper_.Prepare(bind_stream_->param_types));
+
+    UNWRAP_STATUS(BindNextAndExecute(nullptr));
 
     // If there were no arrays in the bind stream, we still need a result
     // to populate the schema. If there were any arrays in the bind stream,
     // the last one will still be in helper_ even if it had zero rows.
     if (!helper_.HasResult()) {
-      RAISE_STATUS(error, helper_.DescribePrepared());
+      UNWRAP_STATUS(helper_.DescribePrepared());
     }
 
     // We can't provide affected row counts if there is a bind stream and
@@ -161,7 +170,7 @@ AdbcStatusCode PqResultArrayReader::Initialize(int64_t* rows_affected,
       *rows_affected = -1;
     }
   } else {
-    RAISE_STATUS(error, helper_.Execute());
+    UNWRAP_STATUS(helper_.Execute());
     if (rows_affected != nullptr) {
       *rows_affected = helper_.AffectedRows();
     }
@@ -169,90 +178,104 @@ AdbcStatusCode PqResultArrayReader::Initialize(int64_t* rows_affected,
 
   // Build the schema for which we are about to build results
   ArrowSchemaInit(schema_.get());
-  CHECK_NA_DETAIL(INTERNAL, ArrowSchemaSetTypeStruct(schema_.get(), helper_.NumColumns()),
-                  &na_error_, error);
+  UNWRAP_NANOARROW(na_error_, Internal,
+                   ArrowSchemaSetTypeStruct(schema_.get(), helper_.NumColumns()));
 
   for (int i = 0; i < helper_.NumColumns(); i++) {
     PostgresType child_type;
-    CHECK_NA_DETAIL(INTERNAL,
-                    type_resolver_->Find(helper_.FieldType(i), &child_type, &na_error_),
-                    &na_error_, error);
+    UNWRAP_NANOARROW(na_error_, Internal,
+                     type_resolver_->Find(helper_.FieldType(i), &child_type, &na_error_));
 
-    CHECK_NA(INTERNAL, child_type.SetSchema(schema_->children[i]), error);
-    CHECK_NA(INTERNAL, ArrowSchemaSetName(schema_->children[i], helper_.FieldName(i)),
-             error);
+    UNWRAP_ERRNO(Internal, child_type.SetSchema(schema_->children[i]));
+    UNWRAP_ERRNO(Internal,
+                 ArrowSchemaSetName(schema_->children[i], helper_.FieldName(i)));
 
     std::unique_ptr<PostgresCopyFieldReader> child_reader;
-    CHECK_NA_DETAIL(
-        INTERNAL,
-        MakeCopyFieldReader(child_type, schema_->children[i], &child_reader, &na_error_),
-        &na_error_, error);
+    UNWRAP_NANOARROW(
+        na_error_, Internal,
+        MakeCopyFieldReader(child_type, schema_->children[i], &child_reader, &na_error_));
 
     child_reader->Init(child_type);
-    CHECK_NA_DETAIL(INTERNAL, child_reader->InitSchema(schema_->children[i]), &na_error_,
-                    error);
+    UNWRAP_NANOARROW(na_error_, Internal, child_reader->InitSchema(schema_->children[i]));
 
     field_readers_.push_back(std::move(child_reader));
   }
 
-  return ADBC_STATUS_OK;
+  return Status::Ok();
 }
 
-AdbcStatusCode PqResultArrayReader::ToArrayStream(int64_t* affected_rows,
-                                                  struct ArrowArrayStream* out,
-                                                  struct AdbcError* error) {
+Status PqResultArrayReader::ToArrayStream(int64_t* affected_rows,
+                                          struct ArrowArrayStream* out) {
   if (out == nullptr) {
     // If there is no output requested, we still need to execute and
     // set affected_rows if needed. We don't need an output schema or to set up a copy
     // reader, so we can skip those steps by going straight to Execute(). This also
     // enables us to support queries with multiple statements because we can call PQexec()
     // instead of PQexecParams().
-    RAISE_ADBC(ExecuteAll(affected_rows, error));
-    return ADBC_STATUS_OK;
+    UNWRAP_STATUS(ExecuteAll(affected_rows));
+    return Status::Ok();
   }
 
   // Otherwise, execute until we have a result to return. We need this to provide row
   // counts for DELETE and CREATE TABLE queries as well as to provide more informative
   // errors until this reader class is wired up to provide extended AdbcError information.
-  RAISE_ADBC(Initialize(affected_rows, error));
+  UNWRAP_STATUS(Initialize(affected_rows));
 
   nanoarrow::ArrayStreamFactory<PqResultArrayReader>::InitArrayStream(
       new PqResultArrayReader(this), out);
 
-  return ADBC_STATUS_OK;
+  return Status::Ok();
 }
 
-AdbcStatusCode PqResultArrayReader::BindNextAndExecute(int64_t* affected_rows,
-                                                       AdbcError* error) {
+Status PqResultArrayReader::BindNextAndExecute(int64_t* affected_rows) {
   // Keep pulling from the bind stream and executing as long as
   // we receive results with zero rows.
+  AdbcStatusCode status_code;
   do {
-    RAISE_ADBC(bind_stream_->EnsureNextRow(error));
+    status_code = bind_stream_->EnsureNextRow(&error_);
+    if (status_code != ADBC_STATUS_OK) {
+      return Status::FromAdbc(status_code, error_);
+    }
+
     if (!bind_stream_->current->release) {
-      RAISE_ADBC(bind_stream_->Cleanup(conn_, error));
+      status_code = bind_stream_->Cleanup(conn_, &error_);
+      if (status_code != ADBC_STATUS_OK) {
+        return Status::FromAdbc(status_code, error_);
+      }
       bind_stream_.reset();
-      return ADBC_STATUS_OK;
+      return Status::Ok();
     }
 
     PGresult* result;
-    RAISE_ADBC(bind_stream_->BindAndExecuteCurrentRow(
-        conn_, &result, /*result_format*/ kPgBinaryFormat, error));
+    status_code = bind_stream_->BindAndExecuteCurrentRow(
+        conn_, &result, /*result_format*/ kPgBinaryFormat, &error_);
+    if (status_code != ADBC_STATUS_OK) {
+      return Status::FromAdbc(status_code, error_);
+    }
     helper_.SetResult(result);
     if (affected_rows) {
       (*affected_rows) += helper_.AffectedRows();
     }
   } while (helper_.NumRows() == 0);
 
-  return ADBC_STATUS_OK;
+  return Status::Ok();
 }
 
-AdbcStatusCode PqResultArrayReader::ExecuteAll(int64_t* affected_rows, AdbcError* error) {
+Status PqResultArrayReader::ExecuteAll(int64_t* affected_rows) {
   // For the case where we don't need a result, we either need to exhaust the bind
   // stream (if there is one) or execute the query without binding.
   if (bind_stream_) {
-    RAISE_ADBC(bind_stream_->Begin([] { return ADBC_STATUS_OK; }, error));
-    RAISE_ADBC(bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_, error));
-    RAISE_STATUS(error, helper_.Prepare(bind_stream_->param_types));
+    AdbcStatusCode status_code =
+        bind_stream_->Begin([] { return ADBC_STATUS_OK; }, &error_);
+    if (status_code != ADBC_STATUS_OK) {
+      return Status::FromAdbc(status_code, error_);
+    }
+    status_code =
+        bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_, &error_);
+    if (status_code != ADBC_STATUS_OK) {
+      return Status::FromAdbc(status_code, error_);
+    }
+    UNWRAP_STATUS(helper_.Prepare(bind_stream_->param_types));
 
     // Reset affected rows to zero before binding and executing any
     if (affected_rows) {
@@ -260,17 +283,17 @@ AdbcStatusCode PqResultArrayReader::ExecuteAll(int64_t* affected_rows, AdbcError
     }
 
     do {
-      RAISE_ADBC(BindNextAndExecute(affected_rows, error));
+      UNWRAP_STATUS(BindNextAndExecute(affected_rows));
     } while (bind_stream_);
   } else {
-    RAISE_STATUS(error, helper_.Execute());
+    UNWRAP_STATUS(helper_.Execute());
 
     if (affected_rows != nullptr) {
       *affected_rows = helper_.AffectedRows();
     }
   }
 
-  return ADBC_STATUS_OK;
+  return Status::Ok();
 }
 
 }  // namespace adbcpq

--- a/c/driver/postgresql/result_reader.h
+++ b/c/driver/postgresql/result_reader.h
@@ -62,10 +62,9 @@ class PqResultArrayReader {
   int GetNext(struct ArrowArray* out);
   const char* GetLastError();
 
-  AdbcStatusCode ToArrayStream(int64_t* affected_rows, struct ArrowArrayStream* out,
-                               struct AdbcError* error);
+  Status ToArrayStream(int64_t* affected_rows, struct ArrowArrayStream* out);
 
-  AdbcStatusCode Initialize(int64_t* affected_rows, struct AdbcError* error);
+  Status Initialize(int64_t* affected_rows);
 
  private:
   PGconn* conn_;
@@ -89,8 +88,8 @@ class PqResultArrayReader {
     error_ = ADBC_ERROR_INIT;
   }
 
-  AdbcStatusCode BindNextAndExecute(int64_t* affected_rows, AdbcError* error);
-  AdbcStatusCode ExecuteAll(int64_t* affected_rows, AdbcError* error);
+  Status BindNextAndExecute(int64_t* affected_rows);
+  Status ExecuteAll(int64_t* affected_rows);
 
   void ResetErrors() {
     ArrowErrorInit(&na_error_);

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -459,7 +459,7 @@ AdbcStatusCode PostgresStatement::ExecuteBind(struct ArrowArrayStream* stream,
   PqResultArrayReader reader(connection_->conn(), type_resolver_, query_);
   reader.SetAutocommit(connection_->autocommit());
   reader.SetBind(&bind_);
-  RAISE_ADBC(reader.ToArrayStream(rows_affected, stream, error));
+  RAISE_STATUS(error, reader.ToArrayStream(rows_affected, stream));
   return ADBC_STATUS_OK;
 }
 
@@ -487,7 +487,7 @@ AdbcStatusCode PostgresStatement::ExecuteQuery(struct ArrowArrayStream* stream,
   // execute using the PqResultArrayReader.
   if (!stream || !use_copy_) {
     PqResultArrayReader reader(connection_->conn(), type_resolver_, query_);
-    RAISE_ADBC(reader.ToArrayStream(rows_affected, stream, error));
+    RAISE_STATUS(error, reader.ToArrayStream(rows_affected, stream));
     return ADBC_STATUS_OK;
   }
 
@@ -505,7 +505,7 @@ AdbcStatusCode PostgresStatement::ExecuteQuery(struct ArrowArrayStream* stream,
   if (root_type.n_children() == 0) {
     // Could/should move the helper into the reader instead of repreparing
     PqResultArrayReader reader(connection_->conn(), type_resolver_, query_);
-    RAISE_ADBC(reader.ToArrayStream(rows_affected, stream, error));
+    RAISE_STATUS(error, reader.ToArrayStream(rows_affected, stream));
     return ADBC_STATUS_OK;
   }
 

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -493,7 +493,7 @@ AdbcStatusCode PostgresStatement::ExecuteQuery(struct ArrowArrayStream* stream,
 
   PqResultHelper helper(connection_->conn(), query_);
   RAISE_STATUS(error, helper.Prepare());
-  RAISE_ADBC(helper.DescribePrepared(error));
+  RAISE_STATUS(error, helper.DescribePrepared());
 
   // Initialize the copy reader and infer the output schema (i.e., error for
   // unsupported types before issuing the COPY query). This could be lazier
@@ -567,7 +567,7 @@ AdbcStatusCode PostgresStatement::ExecuteSchema(struct ArrowSchema* schema,
     RAISE_STATUS(error, helper.Prepare());
   }
 
-  RAISE_ADBC(helper.DescribePrepared(error));
+  RAISE_STATUS(error, helper.DescribePrepared());
 
   PostgresType output_type;
   RAISE_ADBC(helper.ResolveOutputTypes(*type_resolver_, &output_type, error));

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -499,7 +499,7 @@ AdbcStatusCode PostgresStatement::ExecuteQuery(struct ArrowArrayStream* stream,
   // unsupported types before issuing the COPY query). This could be lazier
   // (i.e., executed on the first call to GetSchema() or GetNext()).
   PostgresType root_type;
-  RAISE_ADBC(helper.ResolveOutputTypes(*type_resolver_, &root_type, error));
+  RAISE_STATUS(error, helper.ResolveOutputTypes(*type_resolver_, &root_type));
 
   // If there will be no columns in the result, we can also avoid COPY
   if (root_type.n_children() == 0) {
@@ -570,7 +570,7 @@ AdbcStatusCode PostgresStatement::ExecuteSchema(struct ArrowSchema* schema,
   RAISE_STATUS(error, helper.DescribePrepared());
 
   PostgresType output_type;
-  RAISE_ADBC(helper.ResolveOutputTypes(*type_resolver_, &output_type, error));
+  RAISE_STATUS(error, helper.ResolveOutputTypes(*type_resolver_, &output_type));
 
   nanoarrow::UniqueSchema tmp;
   ArrowSchemaInit(tmp.get());

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -492,7 +492,7 @@ AdbcStatusCode PostgresStatement::ExecuteQuery(struct ArrowArrayStream* stream,
   }
 
   PqResultHelper helper(connection_->conn(), query_);
-  RAISE_ADBC(helper.Prepare(error));
+  RAISE_STATUS(error, helper.Prepare());
   RAISE_ADBC(helper.DescribePrepared(error));
 
   // Initialize the copy reader and infer the output schema (i.e., error for
@@ -562,9 +562,9 @@ AdbcStatusCode PostgresStatement::ExecuteSchema(struct ArrowSchema* schema,
       param_oids[i] = pg_type.oid();
     }
 
-    RAISE_ADBC(helper.Prepare(param_oids, error));
+    RAISE_STATUS(error, helper.Prepare(param_oids));
   } else {
-    RAISE_ADBC(helper.Prepare(error));
+    RAISE_STATUS(error, helper.Prepare());
   }
 
   RAISE_ADBC(helper.DescribePrepared(error));

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -519,7 +519,7 @@ AdbcStatusCode PostgresStatement::ExecuteQuery(struct ArrowArrayStream* stream,
                   error);
 
   // Execute the COPY query
-  RAISE_ADBC(helper.ExecuteCopy(error));
+  RAISE_STATUS(error, helper.ExecuteCopy());
 
   // We need the PQresult back for the reader
   reader_.result_ = helper.ReleaseResult();

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -598,7 +598,7 @@ AdbcStatusCode PostgresStatement::ExecuteIngest(struct ArrowArrayStream* stream,
   std::string current_schema;
   {
     PqResultHelper result_helper{connection_->conn(), "SELECT CURRENT_SCHEMA"};
-    RAISE_ADBC(result_helper.Execute(error));
+    RAISE_STATUS(error, result_helper.Execute());
     auto it = result_helper.begin();
     if (it == result_helper.end()) {
       SetError(error, "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA'");

--- a/python/adbc_driver_postgresql/tests/test_dbapi.py
+++ b/python/adbc_driver_postgresql/tests/test_dbapi.py
@@ -150,7 +150,7 @@ def test_query_invalid(postgres: dbapi.Connection) -> None:
         with pytest.raises(
             postgres.ProgrammingError, match="Failed to prepare query"
         ) as excinfo:
-            cur.execute("SELECT * FROM tabledoesnotexist")
+            cur.executescript("SELECT * FROM tabledoesnotexist")
 
         assert excinfo.value.sqlstate == "42P01"
         assert len(excinfo.value.details) > 0

--- a/python/adbc_driver_postgresql/tests/test_dbapi.py
+++ b/python/adbc_driver_postgresql/tests/test_dbapi.py
@@ -150,7 +150,7 @@ def test_query_invalid(postgres: dbapi.Connection) -> None:
         with pytest.raises(
             postgres.ProgrammingError, match="Failed to prepare query"
         ) as excinfo:
-            cur.executescript("SELECT * FROM tabledoesnotexist")
+            cur.execute("SELECT * FROM tabledoesnotexist")
 
         assert excinfo.value.sqlstate == "42P01"
         assert len(excinfo.value.details) > 0


### PR DESCRIPTION
This PR migrates the internal PqResultHelper and PqResultReader to use the Status error handling system. This is to make it less painful to transition the bind stream and objects helper (and later the database/connection/statement) to the framework.

The CI failures are still GLib packaging and Python packaging.