### PR TITLE
fix(csharp/src/Drivers/Apache): remove interleaved async look-ahead code

### DIFF
--- a/csharp/test/Drivers/Apache/Spark/DriverTests.cs
+++ b/csharp/test/Drivers/Apache/Spark/DriverTests.cs
@@ -114,7 +114,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
             for (int i = 0; i < queries.Length; i++)
             {
                 string query = queries[i];
-                AdbcStatement statement = adbcConnection.CreateStatement();
+                using AdbcStatement statement = adbcConnection.CreateStatement();
                 statement.SqlQuery = query;
 
                 UpdateResult updateResult = statement.ExecuteUpdate();


### PR DESCRIPTION
The attempt to use “look-ahead” buffering in the HiveServer2Reader is not supported by the Thrift library. The issue is that the Thrift library uses a shared buffer on the Client/Protocol/Transport object -so interleaving Fetch and ExecuteStatement will fail because the buffer will get closed unexpectedly.