### PR TITLE
fix(csharp/src/Drivers/BigQuery): Use job reference instead of job id to get job to avoid interference between different locations

### DIFF
--- a/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
@@ -83,7 +83,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                 BigQueryJob firstQueryJob = new BigQueryJob(client, job.Resource);
                 foreach (BigQueryJob childJob in joblist)
                 {
-                    var tempJob = client.GetJob(childJob.Reference.JobId);
+                    var tempJob = client.GetJob(childJob.Reference);
                     var query = tempJob.Resource?.Configuration?.Query;
                     if (query != null && query.DestinationTable != null && query.DestinationTable.ProjectId != null && query.DestinationTable.DatasetId != null && query.DestinationTable.TableId != null)
                     {


### PR DESCRIPTION
…between different locations.