### PR TITLE
fix(csharp/src/Drivers/Apache/Spark): correct precision/scale handling with zeros in fractional portion

### DIFF
--- a/csharp/src/Drivers/Apache/Hive2/DecimalUtility.cs
+++ b/csharp/src/Drivers/Apache/Hive2/DecimalUtility.cs
@@ -45,7 +45,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
             {
                 throw new ArgumentOutOfRangeException(nameof(precision), precision, "precision value must be greater than zero.");
             }
-            if (scale < 0 || scale >= precision)
+            if (scale < 0 || scale > precision)
             {
                 throw new ArgumentOutOfRangeException(nameof(scale), scale, "scale value must be in the range 0 .. precision.");
             }
@@ -165,8 +165,14 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
                     frac_length = Math.Max(Math.Min(frac_length - exponent, tempSignificant.Length - int_length), 0);
                 }
                 // Reset the integer and fractional span
-                integerSpan = tempSignificant.Slice(0, int_length);
                 fractionalSpan = tempSignificant.Slice(int_length, frac_length);
+                integerSpan = tempSignificant.Slice(0, int_length);
+                // Trim leading zeros fron new integer span
+                while (integerSpan.Length > 0 && integerSpan[0] == AsciiZero)
+                {
+                    integerSpan = integerSpan.Slice(1);
+                    int_length -= 1;
+                }
             }
 
             int neededPrecision = int_length + frac_length;

--- a/csharp/test/Drivers/Apache/Hive2/DecimalUtilityTests.cs
+++ b/csharp/test/Drivers/Apache/Hive2/DecimalUtilityTests.cs
@@ -143,6 +143,11 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Hive2
             yield return new object[] { "-0.1E0", 38, 3, 16, new byte[] { 156, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 }, new SqlDecimal(-0.1) };
             yield return new object[] { "-1e-1", 38, 3, 16, new byte[] { 156, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 }, new SqlDecimal(-0.1) };
             yield return new object[] { "-0.01e1", 38, 3, 16, new byte[] { 156, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255 }, new SqlDecimal(-0.1) };
+
+            yield return new object[] { "0.99999999999999999999999999999999999999", 38, 38, 16, new byte[] { 255, 255, 255, 255, 63, 34, 138, 9, 122, 196, 134, 90, 168, 76, 59, 75 } };
+            yield return new object[] { "0.99999999999999999999999999999999999999E0", 38, 38, 16, new byte[] { 255, 255, 255, 255, 63, 34, 138, 9, 122, 196, 134, 90, 168, 76, 59, 75 } };
+            yield return new object[] { "9.99999999999999999999999999999999999990e-1", 38, 38, 16, new byte[] { 255, 255, 255, 255, 63, 34, 138, 9, 122, 196, 134, 90, 168, 76, 59, 75 } };
+            yield return new object[] { "0.0000000000000000000000000000000000000099999999999999999999999999999999999999e38", 38, 38, 16, new byte[] { 255, 255, 255, 255, 63, 34, 138, 9, 122, 196, 134, 90, 168, 76, 59, 75 } };
         }
 
         private static SqlDecimal GetSqlDecimal128(in byte[] valueBuffer, int index, int precision, int scale)


### PR DESCRIPTION
Fixed two bugs
1. scale should be able to be the same as precision
2. when leading zeros in fractional portion and positive exponent, the significant digits where not calculated correctly.