### PR TITLE
fix(csharp/src/Apache.Arrow.Adbc/C): export statement_execute_schema correctly

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverExporter.cs
+++ b/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverExporter.cs
@@ -127,12 +127,13 @@ namespace Apache.Arrow.Adbc.C
             nativeDriver->StatementBindStream = StatementBindStreamPtr;
             nativeDriver->StatementExecuteQuery = StatementExecuteQueryPtr;
             nativeDriver->StatementExecutePartitions = StatementExecutePartitionsPtr;
-            nativeDriver->StatementGetParameterSchema = StatementGetParameterSchemaPtr;
+            nativeDriver->StatementExecuteSchema = StatementExecuteSchemaPtr;
             nativeDriver->StatementNew = StatementNewPtr;
             nativeDriver->StatementPrepare = StatementPreparePtr;
             nativeDriver->StatementRelease = StatementReleasePtr;
             nativeDriver->StatementSetSqlQuery = StatementSetSqlQueryPtr;
             nativeDriver->StatementSetSubstraitPlan = StatementSetSubstraitPlanPtr;
+            nativeDriver->StatementGetParameterSchema = StatementGetParameterSchemaPtr;
 
             return 0;
         }


### PR DESCRIPTION
Fix a minor typo,

I think we accidentally forgot to export the `statement_execute_schema` handler from the C# exporter. And mistook StatementGetParameterSchema for it, as they two looked so alike to each other...

so, this should restore it, please kindly approve.