### PR TITLE
refactor(c/driver/postgresql): Use Status for error handling in BindStream

### DIFF
--- a/c/driver/postgresql/bind_stream.h
+++ b/c/driver/postgresql/bind_stream.h
@@ -27,7 +27,6 @@
 #include <arrow-adbc/adbc.h>
 
 #include "copy/writer.h"
-#include "driver/common/utils.h"
 #include "error.h"
 #include "postgres_type.h"
 #include "postgres_util.h"

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -48,6 +48,8 @@ struct PqRecord {
     }
     return result;
   }
+
+  std::string_view value() { return std::string_view(data, len); }
 };
 
 // Used by PqResultHelper to provide index-based access to the records within each

--- a/c/driver/postgresql/result_reader.cc
+++ b/c/driver/postgresql/result_reader.cc
@@ -223,10 +223,7 @@ Status PqResultArrayReader::BindNextAndExecute(int64_t* affected_rows) {
   // we receive results with zero rows.
   AdbcStatusCode status_code;
   do {
-    status_code = bind_stream_->EnsureNextRow(&error_);
-    if (status_code != ADBC_STATUS_OK) {
-      return Status::FromAdbc(status_code, error_);
-    }
+    UNWRAP_STATUS(bind_stream_->EnsureNextRow());
 
     if (!bind_stream_->current->release) {
       status_code = bind_stream_->Cleanup(conn_, &error_);

--- a/c/driver/postgresql/result_reader.cc
+++ b/c/driver/postgresql/result_reader.cc
@@ -140,12 +140,8 @@ Status PqResultArrayReader::Initialize(int64_t* rows_affected) {
 
   // If we have to do binding, set up the bind stream an execute until
   // there is a result with more than zero rows to populate.
-  AdbcStatusCode status_code;
   if (bind_stream_) {
-    status_code = bind_stream_->Begin([] { return ADBC_STATUS_OK; }, &error_);
-    if (status_code != ADBC_STATUS_OK) {
-      return Status::FromAdbc(status_code, error_);
-    }
+    UNWRAP_STATUS(bind_stream_->Begin([] { return Status::Ok(); }));
 
     UNWRAP_STATUS(bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_));
     UNWRAP_STATUS(helper_.Prepare(bind_stream_->param_types));
@@ -260,11 +256,7 @@ Status PqResultArrayReader::ExecuteAll(int64_t* affected_rows) {
   // For the case where we don't need a result, we either need to exhaust the bind
   // stream (if there is one) or execute the query without binding.
   if (bind_stream_) {
-    AdbcStatusCode status_code =
-        bind_stream_->Begin([] { return ADBC_STATUS_OK; }, &error_);
-    if (status_code != ADBC_STATUS_OK) {
-      return Status::FromAdbc(status_code, error_);
-    }
+    UNWRAP_STATUS(bind_stream_->Begin([] { return Status::Ok(); }));
     UNWRAP_STATUS(bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_));
     UNWRAP_STATUS(helper_.Prepare(bind_stream_->param_types));
 

--- a/c/driver/postgresql/result_reader.cc
+++ b/c/driver/postgresql/result_reader.cc
@@ -146,14 +146,9 @@ Status PqResultArrayReader::Initialize(int64_t* rows_affected) {
     if (status_code != ADBC_STATUS_OK) {
       return Status::FromAdbc(status_code, error_);
     }
-    status_code =
-        bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_, &error_);
-    if (status_code != ADBC_STATUS_OK) {
-      return Status::FromAdbc(status_code, error_);
-    }
 
+    UNWRAP_STATUS(bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_));
     UNWRAP_STATUS(helper_.Prepare(bind_stream_->param_types));
-
     UNWRAP_STATUS(BindNextAndExecute(nullptr));
 
     // If there were no arrays in the bind stream, we still need a result
@@ -270,11 +265,7 @@ Status PqResultArrayReader::ExecuteAll(int64_t* affected_rows) {
     if (status_code != ADBC_STATUS_OK) {
       return Status::FromAdbc(status_code, error_);
     }
-    status_code =
-        bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_, &error_);
-    if (status_code != ADBC_STATUS_OK) {
-      return Status::FromAdbc(status_code, error_);
-    }
+    UNWRAP_STATUS(bind_stream_->SetParamTypes(conn_, *type_resolver_, autocommit_));
     UNWRAP_STATUS(helper_.Prepare(bind_stream_->param_types));
 
     // Reset affected rows to zero before binding and executing any

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -635,8 +635,9 @@ AdbcStatusCode PostgresStatement::ExecuteIngest(struct ArrowArrayStream* stream,
   }
 
   PQclear(result);
-  RAISE_ADBC(bind_stream.ExecuteCopy(connection_->conn(), *connection_->type_resolver(),
-                                     rows_affected, error));
+  RAISE_STATUS(error,
+               bind_stream.ExecuteCopy(connection_->conn(), *connection_->type_resolver(),
+                                       rows_affected));
   return ADBC_STATUS_OK;
 }
 


### PR DESCRIPTION
This PR migrates the `BindStream` to use the `PqResultHelper` and `Status`!

I believe the CI failure are still glib and Python packaging.