### PR TITLE
chore(ci): add `-o pipefail` to default `bash` shell for Rust jobs and fix CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,9 +86,6 @@ jobs:
       - name: Install sqlite3
         if: runner.os == 'Linux'
         run: sudo apt-get install libsqlite3-dev
-      - name: Install sqlite3
-        if: runner.os == 'macOS'
-        run: brew install sqlite3
       - name: Build C++/Go drivers
         run: |
           mkdir -p build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash
+    shell: bash -l -eo pipefail {0}
 
 jobs:
   rust:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,7 +84,6 @@ jobs:
           unzip "protoc.zip" -d $HOME/.local
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Build C++/Go drivers
-        shell: bash -l {0}
         run: |
           mkdir -p build
           mkdir -p local

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ permissions:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash
 
 jobs:
   rust:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,6 +83,12 @@ jobs:
           curl -L "https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-osx-universal_binary.zip" -o protoc.zip
           unzip "protoc.zip" -d $HOME/.local
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Install sqlite3
+        if: runner.os == 'Linux'
+        run: sudo apt-get install libsqlite3-dev
+      - name: Install sqlite3
+        if: runner.os == 'macOS'
+        run: brew install sqlite3
       - name: Build C++/Go drivers
         run: |
           mkdir -p build


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell

Setting default shell for Rust CI jobs to `bash -l -eo pipefail {0}`. Without `pipefail` the exit code is the result of the last command (e.g. `popd` as noted here https://github.com/apache/arrow-adbc/pull/2414#issuecomment-2573937068).