### PR TITLE
ci: make token available when verifying binaries

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,13 +30,10 @@ on:
         required: false
         type: string
         default: ""
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/verify.yml'
-      - 'dev/release/verify-release-candidate.sh'
-      - 'dev/release/verify-release-candidate.ps1'
+
+# Don't automatically run on pull requests.  While we're only using a
+# read-only token below, let's play it safe since we are running code out of
+# the given branch.
 
 permissions:
   contents: read
@@ -70,6 +67,8 @@ jobs:
           TEST_BINARIES: "1"
           USE_CONDA: "1"
           VERBOSE: "1"
+          # Make this available to download_rc_binaries.py
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./dev/release/verify-release-candidate.sh ${{ inputs.version }} ${{ inputs.rc }}
 


### PR DESCRIPTION
Otherwise GitHub rate-limits us.

Fixes #2307.