### PR TITLE
feat(rust/driver/snowflake)!: return a `Result` from `Builder::from_env` when parsing fails

### DIFF
--- a/rust/driver/snowflake/README.md
+++ b/rust/driver/snowflake/README.md
@@ -41,10 +41,10 @@ use arrow_array::{cast::AsArray, types::Decimal128Type};
 let mut driver = Driver::try_load()?;
 
 // Construct a database using environment variables
-let mut database = database::Builder::from_env().build(&mut driver)?;
+let mut database = database::Builder::from_env()?.build(&mut driver)?;
 
 // Create a connection to the database
-let mut connection = connection::Builder::from_env().build(&mut database)?;
+let mut connection = connection::Builder::from_env()?.build(&mut database)?;
 
 // Construct a statement to execute a query
 let mut statement = connection.new_statement()?;

--- a/rust/driver/snowflake/src/connection/builder.rs
+++ b/rust/driver/snowflake/src/connection/builder.rs
@@ -19,8 +19,6 @@
 //!
 //!
 
-#[cfg(feature = "env")]
-use std::env;
 use std::fmt;
 
 use adbc_core::{
@@ -30,7 +28,7 @@ use adbc_core::{
 };
 
 #[cfg(feature = "env")]
-use crate::database;
+use crate::{builder::env_parse_map_err, database};
 use crate::{builder::BuilderIter, Connection, Database};
 
 /// A builder for [`Connection`].
@@ -61,18 +59,21 @@ impl Builder {
 
     /// Construct a builder, setting values based on values of the
     /// configuration environment variables.
-    pub fn from_env() -> Self {
+    ///
+    /// # Error
+    ///
+    /// Returns an error when environment variables are set but their values
+    /// fail to parse.
+    pub fn from_env() -> Result<Self> {
         #[cfg(feature = "dotenv")]
         let _ = dotenvy::dotenv();
 
-        let use_high_precision = env::var(Self::USE_HIGH_PRECISION_ENV)
-            .ok()
-            .as_deref()
-            .and_then(|value| value.parse().ok());
-        Self {
+        let use_high_precision = env_parse_map_err(Self::USE_HIGH_PRECISION_ENV, str::parse)?;
+
+        Ok(Self {
             use_high_precision,
             ..Default::default()
-        }
+        })
     }
 }
 

--- a/rust/driver/snowflake/src/duration.rs
+++ b/rust/driver/snowflake/src/duration.rs
@@ -39,11 +39,11 @@ fn arg_err(err: impl StdError) -> Error {
 }
 
 fn overflow() -> Error {
-    invalid_arg("overflow")
+    invalid_arg("duration overflow")
 }
 
 fn bad_input<T>() -> Result<T> {
-    Err(invalid_arg("bad input"))
+    Err(invalid_arg("invalid duration (valid durations are a sequence of decimal numbers, each with optional fraction and a unit suffix, such as 300ms, 1.5h, 2h45m, valid time units are ns, us, ms, s, m, h)"))
 }
 
 /// Parse the given string to a [`Duration`], returning an eror when parsing
@@ -260,7 +260,7 @@ mod tests {
                 + Duration::from_secs(48)
                 + Duration::from_nanos(372539828))
         );
-        let bad_input = Err(invalid_arg("bad input"));
+        let bad_input = Err(invalid_arg("invalid duration (valid durations are a sequence of decimal numbers, each with optional fraction and a unit suffix, such as 300ms, 1.5h, 2h45m, valid time units are ns, us, ms, s, m, h)"));
         assert_eq!(parse_duration(""), bad_input);
         assert_eq!(parse_duration("3"), bad_input);
         assert_eq!(parse_duration("-"), bad_input);

--- a/rust/driver/snowflake/tests/driver.rs
+++ b/rust/driver/snowflake/tests/driver.rs
@@ -47,16 +47,16 @@ mod tests {
     const ADBC_VERSION: AdbcVersion = AdbcVersion::V110;
 
     static DRIVER: LazyLock<Result<Driver>> = LazyLock::new(|| {
-        driver::Builder::from_env()
+        driver::Builder::from_env()?
             .with_adbc_version(ADBC_VERSION)
             .try_load()
     });
 
     static DATABASE: LazyLock<Result<Database>> =
-        LazyLock::new(|| database::Builder::from_env().build(&mut DRIVER.deref().clone()?));
+        LazyLock::new(|| database::Builder::from_env()?.build(&mut DRIVER.deref().clone()?));
 
     static CONNECTION: LazyLock<Result<Connection>> =
-        LazyLock::new(|| connection::Builder::from_env().build(&mut DATABASE.deref().clone()?));
+        LazyLock::new(|| connection::Builder::from_env()?.build(&mut DATABASE.deref().clone()?));
 
     fn with_database(func: impl FnOnce(Database) -> Result<()>) -> Result<()> {
         DATABASE.deref().clone().and_then(func)


### PR DESCRIPTION
As suggested in https://github.com/apache/arrow-adbc/pull/2207#discussion_r1853206066 the `Builder::from_env` methods should return a result when parsing fails.