### PR TITLE
feat(c/driver/postgresql): Enable basic connect/query workflow for Redshift

### DIFF
--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -492,7 +492,7 @@ AdbcStatusCode PostgresConnection::GetInfo(struct AdbcConnection* connection,
           std::string version_string = std::to_string(version[0]) + "." +
                                        std::to_string(version[1]) + "." +
                                        std::to_string(version[2]);
-          infos.push_back({info_codes[i], version_string});
+          infos.emplace_back(info_codes[i], std::move(version_string));
 
         } else {
           // Gives a version in the form 140000 instead of 14.0.0

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -17,6 +17,7 @@
 
 #include "connection.h"
 
+#include <array>
 #include <cassert>
 #include <cinttypes>
 #include <cmath>

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -494,6 +494,7 @@ AdbcStatusCode PostgresConnection::GetInfo(struct AdbcConnection* connection,
           infos.push_back({info_codes[i], version_string});
 
         } else {
+          // Gives a version in the form 140000 instead of 14.0.0
           const char* stmt = "SHOW server_version_num";
           auto result_helper = PqResultHelper{conn_, std::string(stmt)};
           RAISE_STATUS(error, result_helper.Execute());

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -480,7 +480,7 @@ AdbcStatusCode PostgresConnection::GetInfo(struct AdbcConnection* connection,
     switch (info_codes[i]) {
       case ADBC_INFO_VENDOR_NAME:
         if (RedshiftVersion()[0] > 0) {
-          infos.push_back({info_codes[i], "Redshift"});
+          infos.emplace_back(info_codes[i], "Redshift");
         } else {
           infos.push_back({info_codes[i], "PostgreSQL"});
         }

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -1001,7 +1001,6 @@ AdbcStatusCode PostgresConnection::GetTableSchema(const char* catalog,
   CHECK_NA(INTERNAL, ArrowSchemaSetTypeStruct(uschema.get(), result_helper.NumRows()),
            error);
 
-  ArrowError na_error;
   int row_counter = 0;
   for (auto row : result_helper) {
     const char* colname = row[0].data;
@@ -1009,9 +1008,9 @@ AdbcStatusCode PostgresConnection::GetTableSchema(const char* catalog,
         static_cast<uint32_t>(std::strtol(row[1].data, /*str_end=*/nullptr, /*base=*/10));
 
     PostgresType pg_type;
-    if (type_resolver_->Find(pg_oid, &pg_type, &na_error) != NANOARROW_OK) {
-      SetError(error, "%s%d%s%s%s%" PRIu32, "Column #", row_counter + 1, " (\"", colname,
-               "\") has unknown type code ", pg_oid);
+    if (type_resolver_->FindWithDefault(pg_oid, &pg_type) != NANOARROW_OK) {
+      SetError(error, "%s%d%s%s%s%" PRIu32, "Error resolving type code for column #",
+               row_counter + 1, " (\"", colname, "\")  with oid ", pg_oid);
       final_status = ADBC_STATUS_NOT_IMPLEMENTED;
       break;
     }

--- a/c/driver/postgresql/connection.h
+++ b/c/driver/postgresql/connection.h
@@ -73,6 +73,8 @@ class PostgresConnection {
     return type_resolver_;
   }
   bool autocommit() const { return autocommit_; }
+  std::array<int, 3> PostgreSQLVersion();
+  std::array<int, 3> RedshiftVersion();
 
  private:
   std::shared_ptr<PostgresDatabase> database_;

--- a/c/driver/postgresql/connection.h
+++ b/c/driver/postgresql/connection.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <memory>
 

--- a/c/driver/postgresql/connection.h
+++ b/c/driver/postgresql/connection.h
@@ -74,8 +74,8 @@ class PostgresConnection {
     return type_resolver_;
   }
   bool autocommit() const { return autocommit_; }
-  std::array<int, 3> PostgreSQLVersion();
-  std::array<int, 3> RedshiftVersion();
+  std::string_view VendorName();
+  const std::array<int, 3>& VendorVersion();
 
  private:
   std::shared_ptr<PostgresDatabase> database_;

--- a/c/driver/postgresql/copy/postgres_copy_reader_test.cc
+++ b/c/driver/postgresql/copy/postgres_copy_reader_test.cc
@@ -27,7 +27,7 @@ class PostgresCopyStreamTester {
  public:
   ArrowErrorCode Init(const PostgresType& root_type, ArrowError* error = nullptr) {
     NANOARROW_RETURN_NOT_OK(reader_.Init(root_type));
-    NANOARROW_RETURN_NOT_OK(reader_.InferOutputSchema(error));
+    NANOARROW_RETURN_NOT_OK(reader_.InferOutputSchema("PostgreSQL Tester", error));
     NANOARROW_RETURN_NOT_OK(reader_.InitFieldReaders(error));
     return NANOARROW_OK;
   }

--- a/c/driver/postgresql/copy/reader.h
+++ b/c/driver/postgresql/copy/reader.h
@@ -972,10 +972,11 @@ class PostgresCopyStreamReader {
     return NANOARROW_OK;
   }
 
-  ArrowErrorCode InferOutputSchema(ArrowError* error) {
+  ArrowErrorCode InferOutputSchema(const std::string& vendor_name, ArrowError* error) {
     schema_.reset();
     ArrowSchemaInit(schema_.get());
-    NANOARROW_RETURN_NOT_OK(root_reader_.InputType().SetSchema(schema_.get()));
+    NANOARROW_RETURN_NOT_OK(
+        root_reader_.InputType().SetSchema(schema_.get(), vendor_name));
     return NANOARROW_OK;
   }
 

--- a/c/driver/postgresql/database.cc
+++ b/c/driver/postgresql/database.cc
@@ -279,7 +279,7 @@ static Status InsertPgAttributeResult(
     const PqResultHelper& result, const std::shared_ptr<PostgresTypeResolver>& resolver) {
   int num_rows = result.NumRows();
   std::vector<std::pair<std::string, uint32_t>> columns;
-  uint32_t current_type_oid = 0;
+  int64_t current_type_oid = 0;
 
   if (result.NumColumns() != 3) {
     return Status::Internal(
@@ -303,7 +303,7 @@ static Status InsertPgAttributeResult(
   }
 
   if (!columns.empty()) {
-    resolver->InsertClass(current_type_oid, columns);
+    resolver->InsertClass(static_cast<uint32_t>(current_type_oid), columns);
   }
 
   return Status::Ok();
@@ -341,11 +341,11 @@ static Status InsertPgTypeResult(const PqResultHelper& result,
       typreceive = "aclitem_recv";
     }
 
-    type_item.oid = oid;
+    type_item.oid = static_cast<uint32_t>(oid);
     type_item.typname = typname;
     type_item.typreceive = typreceive;
-    type_item.class_oid = typrelid;
-    type_item.base_oid = typbasetype;
+    type_item.class_oid = static_cast<uint32_t>(typrelid);
+    type_item.base_oid = static_cast<uint32_t>(typbasetype);
 
     int result = resolver->Insert(type_item, nullptr);
 
@@ -355,7 +355,7 @@ static Status InsertPgTypeResult(const PqResultHelper& result,
       type_item.oid = typarray;
       type_item.typname = array_typname.c_str();
       type_item.typreceive = "array_recv";
-      type_item.child_oid = oid;
+      type_item.child_oid = static_cast<uint32_t>(oid);
 
       resolver->Insert(type_item, nullptr);
     }

--- a/c/driver/postgresql/database.cc
+++ b/c/driver/postgresql/database.cc
@@ -152,9 +152,9 @@ std::array<int, 3> ParseVersion(std::string_view version) {
   while (component_begin < version.size() && component < out.size()) {
     // Find the next character that marks a version component separation or the end of the
     // string
-    while (component_end < version.size() && version[component_end] != '.' &&
-           version[component_end] != '-') {
-      component_end++;
+    component_end = version.find_first_of(".-", component_begin);
+    if (component_end == version.npos) {
+      component_end = version.size();
     }
 
     // Try to parse the component as an integer (assigning zero if this fails)
@@ -183,9 +183,9 @@ std::array<int, 3> ParsePrefixedVersion(std::string_view version_info,
   }
 
   // Skip the prefix and any leading whitespace
-  pos += prefix.size();
-  while (pos < version_info.size() && version_info[pos] == ' ') {
-    ++pos;
+  pos = version_info.find_first_not_of(' ', pos + prefix.size());
+  if (pos == version_info.npos) {
+    return {0, 0, 0};
   }
 
   return ParseVersion(version_info.substr(pos));

--- a/c/driver/postgresql/database.cc
+++ b/c/driver/postgresql/database.cc
@@ -271,7 +271,7 @@ static std::string BuildPgTypeQuery(bool has_typarray) {
 
   return std::string() + "SELECT oid, typname, typreceive, typbasetype, typrelid" +
          maybe_typarray_col + " FROM pg_catalog.pg_type " +
-         " WHERE (typreceive != 0 OR typname = 'aclitem') AND typtype != 'r' " +
+         " WHERE (typreceive != 0 OR typsend != 0) AND typtype != 'r' " +
          maybe_array_recv_filter;
 }
 

--- a/c/driver/postgresql/database.cc
+++ b/c/driver/postgresql/database.cc
@@ -299,7 +299,7 @@ static Status InsertPgAttributeResult(
       current_type_oid = type_oid;
     }
 
-    columns.push_back({std::string(col_name), col_oid});
+    columns.push_back({std::string(col_name), static_cast<uint32_t>(col_oid)});
   }
 
   if (!columns.empty()) {

--- a/c/driver/postgresql/database.cc
+++ b/c/driver/postgresql/database.cc
@@ -17,6 +17,7 @@
 
 #include "database.h"
 
+#include <array>
 #include <charconv>
 #include <cinttypes>
 #include <cstring>

--- a/c/driver/postgresql/database.h
+++ b/c/driver/postgresql/database.h
@@ -26,6 +26,8 @@
 
 #include "postgres_type.h"
 
+#define ADBC_POSTGRESQL_OPTION_LOAD_ARRAY_TYPES "adbc.postgresql.load_array_types"
+
 namespace adbcpq {
 class PostgresDatabase {
  public:
@@ -64,6 +66,7 @@ class PostgresDatabase {
   int32_t open_connections_;
   std::string uri_;
   std::shared_ptr<PostgresTypeResolver> type_resolver_;
+  bool load_array_types_{true};
 };
 }  // namespace adbcpq
 

--- a/c/driver/postgresql/database.h
+++ b/c/driver/postgresql/database.h
@@ -60,12 +60,17 @@ class PostgresDatabase {
     return type_resolver_;
   }
 
-  AdbcStatusCode RebuildTypeResolver(struct AdbcError* error);
+  AdbcStatusCode InitVersions(PGconn* conn, struct AdbcError* error);
+  AdbcStatusCode RebuildTypeResolver(PGconn* conn, struct AdbcError* error);
+  std::array<int, 3> PostgreSQLVersion() { return postgres_server_version_; }
+  std::array<int, 3> RedshiftVersion() { return redshift_server_version_; }
 
  private:
   int32_t open_connections_;
   std::string uri_;
   std::shared_ptr<PostgresTypeResolver> type_resolver_;
+  std::array<int, 3> postgres_server_version_{};
+  std::array<int, 3> redshift_server_version_{};
   bool load_array_types_{true};
 };
 }  // namespace adbcpq

--- a/c/driver/postgresql/database.h
+++ b/c/driver/postgresql/database.h
@@ -64,8 +64,20 @@ class PostgresDatabase {
 
   Status InitVersions(PGconn* conn);
   Status RebuildTypeResolver(PGconn* conn);
-  std::array<int, 3> PostgreSQLVersion() { return postgres_server_version_; }
-  std::array<int, 3> RedshiftVersion() { return redshift_server_version_; }
+  std::string_view VendorName() {
+    if (redshift_server_version_[0] != 0) {
+      return "Redshift";
+    } else {
+      return "PostgreSQL";
+    }
+  }
+  const std::array<int, 3>& VendorVersion() {
+    if (redshift_server_version_[0] != 0) {
+      return redshift_server_version_;
+    } else {
+      return postgres_server_version_;
+    }
+  }
 
  private:
   int32_t open_connections_;

--- a/c/driver/postgresql/database.h
+++ b/c/driver/postgresql/database.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/c/driver/postgresql/database.h
+++ b/c/driver/postgresql/database.h
@@ -25,9 +25,12 @@
 #include <arrow-adbc/adbc.h>
 #include <libpq-fe.h>
 
+#include "driver/framework/status.h"
 #include "postgres_type.h"
 
 namespace adbcpq {
+using adbc::driver::Status;
+
 class PostgresDatabase {
  public:
   PostgresDatabase();
@@ -59,8 +62,8 @@ class PostgresDatabase {
     return type_resolver_;
   }
 
-  AdbcStatusCode InitVersions(PGconn* conn, struct AdbcError* error);
-  AdbcStatusCode RebuildTypeResolver(PGconn* conn, struct AdbcError* error);
+  Status InitVersions(PGconn* conn);
+  Status RebuildTypeResolver(PGconn* conn);
   std::array<int, 3> PostgreSQLVersion() { return postgres_server_version_; }
   std::array<int, 3> RedshiftVersion() { return redshift_server_version_; }
 

--- a/c/driver/postgresql/database.h
+++ b/c/driver/postgresql/database.h
@@ -26,8 +26,6 @@
 
 #include "postgres_type.h"
 
-#define ADBC_POSTGRESQL_OPTION_LOAD_ARRAY_TYPES "adbc.postgresql.load_array_types"
-
 namespace adbcpq {
 class PostgresDatabase {
  public:
@@ -71,7 +69,6 @@ class PostgresDatabase {
   std::shared_ptr<PostgresTypeResolver> type_resolver_;
   std::array<int, 3> postgres_server_version_{};
   std::array<int, 3> redshift_server_version_{};
-  bool load_array_types_{true};
 };
 }  // namespace adbcpq
 

--- a/c/driver/postgresql/postgres_type.h
+++ b/c/driver/postgresql/postgres_type.h
@@ -115,7 +115,7 @@ enum class PostgresTypeId {
   // This is not an actual type, but there are cases where all we have is an Oid
   // that was not inserted into the type resolver. We can't use "unknown" or "opaque"
   // or "void" because those names show up in actual pg_type tables.
-  kUnnamed
+  kUnnamedArrowOpaque
 };
 
 // Returns the receive function name as defined in the typrecieve column
@@ -144,7 +144,7 @@ class PostgresType {
   PostgresType() : PostgresType(PostgresTypeId::kUninitialized) {}
 
   static PostgresType Unnamed(uint32_t oid) {
-    return PostgresType(PostgresTypeId::kUnnamed)
+    return PostgresType(PostgresTypeId::kUnnamedArrowOpaque)
         .WithPgTypeInfo(oid, "unnamed<oid:" + std::to_string(oid) + ">");
   }
 

--- a/c/driver/postgresql/postgres_type_test.cc
+++ b/c/driver/postgresql/postgres_type_test.cc
@@ -339,7 +339,7 @@ TEST(PostgresTypeTest, PostgresTypeResolver) {
 
   EXPECT_EQ(resolver.FindWithDefault(123, &type), NANOARROW_OK);
   EXPECT_EQ(type.oid(), 123);
-  EXPECT_EQ(type.type_id(), PostgresTypeId::kUnnamed);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kUnnamedArrowOpaque);
   EXPECT_EQ(type.typname(), "unnamed<oid:123>");
 
   // Check error for Array with unknown child

--- a/c/driver/postgresql/postgres_type_test.cc
+++ b/c/driver/postgresql/postgres_type_test.cc
@@ -337,6 +337,11 @@ TEST(PostgresTypeTest, PostgresTypeResolver) {
   EXPECT_EQ(resolver.Find(123, &type, &error), EINVAL);
   EXPECT_STREQ(ArrowErrorMessage(&error), "Postgres type with oid 123 not found");
 
+  EXPECT_EQ(resolver.FindWithDefault(123, &type), NANOARROW_OK);
+  EXPECT_EQ(type.oid(), 123);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kUnnamed);
+  EXPECT_EQ(type.typname(), "unnamed<oid:123>");
+
   // Check error for Array with unknown child
   item.oid = 123;
   item.typname = "some_array";

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -167,7 +167,7 @@ class PqResultHelper {
     return PQfname(result_, column_number);
   }
   Oid FieldType(int column_number) const { return PQftype(result_, column_number); }
-  PqResultRow Row(int i) { return PqResultRow(result_, i); }
+  PqResultRow Row(int i) const { return PqResultRow(result_, i); }
 
   class iterator {
     const PqResultHelper& outer_;

--- a/c/driver/postgresql/result_reader.cc
+++ b/c/driver/postgresql/result_reader.cc
@@ -177,7 +177,7 @@ Status PqResultArrayReader::Initialize(int64_t* rows_affected) {
     UNWRAP_NANOARROW(na_error_, Internal,
                      type_resolver_->Find(helper_.FieldType(i), &child_type, &na_error_));
 
-    UNWRAP_ERRNO(Internal, child_type.SetSchema(schema_->children[i]));
+    UNWRAP_ERRNO(Internal, child_type.SetSchema(schema_->children[i], vendor_name_));
     UNWRAP_ERRNO(Internal,
                  ArrowSchemaSetName(schema_->children[i], helper_.FieldName(i)));
 

--- a/c/driver/postgresql/result_reader.cc
+++ b/c/driver/postgresql/result_reader.cc
@@ -174,8 +174,8 @@ Status PqResultArrayReader::Initialize(int64_t* rows_affected) {
 
   for (int i = 0; i < helper_.NumColumns(); i++) {
     PostgresType child_type;
-    UNWRAP_NANOARROW(na_error_, Internal,
-                     type_resolver_->Find(helper_.FieldType(i), &child_type, &na_error_));
+    UNWRAP_ERRNO(Internal,
+                 type_resolver_->FindWithDefault(helper_.FieldType(i), &child_type));
 
     UNWRAP_ERRNO(Internal, child_type.SetSchema(schema_->children[i], vendor_name_));
     UNWRAP_ERRNO(Internal,

--- a/c/driver/postgresql/result_reader.h
+++ b/c/driver/postgresql/result_reader.h
@@ -58,6 +58,10 @@ class PqResultArrayReader {
     bind_stream_->SetBind(stream);
   }
 
+  void SetVendorName(std::string_view vendor_name) {
+    vendor_name_ = std::string(vendor_name);
+  }
+
   int GetSchema(struct ArrowSchema* out);
   int GetNext(struct ArrowArray* out);
   const char* GetLastError();
@@ -74,6 +78,7 @@ class PqResultArrayReader {
   std::vector<std::unique_ptr<PostgresCopyFieldReader>> field_readers_;
   nanoarrow::UniqueSchema schema_;
   bool autocommit_;
+  std::string vendor_name_;
   struct AdbcError error_;
   struct ArrowError na_error_;
 

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -608,7 +608,8 @@ AdbcStatusCode PostgresStatement::ExecuteIngest(struct ArrowArrayStream* stream,
     RAISE_STATUS(error, result_helper.Execute());
     auto it = result_helper.begin();
     if (it == result_helper.end()) {
-      SetError(error, "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA()'");
+      SetError(error,
+               "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA()'");
       return ADBC_STATUS_INTERNAL;
     }
     current_schema = (*it)[0].data;

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -604,11 +604,11 @@ AdbcStatusCode PostgresStatement::ExecuteIngest(struct ArrowArrayStream* stream,
   // This is a little unfortunate; we need another DB roundtrip
   std::string current_schema;
   {
-    PqResultHelper result_helper{connection_->conn(), "SELECT CURRENT_SCHEMA"};
+    PqResultHelper result_helper{connection_->conn(), "SELECT CURRENT_SCHEMA()"};
     RAISE_STATUS(error, result_helper.Execute());
     auto it = result_helper.begin();
     if (it == result_helper.end()) {
-      SetError(error, "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA'");
+      SetError(error, "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA()'");
       return ADBC_STATUS_INTERNAL;
     }
     current_schema = (*it)[0].data;

--- a/c/driver/postgresql/statement.h
+++ b/c/driver/postgresql/statement.h
@@ -97,7 +97,7 @@ class PostgresStatement {
       : connection_(nullptr),
         query_(),
         prepared_(false),
-        use_copy_(true),
+        use_copy_(-1),
         reader_(nullptr) {
     std::memset(&bind_, 0, sizeof(bind_));
   }
@@ -161,7 +161,7 @@ class PostgresStatement {
   };
 
   // Options
-  bool use_copy_;
+  int use_copy_;
 
   struct {
     std::string db_schema;
@@ -171,5 +171,7 @@ class PostgresStatement {
   } ingest_;
 
   TupleReader reader_;
+
+  int UseCopy();
 };
 }  // namespace adbcpq

--- a/docs/source/driver/postgresql.rst
+++ b/docs/source/driver/postgresql.rst
@@ -35,6 +35,13 @@ overall approach.
           Performance/optimization and support for complex types and
           different ADBC features is still ongoing.
 
+.. note:: AWS Redshift supports a very old version of the PostgreSQL
+          wire protocol and has a basic level of support in the ADBC
+          PostgreSQL driver. Because Redshift does not support reading or
+          writing COPY in PostgreSQL binary format, the optimizations that
+          accellerate non-Redshift queries are not enabled when connecting
+          to a Redshift database. This functionality is experimental.
+
 Installation
 ============
 


### PR DESCRIPTION
Just following up on #1563 to see if the missing `typarray` column is the only issue. To get the details right might be a large project, but we might be able to support a basic connection without too much effort. Paramter binding and non-COPY result fetching seem to work...the default query fetch method (COPY) is not supported, `connection_get_info()` fails, and at a glance, `connection_get_objects()` might be returning incorrect results (and fails at the column depth).

``` r
library(adbcdrivermanager)

db <- adbc_database_init(
  adbcpostgresql::adbcpostgresql(),
  uri = Sys.getenv("ADBC_REDSHIFT_TEST_URI"),
  adbc.postgresql.load_array_types = FALSE
)

con <- db |> 
  adbc_connection_init()

stmt <- con |> 
  adbc_statement_init(adbc.postgresql.use_copy = FALSE)

stream <- nanoarrow::nanoarrow_allocate_array_stream()
stmt |> 
  adbc_statement_bind(data.frame(45)) |> 
  adbc_statement_set_sql_query("SELECT 1 + $1 as foofy, 'string' as foofy_string") |> 
  adbc_statement_execute_query(stream)
#> [1] -1

tibble::as_tibble(stream)
#> # A tibble: 1 × 2
#>   foofy foofy_string
#>   <dbl> <chr>       
#> 1    46 string
```

<sup>Created on 2024-10-04 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>