### PR TITLE
chore(dev): Use Miniforge instead of Mambaforge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,8 @@ https://github.com/apache/arrow-adbc/issues
 Some dependencies are required to build and test the various ADBC packages.
 
 For C/C++, you will most likely want a [Conda][conda] installation,
-with [Mambaforge][mambaforge] being the most convenient distribution.
-If you have Mambaforge installed, you can set up a development
+with [Miniforge][miniforge] being the most convenient distribution.
+If you have Miniforge installed, you can set up a development
 environment as follows:
 
 ```shell
@@ -52,7 +52,7 @@ CMake or other build tool appropriately.  However, we primarily
 develop and support Conda users.
 
 [conda]: https://docs.conda.io/en/latest/
-[mambaforge]: https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html
+[miniforge]: https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html
 
 ### Running Integration Tests
 

--- a/ci/conda_env_glib.txt
+++ b/ci/conda_env_glib.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 arrow-c-glib=15.0.2
-glib
+glib=2.80.5
 gobject-introspection
 meson
 postgresql

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -382,7 +382,7 @@ install_rust() {
 install_conda() {
   # Setup short-lived miniconda for Python and integration tests
   show_info "Ensuring that Conda is installed..."
-  local prefix=$ARROW_TMPDIR/mambaforge
+  local prefix=$ARROW_TMPDIR/miniforge
 
   # Setup miniconda only if the directory doesn't exist yet
   if [ "${CONDA_ALREADY_INSTALLED:-0}" -eq 0 ]; then
@@ -390,7 +390,7 @@ install_conda() {
       show_info "Installing miniconda at ${prefix}..."
       local arch=$(uname -m)
       local platform=$(uname)
-      local url="https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-${platform}-${arch}.sh"
+      local url="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${platform}-${arch}.sh"
       curl -sL -o miniconda.sh $url
       bash miniconda.sh -b -p $prefix
       rm -f miniconda.sh

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -390,7 +390,7 @@ install_conda() {
       show_info "Installing miniconda at ${prefix}..."
       local arch=$(uname -m)
       local platform=$(uname)
-      local url="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${platform}-${arch}.sh"
+      local url="https://github.com/conda-forge/miniforge/releases/latest/download/miniforge3-${platform}-${arch}.sh"
       curl -sL -o miniconda.sh $url
       bash miniconda.sh -b -p $prefix
       rm -f miniconda.sh


### PR DESCRIPTION
Use Miniforge instead of Mambaforge, as the latter has been deprecated.

Closes #2206