### PR TITLE
chore(c): fix some warnings reported by MSVC

### DIFF
--- a/c/cmake_modules/AdbcDefines.cmake
+++ b/c/cmake_modules/AdbcDefines.cmake
@@ -93,7 +93,9 @@ if(MSVC)
   # Don't warn about padding added after members
   add_compile_options(/wd4820)
   add_compile_options(/wd5027)
+  add_compile_options(/wd5039)
   add_compile_options(/wd5045)
+  add_compile_options(/wd5246)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
        OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
        OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")

--- a/c/driver/framework/base_driver.h
+++ b/c/driver/framework/base_driver.h
@@ -116,8 +116,9 @@ class Option {
                                              "': trailing data", value);
             }
             return parsed;
+          } else {
+            return status::InvalidArgument("Invalid integer value ", this->Format());
           }
-          return status::InvalidArgument("Invalid integer value ", this->Format());
         },
         value_);
   }
@@ -129,8 +130,9 @@ class Option {
           using T = std::decay_t<decltype(value)>;
           if constexpr (std::is_same_v<T, std::string>) {
             return value;
+          } else {
+            return status::InvalidArgument("Invalid string value ", this->Format());
           }
-          return status::InvalidArgument("Invalid string value ", this->Format());
         },
         value_);
   }

--- a/c/driver/framework/utility.cc
+++ b/c/driver/framework/utility.cc
@@ -163,7 +163,6 @@ Status MakeGetInfoStream(const std::vector<InfoValue>& infos, ArrowArrayStream* 
           } else {
             static_assert(!sizeof(T), "info value type not implemented");
           }
-          return status::Ok();
         },
         info.value));
     UNWRAP_ERRNO(Internal, ArrowArrayFinishElement(array.get()));

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -300,7 +300,8 @@ class PostgresGetObjectsHelper : public adbc::driver::GetObjectsHelper {
 
     Column col;
     col.column_name = next_column_[0].value();
-    UNWRAP_RESULT(col.ordinal_position, next_column_[1].ParseInteger());
+    UNWRAP_RESULT(int64_t ordinal_position, next_column_[1].ParseInteger());
+    col.ordinal_position = static_cast<int32_t>(ordinal_position);
     if (!next_column_[2].is_null) {
       col.remarks = next_column_[2].value();
     }

--- a/c/driver/postgresql/database.cc
+++ b/c/driver/postgresql/database.cc
@@ -294,7 +294,7 @@ static Status InsertPgAttributeResult(
     UNWRAP_RESULT(int64_t col_oid, item[2].ParseInteger());
 
     if (type_oid != current_type_oid && !columns.empty()) {
-      resolver->InsertClass(current_type_oid, columns);
+      resolver->InsertClass(static_cast<uint32_t>(current_type_oid), columns);
       columns.clear();
       current_type_oid = type_oid;
     }
@@ -347,12 +347,12 @@ static Status InsertPgTypeResult(const PqResultHelper& result,
     type_item.class_oid = static_cast<uint32_t>(typrelid);
     type_item.base_oid = static_cast<uint32_t>(typbasetype);
 
-    int result = resolver->Insert(type_item, nullptr);
+    int insert_result = resolver->Insert(type_item, nullptr);
 
     // If there's an array type and the insert succeeded, add that now too
-    if (result == NANOARROW_OK && typarray != 0) {
+    if (insert_result == NANOARROW_OK && typarray != 0) {
       std::string array_typname = "_" + std::string(typname);
-      type_item.oid = typarray;
+      type_item.oid = static_cast<uint32_t>(typarray);
       type_item.typname = array_typname.c_str();
       type_item.typreceive = "array_recv";
       type_item.child_oid = static_cast<uint32_t>(oid);

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -46,7 +46,7 @@ Status PqResultHelper::PrepareInternal(int n_params, const Oid* param_oids) cons
 Status PqResultHelper::Prepare() const { return PrepareInternal(0, nullptr); }
 
 Status PqResultHelper::Prepare(const std::vector<Oid>& param_oids) const {
-  return PrepareInternal(param_oids.size(), param_oids.data());
+  return PrepareInternal(static_cast<int>(param_oids.size()), param_oids.data());
 }
 
 Status PqResultHelper::DescribePrepared() {
@@ -90,8 +90,8 @@ Status PqResultHelper::Execute(const std::vector<std::string>& params,
     }
 
     ClearResult();
-    result_ = PQexecParams(conn_, query_.c_str(), param_values.size(), param_oids_ptr,
-                           param_values.data(), param_lengths.data(),
+    result_ = PQexecParams(conn_, query_.c_str(), static_cast<int>(param_values.size()),
+                           param_oids_ptr, param_values.data(), param_lengths.data(),
                            param_formats.data(), static_cast<int>(output_format_));
   }
 

--- a/c/driver/postgresql/result_reader.cc
+++ b/c/driver/postgresql/result_reader.cc
@@ -100,8 +100,8 @@ int PqResultArrayReader::GetNext(struct ArrowArray* out) {
         item.size_bytes = pg_item.len;
       }
 
-      NANOARROW_RETURN_NOT_OK(
-          field_readers_[i]->Read(&item, item.size_bytes, tmp->children[i], &na_error_));
+      NANOARROW_RETURN_NOT_OK(field_readers_[i]->Read(
+          &item, static_cast<int32_t>(item.size_bytes), tmp->children[i], &na_error_));
     }
   }
 

--- a/c/driver/sqlite/sqlite.cc
+++ b/c/driver/sqlite/sqlite.cc
@@ -150,7 +150,7 @@ class SqliteQuery {
     return Close(rc);
   }
 
-  Status Close(int rc) {
+  Status Close(int last_rc) {
     if (stmt_) {
       int rc = sqlite3_finalize(stmt_);
       stmt_ = nullptr;
@@ -158,7 +158,7 @@ class SqliteQuery {
         return status::fmt::Internal("failed to execute: {}\nquery was: {}",
                                      sqlite3_errmsg(conn_), query_);
       }
-    } else if (rc != SQLITE_OK) {
+    } else if (last_rc != SQLITE_OK) {
       return status::fmt::Internal("failed to execute: {}\nquery was: {}",
                                    sqlite3_errmsg(conn_), query_);
     }
@@ -192,7 +192,7 @@ class SqliteQuery {
       UNWRAP_RESULT(bool has_row, q.Next());
       if (!has_row) break;
 
-      int rc = std::forward<RowFunc>(row_func)(q.stmt_);
+      rc = std::forward<RowFunc>(row_func)(q.stmt_);
       if (rc != SQLITE_OK) break;
     }
     return q.Close();


### PR DESCRIPTION
Noted in https://github.com/conda-forge/arrow-adbc-split-feedstock/pull/17