### PR TITLE
chore(dev/release): pin Python 3.12 for now

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -43,6 +43,8 @@ jobs:
           go-version-file: 'go/adbc/go.mod'
           check-latest: true
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
       - name: install golangci-lint
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -513,10 +513,11 @@ test_cpp() {
 
   # Build and test C++
   maybe_setup_go
+  # XXX: pin Python for now since various other packages haven't caught up
   maybe_setup_conda \
     --file ci/conda_env_cpp.txt \
     compilers \
-    go=1.21 || exit 1
+    go=1.22 python=3.12 || exit 1
 
   if [ "${USE_CONDA}" -gt 0 ]; then
     export CMAKE_PREFIX_PATH="${CONDA_BACKUP_CMAKE_PREFIX_PATH}:${CMAKE_PREFIX_PATH}"
@@ -560,7 +561,8 @@ test_python() {
 
   # Build and test Python
   maybe_setup_virtualenv cython duckdb pandas protobuf pyarrow pytest setuptools_scm setuptools importlib_resources || exit 1
-  maybe_setup_conda --file "${ADBC_DIR}/ci/conda_env_python.txt" || exit 1
+  # XXX: pin Python for now since various other packages haven't caught up
+  maybe_setup_conda --file "${ADBC_DIR}/ci/conda_env_python.txt" python=3.12 || exit 1
 
   if [ "${USE_CONDA}" -gt 0 ]; then
     CMAKE_PREFIX_PATH="${CONDA_BACKUP_CMAKE_PREFIX_PATH}:${CMAKE_PREFIX_PATH}"
@@ -669,7 +671,7 @@ test_go() {
   # apache/arrow-adbc#517: `go build` calls git. Don't assume system
   # has git; even if it's there, go_build.sh sets DYLD_LIBRARY_PATH
   # which can interfere with system git.
-  maybe_setup_conda compilers git go=1.21 || exit 1
+  maybe_setup_conda compilers git go=1.22 || exit 1
 
   if [ "${USE_CONDA}" -gt 0 ]; then
     # The CMake setup forces RPATH to be the Conda prefix


### PR DESCRIPTION
Various dependencies don't quite work with 3.13 yet.