### PR TITLE
fix(csharp/src/Drivers/Apache/Spark): correct batch handling for the HiveServer2Reader

### DIFF
--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2Connection.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2Connection.cs
@@ -66,6 +66,19 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
             _client = new TCLIService.Client(protocol);
             TOpenSessionReq request = CreateSessionRequest();
             TOpenSessionResp? session = await Client.OpenSession(request);
+
+            // Some responses don't raise an exception. Explicitly check the status.
+            if (session == null)
+            {
+                throw new HiveServer2Exception("unable to open session. unknown error.");
+            }
+            else if (session.Status.StatusCode != TStatusCode.SUCCESS_STATUS)
+            {
+                throw new HiveServer2Exception(session.Status.ErrorMessage)
+                    .SetNativeError(session.Status.ErrorCode)
+                    .SetSqlState(session.Status.SqlState);
+            }
+
             SessionHandle = session.SessionHandle;
         }
 

--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2Connection.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2Connection.cs
@@ -96,7 +96,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
 
         internal abstract SchemaParser SchemaParser { get; }
 
-        internal abstract IArrowArrayStream NewReader<T>(T statement, Schema schema) where T : HiveServer2Statement;
+        internal abstract IArrowArrayStream NewReader<T>(T statement, Schema schema, CancellationToken cancellationToken = default) where T : HiveServer2Statement;
 
         public override IArrowArrayStream GetObjects(GetObjectsDepth depth, string? catalogPattern, string? dbSchemaPattern, string? tableNamePattern, IReadOnlyList<string>? tableTypes, string? columnNamePattern)
         {

--- a/csharp/src/Drivers/Apache/Impala/ImpalaConnection.cs
+++ b/csharp/src/Drivers/Apache/Impala/ImpalaConnection.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow.Adbc.Drivers.Apache.Hive2;
 using Apache.Arrow.Ipc;
@@ -86,6 +87,6 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Impala
 
         internal override SchemaParser SchemaParser { get; } = new HiveServer2SchemaParser();
 
-        internal override IArrowArrayStream NewReader<T>(T statement, Schema schema) => new HiveServer2Reader(statement, schema, dataTypeConversion: DataTypeConversion);
+        internal override IArrowArrayStream NewReader<T>(T statement, Schema schema, CancellationToken cancellationToken = default) => new HiveServer2Reader(statement, schema, dataTypeConversion: DataTypeConversion, cancellationToken);
     }
 }

--- a/csharp/src/Drivers/Apache/Spark/SparkDatabricksConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkDatabricksConnection.cs
@@ -16,6 +16,7 @@
 */
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow.Adbc.Drivers.Apache.Hive2;
 using Apache.Arrow.Ipc;
@@ -29,7 +30,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
         {
         }
 
-        internal override IArrowArrayStream NewReader<T>(T statement, Schema schema) => new SparkDatabricksReader(statement, schema);
+        internal override IArrowArrayStream NewReader<T>(T statement, Schema schema, CancellationToken cancellationToken = default) => new SparkDatabricksReader(statement, schema);
 
         internal override SchemaParser SchemaParser => new SparkDatabricksSchemaParser();
 

--- a/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
@@ -121,7 +121,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
             TlsOptions = Hive2.TlsOptionsParser.Parse(tlsOptions);
         }
 
-        internal override IArrowArrayStream NewReader<T>(T statement, Schema schema) => new HiveServer2Reader(statement, schema, dataTypeConversion: statement.Connection.DataTypeConversion);
+        internal override IArrowArrayStream NewReader<T>(T statement, Schema schema, CancellationToken cancellationToken = default) => new HiveServer2Reader(statement, schema, dataTypeConversion: statement.Connection.DataTypeConversion, cancellationToken);
 
         protected override Task<TTransport> CreateTransportAsync()
         {


### PR DESCRIPTION
1. Fixes batch handling of the HiveServer2Reader so that it retrieves all subsequent batches after the first batch.
2. Adds async look-ahead fetch for improved performance.
3. Adds test to ensure all records are retrieved regardless of batch size.