### PR TITLE
fix(csharp/src/Drivers/BigQuery): remove details to have type names match ODBC

### DIFF
--- a/csharp/src/Drivers/BigQuery/AssemblyInfo.cs
+++ b/csharp/src/Drivers/BigQuery/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Apache.Arrow.Adbc.Tests.Drivers.BigQuery, PublicKey=0024000004800000940000000602000000240000525341310004000001000100e504183f6d470d6b67b6d19212be3e1f598f70c246a120194bc38130101d0c1853e4a0f2232cb12e37a7a90e707aabd38511dac4f25fcb0d691b2aa265900bf42de7f70468fc997551a40e1e0679b605aa2088a4a69e07c117e988f5b1738c570ee66997fba02485e7856a49eca5fd0706d09899b8312577cbb9034599fc92d4")]

--- a/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
@@ -1,4 +1,3 @@
-
 /*
 * Licensed to the Apache Software Foundation (ASF) under one or more
 * contributor license agreements.  See the NOTICE file distributed with
@@ -448,7 +447,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                     nullBitmapBuffer.Append(true);
                     length++;
 
-                    if (includeConstraints)
+                    if (depth == GetObjectsDepth.All && includeConstraints)
                     {
                         tableConstraintsValues.Add(GetConstraintSchema(
                             depth, catalog, dbSchema, GetValue(row["table_name"]), columnNamePattern));
@@ -657,6 +656,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                 constraintColumnNamesValues.BuildListArrayForType(StringType.Default),
                 constraintColumnUsageValues.BuildListArrayForType(new StructType(StandardSchemas.UsageSchema))
             };
+
             StandardSchemas.ConstraintSchema.Validate(dataArrays);
 
             return new StructArray(
@@ -743,7 +743,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                 dataArrays,
                 nullBitmapBuffer.Build());
         }
-
+        
         private string PatternToRegEx(string? pattern)
         {
             if (pattern == null)

--- a/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
@@ -743,7 +743,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                 dataArrays,
                 nullBitmapBuffer.Build());
         }
-        
+
         private string PatternToRegEx(string? pattern)
         {
             if (pattern == null)

--- a/csharp/src/Drivers/BigQuery/BigQueryTableTypes.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryTableTypes.cs
@@ -20,6 +20,6 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
 {
     internal static class BigQueryTableTypes
     {
-        public static List<string> TableTypes = new List<string> { "BASE TABLE", "VIEW", "CLONE", "SNAPSHOT" };
+        public static readonly string[] TableTypes = new string[]{ "BASE TABLE", "VIEW", "CLONE", "SNAPSHOT" };
     }
 }

--- a/csharp/src/Drivers/BigQuery/BigQueryTableTypes.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryTableTypes.cs
@@ -1,0 +1,25 @@
+﻿/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+using System.Collections.Generic;
+
+namespace Apache.Arrow.Adbc.Drivers.BigQuery
+{
+    internal static class BigQueryTableTypes
+    {
+        public static List<string> TableTypes = new List<string> { "BASE TABLE", "VIEW", "CLONE", "SNAPSHOT" };
+    }
+}

--- a/csharp/test/Apache.Arrow.Adbc.Tests/Metadata/GetObjectsParser.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/Metadata/GetObjectsParser.cs
@@ -157,19 +157,13 @@ namespace Apache.Arrow.Adbc.Tests.Metadata
             if (constraintsArray == null) return null;
 
             // constraint details may not be loaded correctly if the depth wasn't Columns
-            try
-            {
-                if (constraintsArray.Fields.Count == 0)
-                    return null;
-            }
-            catch (NullReferenceException)
-            {
+            int fieldCount = constraintsArray?.Fields?.Count ?? 0;
+            if (fieldCount == 0)
                 return null;
-            }
 
             List<AdbcConstraint> constraints = new List<AdbcConstraint>();
 
-            StringArray name = (StringArray)constraintsArray.Fields[StandardSchemas.ConstraintSchema.FindIndexOrThrow("constraint_name")]; // constraint_name | utf8
+            StringArray name = (StringArray)constraintsArray!.Fields[StandardSchemas.ConstraintSchema.FindIndexOrThrow("constraint_name")]; // constraint_name | utf8
             StringArray type = (StringArray)constraintsArray.Fields[StandardSchemas.ConstraintSchema.FindIndexOrThrow("constraint_type")]; //	constraint_type | utf8 not null
             ListArray columnNames = (ListArray)constraintsArray.Fields[StandardSchemas.ConstraintSchema.FindIndexOrThrow("constraint_column_names")]; //	constraint_column_names | list<utf8> not null
             ListArray columnUsages = (ListArray)constraintsArray.Fields[StandardSchemas.ConstraintSchema.FindIndexOrThrow("constraint_column_usage")]; //	constraint_column_usage | list<USAGE_SCHEMA>

--- a/csharp/test/Apache.Arrow.Adbc.Tests/Metadata/GetObjectsParser.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/Metadata/GetObjectsParser.cs
@@ -156,6 +156,17 @@ namespace Apache.Arrow.Adbc.Tests.Metadata
         {
             if (constraintsArray == null) return null;
 
+            // constraint details may not be loaded correctly if the depth wasn't Columns
+            try
+            {
+                if (constraintsArray.Fields.Count == 0)
+                    return null;
+            }
+            catch (NullReferenceException)
+            {
+                return null;
+            }
+
             List<AdbcConstraint> constraints = new List<AdbcConstraint>();
 
             StringArray name = (StringArray)constraintsArray.Fields[StandardSchemas.ConstraintSchema.FindIndexOrThrow("constraint_name")]; // constraint_name | utf8

--- a/csharp/test/Drivers/BigQuery/DriverTests.cs
+++ b/csharp/test/Drivers/BigQuery/DriverTests.cs
@@ -202,7 +202,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
 
             StringArray stringArray = (StringArray)recordBatch.Column("table_type");
 
-            List<string> known_types = BigQueryTableTypes.TableTypes;
+            List<string> known_types = BigQueryTableTypes.TableTypes.ToList();
 
             int results = 0;
 


### PR DESCRIPTION
- removes additional suffix details from data type names. For example, STRUCT<...> is just a STRUCT type, and NUMERIC(n,y) is just NUMERIC to match the ODBC type names.
- adds support for querying additional table types