### PR TITLE
ci(ci/scripts): Introduce the option to pack csharp without building

### DIFF
--- a/ci/scripts/csharp_pack.ps1
+++ b/ci/scripts/csharp_pack.ps1
@@ -13,10 +13,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+[CmdletBinding(PositionalBinding=$false)]
 param (
     [string]$destination=$null,
-    [string]$versionSuffix=$null
+    [string]$versionSuffix=$null,
+    [switch]$noBuild
 )
 
 $csharpFolder = [IO.Path]::Combine($PSScriptRoot, "..", "..", "csharp") | Resolve-Path
@@ -34,6 +35,10 @@ if ($destination) {
 if ($versionSuffix) {
     Write-Host " * Version Suffix: $versionSuffix"
     $packArgs["-version-suffix"] = $versionSuffix
+}
+if ($noBuild) {
+    Write-Host " * Pack without building"
+    $packArgs["-no-build"] = $true
 }
 
 dotnet pack @packArgs

--- a/ci/scripts/csharp_pack.sh
+++ b/ci/scripts/csharp_pack.sh
@@ -23,10 +23,7 @@ source_dir=${1}/csharp
 
 pushd ${source_dir}
 
-if [ -z ${2-} ]; then
-    dotnet pack -c Release;
-else
-    dotnet pack -c Release --version-suffix ${2};
-fi
+shift
+dotnet pack -c Release "$@";
 
 popd


### PR DESCRIPTION
Modifying the csharp_pack.ps1 script to allow for packing without building.
This unlocks scenarios where we can build and sign the binaries, then pack without having them be overwritten by an implicit build.

Updated the csharp_pack.sh script for parity.