### PR TITLE
docs(r/adbcbigquery,r/adbcflightsql,r/adbcsnowflake): recommend to install from R-multiverse

### DIFF
--- a/r/adbcbigquery/README.Rmd
+++ b/r/adbcbigquery/README.Rmd
@@ -40,10 +40,11 @@ to the Arrow Database Connectivity (ADBC) BigQuery driver.
 
 ## Installation
 
-You can install the released version of adbcbigquery from [CRAN](https://cran.r-project.org/) with:
+You can install the released version of adbcbigquery from
+[R-multiverse](https://community.r-multiverse.org/) with:
 
 ```r
-install.packages("adbcbigquery")
+install.packages("adbcbigquery", repos = "https://community.r-multiverse.org")
 ```
 
 You can install the development version of adbcbigquery from [GitHub](https://github.com/) with:

--- a/r/adbcbigquery/README.md
+++ b/r/adbcbigquery/README.md
@@ -28,10 +28,10 @@ interface to the Arrow Database Connectivity (ADBC) BigQuery driver.
 ## Installation
 
 You can install the released version of adbcbigquery from
-[CRAN](https://cran.r-project.org/) with:
+[R-multiverse](https://community.r-multiverse.org/) with:
 
 ``` r
-install.packages("adbcbigquery")
+install.packages("adbcbigquery", repos = "https://community.r-multiverse.org")
 ```
 
 You can install the development version of adbcbigquery from

--- a/r/adbcflightsql/README.Rmd
+++ b/r/adbcflightsql/README.Rmd
@@ -40,10 +40,11 @@ to the Arrow Database Connectivity (ADBC) FlightSQL driver.
 
 ## Installation
 
-You can install the released version of adbcflightsql from [CRAN](https://cran.r-project.org/) with:
+You can install the released version of adbcflightsql from
+[R-multiverse](https://community.r-multiverse.org/) with:
 
 ```r
-install.packages("adbcflightsql")
+install.packages("adbcflightsql", repos = "https://community.r-multiverse.org")
 ```
 
 You can install the development version of adbcflightsql from [GitHub](https://github.com/) with:

--- a/r/adbcflightsql/README.md
+++ b/r/adbcflightsql/README.md
@@ -28,10 +28,10 @@ interface to the Arrow Database Connectivity (ADBC) FlightSQL driver.
 ## Installation
 
 You can install the released version of adbcflightsql from
-[CRAN](https://cran.r-project.org/) with:
+[R-multiverse](https://community.r-multiverse.org/) with:
 
 ``` r
-install.packages("adbcflightsql")
+install.packages("adbcflightsql", repos = "https://community.r-multiverse.org")
 ```
 
 You can install the development version of adbcflightsql from

--- a/r/adbcsnowflake/README.Rmd
+++ b/r/adbcsnowflake/README.Rmd
@@ -40,6 +40,13 @@ to the Arrow Database Connectivity (ADBC) Snowflake driver.
 
 ## Installation
 
+You can install the released version of adbcsnowflake from
+[R-multiverse](https://community.r-multiverse.org/) with:
+
+``` r
+install.packages("adbcsnowflake", repos = "https://community.r-multiverse.org")
+```
+
 You can install the development version of adbcsnowflake from [GitHub](https://github.com/) with:
 
 ``` r

--- a/r/adbcsnowflake/README.md
+++ b/r/adbcsnowflake/README.md
@@ -27,6 +27,13 @@ interface to the Arrow Database Connectivity (ADBC) Snowflake driver.
 
 ## Installation
 
+You can install the released version of adbcsnowflake from
+[R-multiverse](https://community.r-multiverse.org/) with:
+
+``` r
+install.packages("adbcsnowflake", repos = "https://community.r-multiverse.org")
+```
+
 You can install the development version of adbcsnowflake from
 [GitHub](https://github.com/) with:
 


### PR DESCRIPTION
Close #1647

In the short term, CRAN is unlikely to accept Go-based packages, so for now we can recommend installation from R-multiverse.

We can also use the ASF repo of R-universe (<https://apache.r-universe.dev/>), but R-multiverse is more reliable because it is tied to the latest release with certainty.

Note that `adbcbigquery` has not been added to R-multiverse yet (r-multiverse/contributions#213 will be merged after ADBC 15 release)