### PR TITLE
feat(csharp/src/Client): parse custom properties from connection string

### DIFF
--- a/csharp/src/Client/AdbcCommand.cs
+++ b/csharp/src/Client/AdbcCommand.cs
@@ -53,6 +53,7 @@ namespace Apache.Arrow.Adbc.Client
 
             this.DbConnection = adbcConnection;
             this.DecimalBehavior = adbcConnection.DecimalBehavior;
+            this.StructBehavior = adbcConnection.StructBehavior;
             this._adbcStatement = adbcConnection.CreateStatement();
         }
 
@@ -74,6 +75,7 @@ namespace Apache.Arrow.Adbc.Client
 
             this.DbConnection = adbcConnection;
             this.DecimalBehavior = adbcConnection.DecimalBehavior;
+            this.StructBehavior = adbcConnection.StructBehavior;
         }
 
         // For testing
@@ -83,6 +85,12 @@ namespace Apache.Arrow.Adbc.Client
             this.DbConnection = adbcConnection;
             this.DecimalBehavior = adbcConnection.DecimalBehavior;
             this.StructBehavior = adbcConnection.StructBehavior;
+
+            if (adbcConnection.CommandTimeoutValue != null)
+            {
+                this.AdbcCommandTimeoutProperty = adbcConnection.CommandTimeoutValue.DriverPropertyName;
+                this.CommandTimeout = adbcConnection.CommandTimeoutValue.Value;
+            }
         }
 
         /// <summary>
@@ -118,7 +126,6 @@ namespace Apache.Arrow.Adbc.Client
                 }
             }
         }
-
 
         /// <summary>
         /// Gets or sets the name of the command timeout property for the underlying ADBC driver.

--- a/csharp/src/Client/AdbcCommand.cs
+++ b/csharp/src/Client/AdbcCommand.cs
@@ -88,7 +88,7 @@ namespace Apache.Arrow.Adbc.Client
 
             if (adbcConnection.CommandTimeoutValue != null)
             {
-                this.adbcConnectionParameters[connectionTimeoutValue.DriverPropertyName] = connectionTimeoutValue.Value.ToString();
+                this.AdbcCommandTimeoutProperty = adbcConnection.CommandTimeoutValue.DriverPropertyName;
                 this.CommandTimeout = adbcConnection.CommandTimeoutValue.Value;
             }
         }

--- a/csharp/src/Client/AdbcCommand.cs
+++ b/csharp/src/Client/AdbcCommand.cs
@@ -88,7 +88,7 @@ namespace Apache.Arrow.Adbc.Client
 
             if (adbcConnection.CommandTimeoutValue != null)
             {
-                this.AdbcCommandTimeoutProperty = adbcConnection.CommandTimeoutValue.DriverPropertyName;
+                this.adbcConnectionParameters[connectionTimeoutValue.DriverPropertyName] = connectionTimeoutValue.Value.ToString();
                 this.CommandTimeout = adbcConnection.CommandTimeoutValue.Value;
             }
         }

--- a/csharp/src/Client/AdbcConnection.cs
+++ b/csharp/src/Client/AdbcConnection.cs
@@ -261,8 +261,6 @@ namespace Apache.Arrow.Adbc.Client
                 {
                     string paramValue = Convert.ToString(builderValue)!;
 
-                    this.adbcConnectionParameters.Add(key, paramValue);
-
                     switch (key)
                     {
                         case ConnectionStringKeywords.DecimalBehavior:
@@ -276,6 +274,10 @@ namespace Apache.Arrow.Adbc.Client
                             break;
                         case ConnectionStringKeywords.ConnectionTimeout:
                             this.connectionTimeoutValue = ConnectionStringParser.ParseTimeoutValue(paramValue);
+                            this.adbcConnectionParameters.Add(connectionTimeoutValue.DriverPropertyName, connectionTimeoutValue.Value.ToString());
+                            break;
+                        default:
+                            this.adbcConnectionParameters.Add(key, paramValue);
                             break;
                     }
                 }

--- a/csharp/src/Client/AdbcConnection.cs
+++ b/csharp/src/Client/AdbcConnection.cs
@@ -106,10 +106,7 @@ namespace Apache.Arrow.Adbc.Client
         /// Creates a new <see cref="AdbcCommand"/>.
         /// </summary>
         /// <returns><see cref="AdbcCommand"/></returns>
-        public new AdbcCommand CreateCommand()
-        {
-            return (AdbcCommand)CreateDbCommand();
-        }
+        public new AdbcCommand CreateCommand() => (AdbcCommand)CreateDbCommand();
 
         /// <summary>
         /// Gets or sets the <see cref="AdbcDriver"/> associated with this
@@ -158,11 +155,6 @@ namespace Apache.Arrow.Adbc.Client
         {
             EnsureConnectionOpen();
 
-            return GetAdbcCommand();
-        }
-
-        private AdbcCommand GetAdbcCommand()
-        {
             AdbcCommand cmd = new AdbcCommand(this);
 
             if (CommandTimeoutValue != null)

--- a/csharp/src/Client/AdbcConnection.cs
+++ b/csharp/src/Client/AdbcConnection.cs
@@ -274,7 +274,7 @@ namespace Apache.Arrow.Adbc.Client
                             break;
                         case ConnectionStringKeywords.ConnectionTimeout:
                             this.connectionTimeoutValue = ConnectionStringParser.ParseTimeoutValue(paramValue);
-                            this.adbcConnectionParameters.Add(connectionTimeoutValue.DriverPropertyName, connectionTimeoutValue.Value.ToString());
+                            this.adbcConnectionParameters[connectionTimeoutValue.DriverPropertyName] = connectionTimeoutValue.Value.ToString();
                             break;
                         default:
                             this.adbcConnectionParameters.Add(key, paramValue);

--- a/csharp/src/Client/ConnectionStringParser.cs
+++ b/csharp/src/Client/ConnectionStringParser.cs
@@ -1,0 +1,84 @@
+﻿/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Apache.Arrow.Adbc.Client
+{
+    internal class ConnectionStringKeywords
+    {
+        public const string ConnectionTimeout = "adbcconnectiontimeout";
+        public const string CommandTimeout = "adbccommandtimeout";
+        public const string StructBehavior = "structbehavior";
+        public const string DecimalBehavior = "decimalbehavior";
+    }
+
+    internal class ConnectionStringParser
+    {
+        public static TimeoutValue ParseTimeoutValue(string value)
+        {
+            string pattern = @"\(([^,]+),\s*([^,]+),\s*([^,]+)\)";
+
+            // Match the regex
+            Match match = Regex.Match(value, pattern);
+
+            if (match.Success)
+            {
+                string driverPropertyName = match.Groups[1].Value.Trim();
+                string timeoutAsString = match.Groups[2].Value.Trim();
+                string units = match.Groups[3].Value.Trim();
+
+                if (units != "s" && units != "ms")
+                {
+                    throw new InvalidOperationException("invalid units");
+                }
+
+                TimeoutValue timeoutValue = new TimeoutValue
+                {
+                    DriverPropertyName = driverPropertyName,
+                    Value = int.Parse(timeoutAsString),
+                    Units = units
+                };
+
+                return timeoutValue;
+            }
+            else
+            {
+                throw new InvalidOperationException("cannot parse the timeout value");
+            }
+        }
+    }
+
+    internal class TimeoutValue
+    {
+        public string DriverPropertyName { get; set; } = string.Empty;
+
+        public int Value { get; set; }
+
+        // seconds=s
+        // milliseconds=ms
+        /// <remarks>
+        /// While these can be helpful, the DbConnection and DbCommand
+        /// objects limit the use of these.
+        /// </remarks>
+        public string Units { get; set; } = string.Empty;
+    }
+}

--- a/csharp/src/Client/ConnectionStringParser.cs
+++ b/csharp/src/Client/ConnectionStringParser.cs
@@ -16,9 +16,6 @@
 */
 
 using System;
-using System.Collections.Generic;
-using System.Net.Http.Headers;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Apache.Arrow.Adbc.Client
@@ -62,7 +59,7 @@ namespace Apache.Arrow.Adbc.Client
             }
             else
             {
-                throw new InvalidOperationException("cannot parse the timeout value");
+                throw new ArgumentOutOfRangeException(nameof(value));
             }
         }
     }

--- a/csharp/src/Client/readme.md
+++ b/csharp/src/Client/readme.md
@@ -73,3 +73,12 @@ if using the default user name and password authentication, but look like
 when using JWT authentication with an unencrypted key file.
 
 Other ADBC drivers will have different connection parameters, so be sure to check the documentation for each driver.
+
+### Connection Keywords
+Because the ADO.NET client is designed to work with multiple drivers, callers will need to specify the driver properties that are set for particular values. This can be done either as properties on the objects directly, or can be parsed from the connection string.
+These properties are:
+
+- __AdbcConnectionTimeout__ - This specifies the connection timeout value. The value needs to be in the form (driver.property.name, integer, unit) where the unit is one of `s` or `ms`, For example, `AdbcConnectionTimeout=(adbc.snowflake.sql.client_option.client_timeout,30,s)` would set the connection timeout to 30 seconds.
+- __AdbcCommandTimeout__ - This specifies the command timeout value. This follows the same pattern as `AdbcConnectionTimeout` and sets the `AdbcCommandTimeoutProperty` and `CommandTimeout` values on the `AdbcCommand` object.
+- __StructBehavior__ - This specifies the StructBehavior when working with Arrow Struct arrays. The valid values are `JsonString` (the default) or `Strict` (treat the struct as a native type).
+- __DecimalBehavior__ - This specifies the DecimalBehavior when parsing decimal values from Arrow libraries. The valid values are `UseSqlDecimal` or `OverflowDecimalAsString` where values like Decimal256 are treated as strings.

--- a/csharp/test/Apache.Arrow.Adbc.Tests/Client/ClientTests.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/Client/ClientTests.cs
@@ -181,7 +181,16 @@ namespace Apache.Arrow.Adbc.Tests.Client
         {
             if (!success)
             {
-                Assert.Throws<InvalidOperationException>(() => ConnectionStringParser.ParseTimeoutValue(value));
+                try
+                {
+                    ConnectionStringParser.ParseTimeoutValue(value);
+                }
+                catch (ArgumentOutOfRangeException) { }
+                catch (InvalidOperationException) { }
+                catch
+                {
+                    Assert.Fail("Unknown exception found");
+                }
             }
             else
             {

--- a/csharp/test/Apache.Arrow.Adbc.Tests/Client/ClientTests.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/Client/ClientTests.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data.SqlTypes;
 using System.Linq;
 using System.Threading;
@@ -26,6 +27,7 @@ using Apache.Arrow.Ipc;
 using Apache.Arrow.Types;
 using Moq;
 using Xunit;
+using AdbcClient = Apache.Arrow.Adbc.Client;
 
 namespace Apache.Arrow.Adbc.Tests.Client
 {
@@ -165,6 +167,108 @@ namespace Apache.Arrow.Adbc.Tests.Client
 
             AdbcDataReader reader = cmd.ExecuteReader();
             return reader;
+        }
+
+        [Theory]
+        [InlineData("(adbc.driver.value, 1, s)", "adbc.driver.value", 1, "s", true)]
+        [InlineData("(somevalue,10, ms)", "somevalue", 10, "ms", true)]
+        [InlineData("(somevalue,10, s)", "somevalue", 10, "s", true)]
+        [InlineData("somevalue,10, s)", null, null, null, false)]
+        [InlineData("(somevalue,10, s", null, null, null, false)]
+        [InlineData("(some.value_goes.here,99,Q)", null, null, null, false)]
+        [InlineData("some.value_goes.here,99,Q", null, null, null, false)]
+        public void TestTimeoutParsing(string value, string? driverPropertyName, int? timeout, string? unit, bool success)
+        {
+            if (!success)
+            {
+                Assert.Throws<InvalidOperationException>(() => ConnectionStringParser.ParseTimeoutValue(value));
+            }
+            else
+            {
+                Assert.True(driverPropertyName != null);
+                Assert.True(timeout != null);
+                Assert.True(unit != null);
+
+                TimeoutValue timeoutValue = ConnectionStringParser.ParseTimeoutValue(value);
+
+                Assert.Equal(driverPropertyName, timeoutValue.DriverPropertyName);
+                Assert.Equal(timeout, timeoutValue.Value);
+                Assert.Equal(unit, timeoutValue.Units);
+            }
+        }
+
+        [Theory]
+        [ClassData(typeof(ConnectionParsingTestData))]
+        internal void TestConnectionStringParsing(ConnectionStringExample connectionStringExample)
+        {
+            AdbcClient.AdbcConnection cn = new AdbcClient.AdbcConnection(connectionStringExample.ConnectionString);
+
+            Mock<AdbcStatement> mockStatement = new Mock<AdbcStatement>();
+            AdbcCommand cmd = new AdbcCommand(mockStatement.Object, cn);
+
+            Assert.True(cn.StructBehavior == connectionStringExample.ExpectedStructBehavior);
+            Assert.True(cn.DecimalBehavior == connectionStringExample.ExpectedDecimalBehavior);
+            Assert.True(cn.ConnectionTimeout == connectionStringExample.ConnectionTimeout);
+
+            if (!string.IsNullOrEmpty(connectionStringExample.CommandTimeoutProperty))
+            {
+                Assert.True(cmd.AdbcCommandTimeoutProperty == connectionStringExample.CommandTimeoutProperty);
+                Assert.True(cmd.CommandTimeout == connectionStringExample.CommandTimeout);
+            }
+            else
+            {
+                Assert.Throws<InvalidOperationException>(() => cmd.AdbcCommandTimeoutProperty);
+            }
+        }
+    }
+
+    internal class ConnectionStringExample
+    {
+        public ConnectionStringExample(
+            string connectionString,
+            DecimalBehavior decimalBehavior,
+            StructBehavior structBehavior,
+            string connectionTimeoutPropertyName,
+            int connectionTimeout,
+            string commandTimeoutPropertyName,
+            int commandTimeout)
+        {
+            ConnectionString = connectionString;
+            ExpectedDecimalBehavior = decimalBehavior;
+            ExpectedStructBehavior = structBehavior;
+            ConnectionTimeoutProperty = connectionTimeoutPropertyName;
+            ConnectionTimeout = connectionTimeout;
+            CommandTimeoutProperty = commandTimeoutPropertyName;
+            CommandTimeout = commandTimeout;
+        }
+
+        public string ConnectionString { get; }
+
+        public string ConnectionTimeoutProperty { get; }
+
+        public int ConnectionTimeout { get; }
+
+        public DecimalBehavior ExpectedDecimalBehavior { get; }
+
+        public StructBehavior ExpectedStructBehavior { get; }
+
+        public string CommandTimeoutProperty { get; }
+
+        public int CommandTimeout { get; }
+    }
+
+    /// <summary>
+    /// Collection of <see cref="ConnectionStringExample"/> for testing statement timeouts."/>
+    /// </summary>
+    internal class ConnectionParsingTestData : TheoryData<ConnectionStringExample>
+    {
+        public ConnectionParsingTestData()
+        {
+            int defaultDbConnectionTimeout = 15;
+
+            Add(new("StructBehavior=JsonString", default, StructBehavior.JsonString, "", defaultDbConnectionTimeout, "", 30));
+            Add(new("StructBehavior=JsonString;AdbcCommandTimeout=(adbc.apache.statement.query_timeout_s,45,s)", default, StructBehavior.JsonString, "", defaultDbConnectionTimeout, "adbc.apache.statement.query_timeout_s", 45));
+            Add(new("StructBehavior=JsonString;DecimalBehavior=OverflowDecimalAsString;AdbcConnectionTimeout=(adbc.spark.connect_timeout_ms,90,s);AdbcCommandTimeout=(adbc.apache.statement.query_timeout_s,45,s)", DecimalBehavior.OverflowDecimalAsString, StructBehavior.JsonString, "adbc.spark.connect_timeout_ms", 90, "adbc.apache.statement.query_timeout_s", 45));
         }
     }
 


### PR DESCRIPTION
Follow up to https://github.com/apache/arrow-adbc/pull/2312 to add parsing of the timeout values and other custom properties like StructBehavior and DecimalBehavior from the connection string.