### PR TITLE
refactor(c/driver/postgresql): Use GetObjectsHelper from framework to build objects

### DIFF
--- a/c/driver/framework/objects.cc
+++ b/c/driver/framework/objects.cc
@@ -348,7 +348,7 @@ struct GetObjectsBuilder {
 
   Status AppendColumns(std::string_view catalog, std::string_view schema,
                        std::string_view table) {
-    UNWRAP_STATUS(helper->LoadColumns(catalog, schema, table));
+    UNWRAP_STATUS(helper->LoadColumns(catalog, schema, table, column_filter));
     while (true) {
       UNWRAP_RESULT(auto maybe_column, helper->NextColumn());
       if (!maybe_column.has_value()) break;

--- a/c/driver/framework/objects.cc
+++ b/c/driver/framework/objects.cc
@@ -323,7 +323,7 @@ struct GetObjectsBuilder {
   }
 
   Status AppendTables(std::string_view catalog, std::string_view schema) {
-    UNWRAP_STATUS(helper->LoadTables(catalog, schema));
+    UNWRAP_STATUS(helper->LoadTables(catalog, schema, table_filter, table_types));
     while (true) {
       UNWRAP_RESULT(auto maybe_table, helper->NextTable());
       if (!maybe_table.has_value()) break;

--- a/c/driver/framework/objects.cc
+++ b/c/driver/framework/objects.cc
@@ -284,7 +284,7 @@ struct GetObjectsBuilder {
   }
 
   Status AppendCatalogs() {
-    UNWRAP_STATUS(helper->LoadCatalogs());
+    UNWRAP_STATUS(helper->LoadCatalogs(catalog_filter));
     while (true) {
       UNWRAP_RESULT(auto maybe_catalog, helper->NextCatalog());
       if (!maybe_catalog.has_value()) break;
@@ -302,7 +302,7 @@ struct GetObjectsBuilder {
   }
 
   Status AppendSchemas(std::string_view catalog) {
-    UNWRAP_STATUS(helper->LoadSchemas(catalog));
+    UNWRAP_STATUS(helper->LoadSchemas(catalog, schema_filter));
     while (true) {
       UNWRAP_RESULT(auto maybe_schema, helper->NextSchema());
       if (!maybe_schema.has_value()) break;

--- a/c/driver/framework/objects.h
+++ b/c/driver/framework/objects.h
@@ -130,7 +130,8 @@ struct GetObjectsHelper {
   virtual Result<std::optional<Table>> NextTable() { return std::nullopt; }
 
   virtual Status LoadColumns(std::string_view catalog, std::string_view schema,
-                             std::string_view table) {
+                             std::string_view table,
+                             std::optional<std::string_view> column_filter) {
     return status::NotImplemented("GetObjects at depth = column");
   };
 

--- a/c/driver/framework/objects.h
+++ b/c/driver/framework/objects.h
@@ -121,7 +121,9 @@ struct GetObjectsHelper {
 
   virtual Result<std::optional<std::string_view>> NextSchema() { return std::nullopt; }
 
-  virtual Status LoadTables(std::string_view catalog, std::string_view schema) {
+  virtual Status LoadTables(std::string_view catalog, std::string_view schema,
+                            std::optional<std::string_view> table_filter,
+                            const std::vector<std::string_view>& table_types) {
     return status::NotImplemented("GetObjects at depth = table");
   };
 

--- a/c/driver/framework/objects.h
+++ b/c/driver/framework/objects.h
@@ -108,13 +108,14 @@ struct GetObjectsHelper {
     return status::NotImplemented("GetObjects");
   }
 
-  virtual Status LoadCatalogs() {
+  virtual Status LoadCatalogs(std::optional<std::string_view> catalog_filter) {
     return status::NotImplemented("GetObjects at depth = catalog");
   };
 
   virtual Result<std::optional<std::string_view>> NextCatalog() { return std::nullopt; }
 
-  virtual Status LoadSchemas(std::string_view catalog) {
+  virtual Status LoadSchemas(std::string_view catalog,
+                             std::optional<std::string_view> schema_filter) {
     return status::NotImplemented("GetObjects at depth = schema");
   };
 

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -20,7 +20,6 @@
 #include <cassert>
 #include <cinttypes>
 #include <cmath>
-#include <cstddef>
 #include <cstring>
 #include <memory>
 #include <optional>

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -1105,8 +1105,11 @@ AdbcStatusCode PostgresConnection::SetOption(const char* key, const char* value,
     return ADBC_STATUS_OK;
   } else if (std::strcmp(key, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
     // PostgreSQL doesn't accept a parameter here
-    // TODO: We probably need to quote identifier to avoid SQL injection?
-    PqResultHelper result_helper{conn_, std::string("SET search_path TO ") + value};
+    char* value_esc = PQescapeIdentifier(conn_, value, strlen(value));
+    std::string query = std::string("SET search_path TO ") + value_esc;
+    PQfreemem(value_esc);
+
+    PqResultHelper result_helper{conn_, query};
     RAISE_STATUS(error, result_helper.Execute());
     return ADBC_STATUS_OK;
   }

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -60,7 +60,7 @@ class PqResultRow {
     ncols_ = PQnfields(result);
   }
 
-  PqRecord operator[](const int& col_num) {
+  PqRecord operator[](const int& col_num) const {
     assert(col_num < ncols_);
     const char* data = PQgetvalue(result_, row_num_, col_num);
     const int len = PQgetlength(result_, row_num_, col_num);
@@ -143,6 +143,7 @@ class PqResultHelper {
    public:
     explicit iterator(const PqResultHelper& outer, int curr_row = 0)
         : outer_(outer), curr_row_(curr_row) {}
+    iterator end() const { return outer_.end(); }
     iterator& operator++() {
       curr_row_++;
       return *this;
@@ -164,8 +165,8 @@ class PqResultHelper {
     using reference = const std::vector<PqResultRow>&;
   };
 
-  iterator begin() { return iterator(*this); }
-  iterator end() { return iterator(*this, NumRows()); }
+  iterator begin() const { return iterator(*this); }
+  iterator end() const { return iterator(*this, NumRows()); }
 
  private:
   PGresult* result_ = nullptr;

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -87,6 +87,7 @@ struct PqRecord {
 // row of a PGresult
 class PqResultRow {
  public:
+  PqResultRow() : result_(nullptr), row_num_(-1) {}
   PqResultRow(PGresult* result, int row_num) : result_(result), row_num_(row_num) {
     ncols_ = PQnfields(result);
   }
@@ -99,6 +100,10 @@ class PqResultRow {
 
     return PqRecord{data, len, is_null};
   }
+
+  bool IsValid() { return result_ && row_num_ >= 0 && row_num_ < PQntuples(result_); }
+
+  PqResultRow Next() { return PqResultRow(result_, row_num_ + 1); }
 
  private:
   PGresult* result_ = nullptr;
@@ -166,6 +171,7 @@ class PqResultHelper {
     return PQfname(result_, column_number);
   }
   Oid FieldType(int column_number) const { return PQftype(result_, column_number); }
+  PqResultRow Row(int i = 0) { return PqResultRow(result_, i); }
 
   class iterator {
     const PqResultHelper& outer_;

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -56,7 +56,7 @@ struct PqRecord {
   Result<int64_t> ParseInteger() const {
     const char* last = data + len;
     int64_t value = 0;
-    auto result = std::from_chars<int64_t>(data, last, value, 10);
+    auto result = std::from_chars(data, last, value, 10);
     if (result.ec == std::errc() && result.ptr == last) {
       return value;
     } else {

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -177,7 +177,6 @@ class PqResultHelper {
    public:
     explicit iterator(const PqResultHelper& outer, int curr_row = 0)
         : outer_(outer), curr_row_(curr_row) {}
-    iterator end() const { return outer_.end(); }
     iterator& operator++() {
       curr_row_++;
       return *this;
@@ -199,8 +198,8 @@ class PqResultHelper {
     using reference = const std::vector<PqResultRow>&;
   };
 
-  iterator begin() const { return iterator(*this); }
-  iterator end() const { return iterator(*this, NumRows()); }
+  iterator begin() { return iterator(*this); }
+  iterator end() { return iterator(*this, NumRows()); }
 
  private:
   PGresult* result_ = nullptr;

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -88,12 +88,10 @@ struct PqRecord {
 class PqResultRow {
  public:
   PqResultRow() : result_(nullptr), row_num_(-1) {}
-  PqResultRow(PGresult* result, int row_num) : result_(result), row_num_(row_num) {
-    ncols_ = PQnfields(result);
-  }
+  PqResultRow(PGresult* result, int row_num) : result_(result), row_num_(row_num) {}
 
   PqRecord operator[](const int& col_num) const {
-    assert(col_num < ncols_);
+    assert(col_num < PQnfields(result_));
     const char* data = PQgetvalue(result_, row_num_, col_num);
     const int len = PQgetlength(result_, row_num_, col_num);
     const bool is_null = PQgetisnull(result_, row_num_, col_num);
@@ -108,7 +106,6 @@ class PqResultRow {
  private:
   PGresult* result_ = nullptr;
   int row_num_;
-  int ncols_;
 };
 
 // Helper to manager the lifecycle of a PQResult. The query argument
@@ -171,7 +168,7 @@ class PqResultHelper {
     return PQfname(result_, column_number);
   }
   Oid FieldType(int column_number) const { return PQftype(result_, column_number); }
-  PqResultRow Row(int i = 0) { return PqResultRow(result_, i); }
+  PqResultRow Row(int i) { return PqResultRow(result_, i); }
 
   class iterator {
     const PqResultHelper& outer_;

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -23,7 +23,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <system_error>
 #include <utility>
 #include <vector>
 

--- a/c/driver/sqlite/sqlite.cc
+++ b/c/driver/sqlite/sqlite.cc
@@ -310,7 +310,8 @@ struct SqliteGetObjectsHelper : public driver::GetObjectsHelper {
   }
 
   Status LoadColumns(std::string_view catalog, std::string_view schema,
-                     std::string_view table) override {
+                     std::string_view table,
+                     std::optional<std::string_view> column_filter) override {
     // XXX: pragma_table_info doesn't appear to work with bind parameters
     // XXX: because we're saving the SqliteQuery, we also need to save the string builder
     columns_query.Reset();

--- a/c/driver/sqlite/sqlite.cc
+++ b/c/driver/sqlite/sqlite.cc
@@ -218,10 +218,6 @@ struct SqliteGetObjectsHelper : public driver::GetObjectsHelper {
     std::string query =
         "SELECT DISTINCT name FROM pragma_database_list() WHERE name LIKE ?";
 
-    this->table_filter = table_filter;
-    this->column_filter = column_filter;
-    this->table_types = table_types;
-
     UNWRAP_STATUS(SqliteQuery::Scan(
         conn, query,
         [&](sqlite3_stmt* stmt) {
@@ -488,9 +484,6 @@ struct SqliteGetObjectsHelper : public driver::GetObjectsHelper {
   };
 
   sqlite3* conn = nullptr;
-  std::optional<std::string_view> table_filter;
-  std::optional<std::string_view> column_filter;
-  std::vector<std::string_view> table_types;
   std::vector<std::string> catalogs;
   std::vector<std::string> schemas;
   std::vector<std::pair<std::string, std::string>> tables;

--- a/c/driver/sqlite/sqlite.cc
+++ b/c/driver/sqlite/sqlite.cc
@@ -265,7 +265,9 @@ struct SqliteGetObjectsHelper : public driver::GetObjectsHelper {
     return schemas[next_schema++];
   }
 
-  Status LoadTables(std::string_view catalog, std::string_view schema) override {
+  Status LoadTables(std::string_view catalog, std::string_view schema,
+                    std::optional<std::string_view> table_filter,
+                    const std::vector<std::string_view>& table_types) override {
     next_table = 0;
     tables.clear();
     if (!schema.empty()) return status::Ok();

--- a/c/driver/sqlite/sqlite.cc
+++ b/c/driver/sqlite/sqlite.cc
@@ -245,14 +245,17 @@ struct SqliteGetObjectsHelper : public driver::GetObjectsHelper {
     return status::Ok();
   }
 
-  Status LoadCatalogs() override { return status::Ok(); };
+  Status LoadCatalogs(std::optional<std::string_view> catalog_filter) override {
+    return status::Ok();
+  };
 
   Result<std::optional<std::string_view>> NextCatalog() override {
     if (next_catalog >= catalogs.size()) return std::nullopt;
     return catalogs[next_catalog++];
   }
 
-  Status LoadSchemas(std::string_view catalog) override {
+  Status LoadSchemas(std::string_view catalog,
+                     std::optional<std::string_view> schema_filter) override {
     next_schema = 0;
     return status::Ok();
   };

--- a/r/adbcpostgresql/configure
+++ b/r/adbcpostgresql/configure
@@ -53,8 +53,8 @@ elif [ ! -z "$HAS_PKG_CONFIG" ]; then
   PKG_LIBS="`pkg-config libpq --libs` $PKG_LIBS"
 elif [ ! -z "$HAS_PG_CONFIG" ]; then
   echo "Using pg_config to locate libpq headers/libs"
-  PKG_CPPFLAGS="-I`pg_config --includedir` $PKG_CPPFLAGS"
-  PKG_LIBS="-L`pg_config --libdir` -lpq $PKG_LIBS"
+  PKG_CPPFLAGS="-I`pg_config --includedir` `pg_config --cppflags` $PKG_CPPFLAGS"
+  PKG_LIBS="-L`pg_config --libdir` -lpq `pg_config --ldflags` `pg_config --libs` $PKG_LIBS"
 else
   echo "INCLUDE_DIR/LIB_DIR, pkg-config, and pg_config not found; trying PKG_LIBS=-lpq"
   PKG_LIBS="-lpq"


### PR DESCRIPTION
This PR migrates the PostgreSQL driver to use the same `GetObjectsHelper` as the SQLite driver (the one provided by the framework). This involved a few updates to the helper (notably: ensure the filter is passed to the `LoadXXX()` methods), and an update to the result helper to make it easier to store iteration state along a result as a member of the helper.