### PR TITLE
chore(rust): add dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,3 +51,9 @@ updates:
       - dependency-name: "System.*"
         update-types:
           - "version-update:semver-major"
+  - package-ecosystem: "cargo"
+    directory: "/rust/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(rust): "


### PR DESCRIPTION
Adds a weekly `cargo` update check with dependabot for `/rust/`.