### PR TITLE
chore(ci): Fix install of local driver manager in valgrind extended checks

### DIFF
--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -123,11 +123,13 @@ jobs:
       - name: Bootstrap R Package
         run: |
           pushd r/adbcdrivermanager
+          R -e 'if (!requireNamespace("nanoarrow", quietly = TRUE)) install.packages("nanoarrow", repos = "https://cloud.r-project.org/")'
+          R CMD INSTALL . --preclean
+          popd
+          pushd "r/${{ inputs.pkg }}"
           Rscript bootstrap.R
           popd
-          pushd "r/${{ matrix.pkg }}"
-          Rscript bootstrap.R
-          popd
+        shell: bash
 
       - uses: r-lib/actions/setup-r-dependencies@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
         with:

--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -126,7 +126,7 @@ jobs:
           R -e 'if (!requireNamespace("nanoarrow", quietly = TRUE)) install.packages("nanoarrow", repos = "https://cloud.r-project.org/")'
           R CMD INSTALL . --preclean
           popd
-          pushd "r/${{ inputs.pkg }}"
+          pushd "r/${{ matrix.pkg }}"
           Rscript bootstrap.R
           popd
         shell: bash

--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -133,7 +133,6 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@f4937e0dc26f9b99c969cd3e4ca943b576e7f991
         with:
-          extra-packages: local::../adbcdrivermanager
           working-directory: r/${{ matrix.pkg }}
 
       - name: Start postgres test database


### PR DESCRIPTION
This PR fixes the failing weekly extended R workflow, which is currently failing because of how pak installs `local::` packages. This was fixed for other workflows but not for valgrind because the other workflows use the reusable `r-check.yml` action.

Failure: https://github.com/apache/arrow-adbc/actions/runs/11088200259/job/30807805100