### PR TITLE
chore: bump last instance of `actions/*-artifact` to v4

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -132,7 +132,7 @@ jobs:
           popd
 
       - name: Upload Go binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 7
           path: |
@@ -167,7 +167,7 @@ jobs:
           echo "schedule: ${{ github.event.schedule }}" >> $GITHUB_STEP_SUMMARY
           echo "ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: adbc/go/adbc/pkg
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -175,7 +175,8 @@ jobs:
 
       - name: Copy Go binaries
         run: |
-          pushd adbc/go/adbc/pkg
+          ls -R adbc/go/pkg
+          pushd adbc/go/adbc/pkg/go-ubuntu-latest
           cp *.dll ../
           cp *.so ../
           cp *.dylib ../

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -176,6 +176,7 @@ jobs:
 
       - name: Copy Go binaries
         run: |
+          ls -R
           pushd adbc/go/adbc/pkg/
           cp *.dll ../
           cp *.so ../

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -170,13 +170,13 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: go-ubuntu-latest
+          pattern: go-*
           path: adbc/go/adbc/pkg
+          merge-multiple: true
 
       - name: Copy Go binaries
         run: |
-          ls -R adbc/go/pkg
-          pushd adbc/go/adbc/pkg/go-ubuntu-latest
+          pushd adbc/go/adbc/pkg/
           cp *.dll ../
           cp *.so ../
           cp *.dylib ../

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Copy Go binaries
         run: |
-          pushd adbc/go/adbc/pkg/artifact
+          pushd adbc/go/adbc/pkg
           cp *.dll ../
           cp *.so ../
           cp *.dylib ../

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -176,7 +176,6 @@ jobs:
 
       - name: Copy Go binaries
         run: |
-          ls -R
           pushd adbc/go/adbc/pkg/
           cp *.dll ../
           cp *.so ../

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Upload Go binaries
         uses: actions/upload-artifact@v4
         with:
+          name: go-${{ matrix.os }}
           retention-days: 7
           path: |
             adbc/go/adbc/pkg/libadbc_driver_flightsql.*
@@ -169,6 +170,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
+          name: go-ubuntu-latest
           path: adbc/go/adbc/pkg
 
       - name: Copy Go binaries


### PR DESCRIPTION
This instance was merged a day after everything else was bumped and as the dependabot PR was closed it's ignoring it.