### PR TITLE
build(c): Fix linker error with SQLite tests

### DIFF
--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -491,6 +491,14 @@ class StatementTest {
                                             const char* timezone);
 };
 
+template <typename CType>
+void StatementTest::TestSqlIngestType(ArrowType type,
+                                      const std::vector<std::optional<CType>>& values,
+                                      bool dictionary_encode) {
+  SchemaField field("col", type);
+  TestSqlIngestType<CType>(field, values, dictionary_encode);
+}
+
 #define ADBCV_TEST_STATEMENT(FIXTURE)                                                   \
   static_assert(std::is_base_of<adbc_validation::StatementTest, FIXTURE>::value,        \
                 ADBCV_STRINGIFY(FIXTURE) " must inherit from StatementTest");           \

--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -179,14 +179,6 @@ void StatementTest::TestSqlIngestType(SchemaField field,
 }
 
 template <typename CType>
-void StatementTest::TestSqlIngestType(ArrowType type,
-                                      const std::vector<std::optional<CType>>& values,
-                                      bool dictionary_encode) {
-  SchemaField field("col", type);
-  TestSqlIngestType<CType>(field, values, dictionary_encode);
-}
-
-template <typename CType>
 void StatementTest::TestSqlIngestNumericType(ArrowType type) {
   std::vector<std::optional<CType>> values = {
       std::nullopt,


### PR DESCRIPTION
Noticed this when compiled via meson:

```base
$ meson setup builddir -Dtests=true -Dsqlite=true
$ meson compile -C builddir

...

/usr/bin/ld: driver/sqlite/adbc-driver-sqlite-test.p/sqlite_test.cc.o: in function `SqliteStatementTest_SqlIngestUInt64_Test::TestBody()':
sqlite_test.cc:(.text+0x802): undefined reference to `void adbc_validation::StatementTest::TestSqlIngestType<unsigned long>(ArrowType, std::vector<std::optional<unsigned long>, std::allocator<std::optional<unsigned long> > > const&, bool)'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

I'm not sure why the CMake config is OK with this, likely some magic I don't understand. However, it makes sense to me that the linker is complaining; the adbc_validation.h header declares this template but the definition is tucked away in adbc_validation_statement.cc. So I don't think the TU for sqlite_test.cc would have access to that (?) without moving the definition to the header.

Alternatively we could provide an explicit template instantiation for the type (uint64_t) in adbc_validation_statement.cc, though I don't think that is inline with the intent of this class