### PR TITLE
fix(go/adbc/driver/bigquery): set default project and dataset for new statements

### DIFF
--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -440,6 +440,10 @@ func (c *connectionImpl) NewStatement() (adbc.Statement, error) {
 		parameterMode:          OptionValueQueryParameterModePositional,
 		resultRecordBufferSize: c.resultRecordBufferSize,
 		prefetchConcurrency:    c.prefetchConcurrency,
+		queryConfig: bigquery.QueryConfig{
+			DefaultProjectID: c.catalog,
+			DefaultDatasetID: c.dbSchema,
+		},
 	}, nil
 }
 


### PR DESCRIPTION
This PR sets `DefaultProjectID` and `DefaultDatasetID` for new `adbc.Statement` to the corresponding value in the `adbc.Connection`.