### PR TITLE
chore(rust): group `arrow` and `datafusion` dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,3 +57,12 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(rust): "
+    groups:
+      arrow:
+        applies-to: version-updates
+        patterns:
+          - "arrow-*"
+      datafusion:
+        applies-to: version-updates
+        patterns:
+          - "datafusion*"


### PR DESCRIPTION
We want to bump these crates together.