### PR TITLE
fix(go/adbc/driver/internal/driverbase): proper unmarshalling for ConstraintColumnNames

### DIFF
--- a/go/adbc/driver/internal/driverbase/connection.go
+++ b/go/adbc/driver/internal/driverbase/connection.go
@@ -584,8 +584,8 @@ func RequiredList[T any](vals []T) requiredList[T] {
 type requiredList[T any] []T
 
 func (n requiredList[T]) UnmarshalJSON(data []byte) error {
-	v := []T(n)
-	return json.Unmarshal(data, &v)
+	v := (*[]T)(&n)
+	return json.Unmarshal(data, v)
 }
 
 func (n requiredList[T]) MarshalJSON() ([]byte, error) {

--- a/go/adbc/driver/internal/driverbase/connection.go
+++ b/go/adbc/driver/internal/driverbase/connection.go
@@ -583,8 +583,8 @@ func RequiredList[T any](vals []T) requiredList[T] {
 
 type requiredList[T any] []T
 
-func (n requiredList[T]) UnmarshalJSON(data []byte) error {
-	v := (*[]T)(&n)
+func (n *requiredList[T]) UnmarshalJSON(data []byte) error {
+	v := (*[]T)(n)
 	return json.Unmarshal(data, v)
 }
 

--- a/go/adbc/driver/internal/driverbase/driver_test.go
+++ b/go/adbc/driver/internal/driverbase/driver_test.go
@@ -19,6 +19,7 @@ package driverbase_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -30,6 +31,7 @@ import (
 	"github.com/apache/arrow/go/v18/arrow"
 	"github.com/apache/arrow/go/v18/arrow/array"
 	"github.com/apache/arrow/go/v18/arrow/memory"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -707,4 +709,14 @@ func tableFromRecordReader(rdr array.RecordReader) arrow.Table {
 		recs = append(recs, rec)
 	}
 	return array.NewTableFromRecords(rdr.Schema(), recs)
+}
+
+func TestRequiredList(t *testing.T) {
+	v := driverbase.RequiredList([]string{"a", "b", "c"})
+	result, err := json.Marshal(v)
+	require.NoError(t, err)
+	assert.JSONEq(t, `["a", "b", "c"]`, string(result))
+
+	require.NoError(t, json.Unmarshal([]byte(`["d", "e", "f"]`), &v))
+	assert.Equal(t, driverbase.RequiredList([]string{"d", "e", "f"}), v)
 }


### PR DESCRIPTION
Fixes #2278

The current `UnmarshalJSON` function for `requiredList` ended up unmarshalling into a copy of the underlying slice rather than using the actual slice, so the data wasn't being propagated appropriately. This fixes the `UnmarshalJSON` function to handle the scenario appropriately.