### PR TITLE
chore(java): bump arrow to 18.0.0

### DIFF
--- a/.env
+++ b/.env
@@ -28,7 +28,7 @@ ARCH_SHORT=amd64
 ARCH_CONDA_FORGE=linux_64_
 
 # Default versions for various dependencies
-JDK=8
+JDK=11
 MANYLINUX=2-28
 MAVEN=3.6.3
 PLATFORM=linux/amd64

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['8', '11', '17', '21', '22']
+        java: ['11', '17', '21', '22']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -243,7 +243,7 @@ jobs:
             docs.tgz
 
   java:
-    name: "Java 1.8"
+    name: "Java 11"
     runs-on: ubuntu-latest
     needs:
       - source

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -36,11 +36,7 @@ main() {
     pushd ${source_dir}/java
     mvn -B clean \
         install \
-        assembly:single \
-        source:jar \
-        javadoc:jar \
         -Papache-release \
-        -DdescriptorId=source-release \
         -T 2C \
         -DskipTests \
         -Dgpg.skip

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -21,7 +21,7 @@
 # Requirements
 # - Ruby >= 2.3
 # - Maven >= 3.3.9
-# - JDK >=7
+# - JDK >= 11
 # - gcc >= 4.8
 # - Go >= 1.21
 # - Docker

--- a/docs/source/development/releasing.rst
+++ b/docs/source/development/releasing.rst
@@ -218,7 +218,7 @@ How to Verify Release Candidates
    - GLib and gobject-introspection with headers
       - pkg-config or cmake must be able to find libarrow-glib.so
       - GI_TYPELIB_PATH should be set to the path to the girepository-1.0 directory
-   - Java JRE and JDK (Java 8+)
+   - Java JRE and JDK (Java 11+)
       - the javadoc command must also be accessible
    - Go
    - CMake, ninja-build, libpq (with headers), SQLite (with headers)

--- a/java/driver/flight-sql/pom.xml
+++ b/java/driver/flight-sql/pom.xml
@@ -103,13 +103,6 @@
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- To use FlightSeverTestRule from arrow-flight-sql-jdbc-core -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>flight-sql-jdbc-core</artifactId>

--- a/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/GetObjectsTests.java
+++ b/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/GetObjectsTests.java
@@ -38,7 +38,7 @@ import org.apache.arrow.adbc.core.AdbcDatabase;
 import org.apache.arrow.adbc.core.AdbcDriver;
 import org.apache.arrow.adbc.core.AdbcException;
 import org.apache.arrow.adbc.drivermanager.AdbcDriverManager;
-import org.apache.arrow.driver.jdbc.FlightServerTestRule;
+import org.apache.arrow.driver.jdbc.FlightServerTestExtension;
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
 import org.apache.arrow.flight.FlightProducer;
 import org.apache.arrow.flight.sql.FlightSqlProducer;
@@ -58,19 +58,19 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.util.Text;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Test functions for returning database catalog information. */
 public class GetObjectsTests {
   private static final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
   private static final MockFlightSqlProducer FLIGHT_SQL_PRODUCER = new MockFlightSqlProducer();
 
-  @ClassRule
-  public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE =
-      FlightServerTestRule.createStandardTestRule(FLIGHT_SQL_PRODUCER);
+  @RegisterExtension
+  public static FlightServerTestExtension FLIGHT_SERVER_TEST_EXTENSION =
+      FlightServerTestExtension.createStandardTestExtension(FLIGHT_SQL_PRODUCER);
 
   private static final int BASE_ROW_COUNT = 10;
   private static AdbcConnection connection;
@@ -82,13 +82,14 @@ public class GetObjectsTests {
     ALL_COLUMNS
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws AdbcException {
-    String uri = String.format("grpc+tcp://%s:%d", "localhost", FLIGHT_SERVER_TEST_RULE.getPort());
+    String uri =
+        String.format("grpc+tcp://%s:%d", "localhost", FLIGHT_SERVER_TEST_EXTENSION.getPort());
     Map<String, Object> params = new HashMap<>();
     params.put(AdbcDriver.PARAM_URI.getKey(), uri);
-    params.put(AdbcDriver.PARAM_USERNAME.getKey(), FlightServerTestRule.DEFAULT_USER);
-    params.put(AdbcDriver.PARAM_PASSWORD.getKey(), FlightServerTestRule.DEFAULT_PASSWORD);
+    params.put(AdbcDriver.PARAM_USERNAME.getKey(), FlightServerTestExtension.DEFAULT_USER);
+    params.put(AdbcDriver.PARAM_PASSWORD.getKey(), FlightServerTestExtension.DEFAULT_PASSWORD);
     params.put(FlightSqlConnectionProperties.WITH_COOKIE_MIDDLEWARE.getKey(), true);
     AdbcDatabase db =
         AdbcDriverManager.getInstance()
@@ -291,7 +292,7 @@ public class GetObjectsTests {
         commandGetTablesWithSchema, commandGetTablesWithSchemaResultProducer);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     AutoCloseables.close(connection, FLIGHT_SQL_PRODUCER, allocator);
   }

--- a/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/MutualTlsTest.java
+++ b/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/MutualTlsTest.java
@@ -30,21 +30,21 @@ import org.apache.arrow.adbc.core.AdbcDriver;
 import org.apache.arrow.adbc.core.AdbcException;
 import org.apache.arrow.adbc.core.AdbcStatusCode;
 import org.apache.arrow.adbc.drivermanager.AdbcDriverManager;
-import org.apache.arrow.driver.jdbc.FlightServerTestRule;
+import org.apache.arrow.driver.jdbc.FlightServerTestExtension;
 import org.apache.arrow.driver.jdbc.authentication.UserPasswordAuthentication;
 import org.apache.arrow.driver.jdbc.utils.FlightSqlTestCertificates;
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.AutoCloseables;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class MutualTlsTest {
 
-  @ClassRule public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
+  @RegisterExtension public static FlightServerTestExtension FLIGHT_SERVER_TEST_EXTENSION;
 
   private static final String USER_1 = "user1";
   private static final String PASS_1 = "pass1";
@@ -67,8 +67,8 @@ public class MutualTlsTest {
     UserPasswordAuthentication authentication =
         new UserPasswordAuthentication.Builder().user(USER_1, PASS_1).build();
 
-    FLIGHT_SERVER_TEST_RULE =
-        new FlightServerTestRule.Builder()
+    FLIGHT_SERVER_TEST_EXTENSION =
+        new FlightServerTestExtension.Builder()
             .authentication(authentication)
             .useEncryption(certKey.cert, certKey.key)
             .useMTlsClientVerification(FlightSqlTestCertificates.exampleCACert())
@@ -79,7 +79,7 @@ public class MutualTlsTest {
   private BufferAllocator allocator;
   private Map<String, Object> params;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     allocator = new RootAllocator(Long.MAX_VALUE);
     params = new HashMap<>();
@@ -87,7 +87,7 @@ public class MutualTlsTest {
     params.put(AdbcDriver.PARAM_PASSWORD.getKey(), PASS_1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     AutoCloseables.close(allocator);
   }
@@ -147,6 +147,6 @@ public class MutualTlsTest {
     String protocol = String.format("grpc%s", withTls ? "+tls" : "+tcp");
     return String.format(
         "%s://%s:%d",
-        protocol, FLIGHT_SERVER_TEST_RULE.getHost(), FLIGHT_SERVER_TEST_RULE.getPort());
+        protocol, FLIGHT_SERVER_TEST_EXTENSION.getHost(), FLIGHT_SERVER_TEST_EXTENSION.getPort());
   }
 }

--- a/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/TlsTest.java
+++ b/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/TlsTest.java
@@ -30,21 +30,21 @@ import org.apache.arrow.adbc.core.AdbcDriver;
 import org.apache.arrow.adbc.core.AdbcException;
 import org.apache.arrow.adbc.core.AdbcStatusCode;
 import org.apache.arrow.adbc.drivermanager.AdbcDriverManager;
-import org.apache.arrow.driver.jdbc.FlightServerTestRule;
+import org.apache.arrow.driver.jdbc.FlightServerTestExtension;
 import org.apache.arrow.driver.jdbc.authentication.UserPasswordAuthentication;
 import org.apache.arrow.driver.jdbc.utils.FlightSqlTestCertificates;
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.AutoCloseables;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class TlsTest {
 
-  @ClassRule public static final FlightServerTestRule FLIGHT_SERVER_TEST_RULE;
+  @RegisterExtension public static FlightServerTestExtension FLIGHT_SERVER_TEST_EXTENSION;
 
   private static final String USER_1 = "user1";
   private static final String PASS_1 = "pass1";
@@ -59,8 +59,8 @@ public class TlsTest {
     UserPasswordAuthentication authentication =
         new UserPasswordAuthentication.Builder().user(USER_1, PASS_1).build();
 
-    FLIGHT_SERVER_TEST_RULE =
-        new FlightServerTestRule.Builder()
+    FLIGHT_SERVER_TEST_EXTENSION =
+        new FlightServerTestExtension.Builder()
             .authentication(authentication)
             .useEncryption(certKey.cert, certKey.key)
             .producer(new MockFlightSqlProducer())
@@ -70,7 +70,7 @@ public class TlsTest {
   private BufferAllocator allocator;
   private Map<String, Object> params;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     allocator = new RootAllocator(Long.MAX_VALUE);
     params = new HashMap<>();
@@ -78,7 +78,7 @@ public class TlsTest {
     params.put(AdbcDriver.PARAM_PASSWORD.getKey(), PASS_1);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     AutoCloseables.close(allocator);
   }
@@ -160,7 +160,7 @@ public class TlsTest {
     params.put(AdbcDriver.PARAM_URI.getKey(), getUri(true));
     params.put(
         FlightSqlConnectionProperties.TLS_OVERRIDE_HOSTNAME.getKey(),
-        FLIGHT_SERVER_TEST_RULE.getHost());
+        FLIGHT_SERVER_TEST_EXTENSION.getHost());
     try (InputStream stream = Files.newInputStream(Paths.get(TLS_ROOT_CERTS_PATH))) {
       params.put(FlightSqlConnectionProperties.TLS_ROOT_CERTS.getKey(), stream);
       AdbcDatabase db =
@@ -174,6 +174,6 @@ public class TlsTest {
     String protocol = String.format("grpc%s", withTls ? "+tls" : "+tcp");
     return String.format(
         "%s://%s:%d",
-        protocol, FLIGHT_SERVER_TEST_RULE.getHost(), FLIGHT_SERVER_TEST_RULE.getPort());
+        protocol, FLIGHT_SERVER_TEST_EXTENSION.getHost(), FLIGHT_SERVER_TEST_EXTENSION.getPort());
   }
 }

--- a/java/driver/jdbc-validation-mssqlserver/pom.xml
+++ b/java/driver/jdbc-validation-mssqlserver/pom.xml
@@ -72,17 +72,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>jdk8</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
-
-      <properties>
-        <dep.mssql-jdbc.version>12.4.1.jre8</dep.mssql-jdbc.version>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -101,7 +101,7 @@
     <!-- org.apache:apache overrides -->
     <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
     <maven.compiler.target>11</maven.compiler.target>
-    <surefire.version>3.5.1</surefire.version>
+    <surefire.version>3.5.2</surefire.version>
     <version.maven-javadoc-plugin>3.11.1</version.maven-javadoc-plugin>
   </properties>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>33</version>
   </parent>
 
   <groupId>org.apache.arrow.adbc</groupId>
@@ -96,9 +96,13 @@
   </distributionManagement>
 
   <properties>
-    <dep.arrow.version>15.0.0</dep.arrow.version>
+    <dep.arrow.version>18.0.0</dep.arrow.version>
     <dep.org.checkerframework.version>3.48.2</dep.org.checkerframework.version>
-    <adbc.version>0.15.0-SNAPSHOT</adbc.version>
+    <!-- org.apache:apache overrides -->
+    <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
+    <maven.compiler.target>11</maven.compiler.target>
+    <surefire.version>3.5.1</surefire.version>
+    <version.maven-javadoc-plugin>3.11.1</version.maven-javadoc-plugin>
   </properties>
 
   <dependencyManagement>
@@ -116,32 +120,32 @@
       <dependency>
         <groupId>org.apache.arrow.adbc</groupId>
         <artifactId>adbc-core</artifactId>
-        <version>${adbc.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.arrow.adbc</groupId>
         <artifactId>adbc-driver-flight-sql</artifactId>
-        <version>${adbc.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.arrow.adbc</groupId>
         <artifactId>adbc-driver-jdbc</artifactId>
-        <version>${adbc.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.arrow.adbc</groupId>
         <artifactId>adbc-driver-validation</artifactId>
-        <version>${adbc.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.arrow.adbc</groupId>
         <artifactId>adbc-driver-manager</artifactId>
-        <version>${adbc.version}</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.arrow.adbc</groupId>
         <artifactId>adbc-sql</artifactId>
-        <version>${adbc.version}</version>
+        <version>${project.version}</version>
       </dependency>
 
       <!-- Linting and static analysis -->
@@ -171,11 +175,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.5.2</version>
-        </plugin>
-        <plugin>
           <groupId>com.diffplug.spotless</groupId>
           <artifactId>spotless-maven-plugin</artifactId>
           <version>2.43.0</version>
@@ -186,11 +185,9 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
+        <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
 
@@ -236,11 +233,9 @@
   <reporting>
     <plugins>
       <plugin>
-        <!-- Will only work with JDK 17 (JDK 21 is broken and JDK 8 emits the
-             wrong stylesheet) -->
+        <!-- Will only work with JDK 17 (JDK 21 is broken) -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.11.1</version>
         <configuration>
           <!-- Ignore missing @return, @throws -->
           <doclint>all,-missing</doclint>
@@ -248,9 +243,7 @@
             <link>https://arrow.apache.org/docs/java/reference/</link>
           </links>
           <!-- Stop it from trying to document the tests -->
-          <release>8</release>
           <show>public</show>
-          <source>1.8</source>
         </configuration>
         <reportSets>
           <reportSet>
@@ -273,50 +266,13 @@
 
   <profiles>
     <profile>
-      <id>jdk8</id>
-      <activation>
-        <jdk>8</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>jdk9+</id>
-      <activation>
-        <jdk>[9,]</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
       <id>errorprone</id>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.13.0</version>
             <configuration>
-              <source>1.8</source>
-              <target>1.8</target>
-              <encoding>UTF-8</encoding>
               <compilerArgs combine.children="append">
                 <arg>-XDcompilePolicy=simple</arg>
                 <arg>-Xplugin:ErrorProne -Xep:NullAway:ERROR -XepOpt:NullAway:AnnotatedPackages=com.uber</arg>


### PR DESCRIPTION
Update arrow dependency from 15.0.0 to 18.0.0.

As Apache Arrow now requires Java 11, Apache Arrow ADBC also now requires Java 11.

Update Apache Parent pom to version 33 and take advantage of Java 9+ support.

Clean up pom.xml files to remove duplicate or conflicting plugin version definition and/or configuration

Update FlightSQL tests to use the FlightSQL Junit 5 extension.

Update build and dev scripts, and documentation