### PR TITLE
feat(go/adbc/driver/snowflake): add support for a client config file

### DIFF
--- a/docs/source/driver/snowflake.rst
+++ b/docs/source/driver/snowflake.rst
@@ -447,7 +447,8 @@ These options map 1:1 with the Snowflake `Config object <https://pkg.go.dev/gith
     or ``false``.
 
 ``adbc.snowflake.sql.client_option.config_file``
-    Specifies the location of the client configuration json file.
+    Specifies the location of the client configuration JSON file. See the
+    [Snowflake Go docs](https://github.com/snowflakedb/gosnowflake/blob/a26ac8a1b9a0dda854ac5db9c2c145f79d5ac4c0/doc.go#L130) for more details.
 
 ``adbc.snowflake.sql.client_option.tracing``
     Set the logging level

--- a/docs/source/driver/snowflake.rst
+++ b/docs/source/driver/snowflake.rst
@@ -446,6 +446,9 @@ These options map 1:1 with the Snowflake `Config object <https://pkg.go.dev/gith
     disabled by setting this to ``true``. Value should be either ``true``
     or ``false``.
 
+``adbc.snowflake.sql.client_option.config_file``
+    Specifies the location of the client configuration json file.
+
 ``adbc.snowflake.sql.client_option.tracing``
     Set the logging level
 

--- a/go/adbc/driver/snowflake/driver.go
+++ b/go/adbc/driver/snowflake/driver.go
@@ -93,6 +93,8 @@ const (
 	OptionDisableTelemetry           = "adbc.snowflake.sql.client_option.disable_telemetry"
 	// snowflake driver logging level
 	OptionLogTracing = "adbc.snowflake.sql.client_option.tracing"
+	// snowflake driver client logging config file
+	OptionClientConfigFile = "adbc.snowflake.sql.client_option.config_file"
 	// When true, the MFA token is cached in the credential manager. True by default
 	// on Windows/OSX, false for Linux
 	OptionClientRequestMFAToken = "adbc.snowflake.sql.client_option.cache_mfa_token"

--- a/go/adbc/driver/snowflake/driver_test.go
+++ b/go/adbc/driver/snowflake/driver_test.go
@@ -2144,3 +2144,17 @@ func (suite *SnowflakeTests) TestChangeDatabaseAndGetObjects() {
 	_, err2 := suite.cnxn.GetObjects(suite.ctx, adbc.ObjectDepthAll, &newCatalog, &cfg.Schema, &getObjectsTable, nil, nil)
 	suite.NoError(err2)
 }
+
+func (suite *SnowflakeTests) TestGetSetClientConfigFile() {
+	file := "fileNameJustForTest.json"
+	options := map[string]string{
+		driver.OptionClientConfigFile: file,
+	}
+	getSetDB, ok := suite.db.(adbc.GetSetOptions)
+	suite.True(ok)
+	err := suite.db.SetOptions(options)
+	suite.NoError(err)
+	result, err := getSetDB.GetOption(driver.OptionClientConfigFile)
+	suite.NoError(err)
+	suite.True(file == result)
+}

--- a/go/adbc/driver/snowflake/snowflake_database.go
+++ b/go/adbc/driver/snowflake/snowflake_database.go
@@ -125,6 +125,8 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 		return adbc.OptionValueDisabled, nil
 	case OptionLogTracing:
 		return d.cfg.Tracing, nil
+	case OptionClientConfigFile:
+		return d.cfg.ClientConfigFile, nil
 	case OptionUseHighPrecision:
 		if d.useHighPrecision {
 			return adbc.OptionValueEnabled, nil
@@ -415,6 +417,8 @@ func (d *databaseImpl) SetOptions(cnOptions map[string]string) error {
 			}
 		case OptionLogTracing:
 			d.cfg.Tracing = v
+		case OptionClientConfigFile:
+			d.cfg.ClientConfigFile = v
 		case OptionUseHighPrecision:
 			switch v {
 			case adbc.OptionValueEnabled:


### PR DESCRIPTION
Adds a new option to set a client config file to set https://github.com/snowflakedb/gosnowflake/blob/a26ac8a1b9a0dda854ac5db9c2c145f79d5ac4c0/doc.go#L130 as a driver option. 