### PR TITLE
chore(ci): fix Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd
+          mkdir -p ${{ github.workspace }}/build
           tar xvf ~/local.tgz -C ${{ github.workspace }}/build
       - name: Set dynamic linker path
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           cd
           mkdir -p ${{ github.workspace }}/build
-          tar xvf ~/local.tgz -C ${{ github.workspace }}/build
+          tar xvf ~/local.tgz -C ${{ github.workspace }}/build --strip-components=1
       - name: Set dynamic linker path
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/rust/core/src/driver_manager.rs
+++ b/rust/core/src/driver_manager.rs
@@ -44,12 +44,10 @@
 //!
 //! ```rust
 //! # use std::sync::Arc;
-//! # use arrow::{
-//! #     array::{Array, StringArray, Int64Array, Float64Array},
-//! #     record_batch::{RecordBatch, RecordBatchReader},
-//! #     datatypes::{Field, Schema, DataType},
-//! #     compute::concat_batches,
-//! # };
+//! # use arrow_array::{Array, StringArray, Int64Array, Float64Array};
+//! # use arrow_array::{RecordBatch, RecordBatchReader};
+//! # use arrow_schema::{Field, Schema, DataType};
+//! # use arrow_select::concat::concat_batches;
 //! # use adbc_core::{
 //! #     driver_manager::ManagedDriver,
 //! #     options::{AdbcVersion, OptionDatabase, OptionStatement},


### PR DESCRIPTION
This step fails on `main` because the `build` directory does not exist. This was added in #2208, but never ran because the `native-unix` job was failing because of flaky tests.