### PR TITLE
feat(rust/drivers/datafusion): add support for bulk ingest

### DIFF
--- a/rust/drivers/datafusion/src/lib.rs
+++ b/rust/drivers/datafusion/src/lib.rs
@@ -821,7 +821,7 @@ impl Optionable for DataFusionStatement {
                 match target_table {
                     Some(table) => Ok(table),
                     None => Err(Error::with_message_and_status(
-                        format!("{} has not been set", key.as_ref()),
+                        format!("{key:?} has not been set"),
                         Status::NotFound,
                     )),
                 }

--- a/rust/drivers/datafusion/src/lib.rs
+++ b/rust/drivers/datafusion/src/lib.rs
@@ -862,7 +862,7 @@ impl Optionable for DataFusionStatement {
 
 impl Statement for DataFusionStatement {
     fn bind(&mut self, batch: arrow_array::RecordBatch) -> adbc_core::error::Result<()> {
-        self.bound_record_batch = RefCell::new(Some(batch));
+        self.bound_record_batch.replace(Some(batch));
         Ok(())
     }
 

--- a/rust/drivers/datafusion/src/lib.rs
+++ b/rust/drivers/datafusion/src/lib.rs
@@ -895,10 +895,8 @@ impl Statement for DataFusionStatement {
                     .await
                     .unwrap();
             });
-        } else if self.bound_record_batch.is_some() {
+        } else if let Some(batch) = self.bound_record_batch.take() {
             self.runtime.block_on(async {
-                let batch: RecordBatch = self.bound_record_batch.take().unwrap();
-
                 let table = match self.ingest_target_table.clone() {
                     Some(table) => table,
                     None => todo!(),


### PR DESCRIPTION
- swaps todos from Optionable impls to partial support: none for Database, CurrentCatalog and CurrentSchema for Connection and IngestTableTarget for Statement.
- adds support for binding a single batch and executing a bulk insert on it. I used `RefCell` to pass bound record batch from `bind` to an `execute_update` method.