### PR TITLE
ci: pin Ruby version

### DIFF
--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -379,6 +379,17 @@ jobs:
         run: |
           env BUILD_ALL=0 BUILD_DRIVER_MANAGER=1 ./ci/scripts/glib_test.sh "$(pwd)" "$(pwd)/build" "$HOME/local"
 
+      - name: Search for build logs
+        if: failure()
+        run: |
+          for log in $(find glib -type f | grep mkmf.log); do
+            echo ============================================================
+            echo $log
+            cat $log
+            echo ============================================================
+          done
+
+
   # ------------------------------------------------------------
   # Go
   # ------------------------------------------------------------

--- a/ci/conda_env_glib.txt
+++ b/ci/conda_env_glib.txt
@@ -15,12 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-arrow-c-glib=15.0.2
-glib=2.80.5
+arrow-c-glib
+glib
 gobject-introspection
 meson
 postgresql
-ruby
+# It appears 3.4.0 adds a dependency on stdckdint.h which isn't actually usable
+ruby <3.4.0
 # TODO(https://github.com/apache/arrow-adbc/issues/2176): pin for now because
 # gobject-introspection uses a deprecated/removed API
 setuptools <74


### PR DESCRIPTION
It appears that Ruby 3.4.0 introduces a dependency on stdckdint.h. On Linux this appears fine but on macOS for some reason Ruby is configured to assume that this C23 header is provided by the compiler/standard library (it isn't) and fails. Pin to older Ruby for the time being.