### PR TITLE
chore(dev/release): hold off publishing `adbc_snowflake` crate for now

### DIFF
--- a/dev/release/post-08-rust.sh
+++ b/dev/release/post-08-rust.sh
@@ -42,12 +42,10 @@ main() {
 
   pushd "${SOURCE_TOP_DIR}/rust"
   cargo publish --all-features -p adbc_core
-  cargo publish -p adbc_snowflake
   popd
 
-  echo "Success! The released Cargo crates are available here:"
+  echo "Success! The released Cargo crate is available here:"
   echo "  https://crates.io/crates/adbc_core"
-  echo "  https://crates.io/crates/adbc_snowflake"
 }
 
 main "$@"


### PR DESCRIPTION
This reverts commit 041f72ded9b594efa950454a6284385319ef3f9e.

We want to hold off publishing the `adbc_snowflake` crate to crates.io for now.