### PR TITLE
fix(csharp/src/Drivers/BigQuery): ensure BigQuery DATE type is Date32 Arrow type

### DIFF
--- a/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
@@ -928,7 +928,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                 case "TIME":
                     return fieldBuilder.DataType(Time64Type.Default);
                 case "DATE":
-                    return fieldBuilder.DataType(Date64Type.Default);
+                    return fieldBuilder.DataType(Date32Type.Default);
                 case "RECORD" or "STRUCT":
                     string fieldRecords = type.Substring(index + 1);
                     fieldRecords = fieldRecords.Remove(fieldRecords.Length - 1);

--- a/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
@@ -161,7 +161,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                 case "TIME":
                     return GetType(field, Time64Type.Default);
                 case "DATE":
-                    return GetType(field, Date64Type.Default);
+                    return GetType(field, Date32Type.Default);
                 case "RECORD" or "STRUCT":
                     // its a json string
                     return GetType(field, StringType.Default);

--- a/csharp/src/Drivers/BigQuery/readme.md
+++ b/csharp/src/Drivers/BigQuery/readme.md
@@ -87,7 +87,7 @@ The following table depicts how the BigQuery ADBC driver converts a BigQuery typ
 | BIGNUMERIC |    Decimal256    | string
 | BOOL |    Boolean   | bool
 | BYTES |    Binary   | byte[]
-| DATE |    Date64   | DateTime
+| DATE |    Date32   | DateTime
 | DATETIME |    Timestamp   | DateTime
 | FLOAT64 |    Double   | double
 | GEOGRAPHY |    String   | string

--- a/csharp/test/Drivers/BigQuery/BigQueryData.cs
+++ b/csharp/test/Drivers/BigQuery/BigQueryData.cs
@@ -72,7 +72,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
                                     new ColumnNetTypeArrowTypeValue("is_active", typeof(bool), typeof(BooleanType), true),
                                     new ColumnNetTypeArrowTypeValue("name", typeof(string), typeof(StringType), "John Doe"),
                                     new ColumnNetTypeArrowTypeValue("data", typeof(byte[]), typeof(BinaryType), UTF8Encoding.UTF8.GetBytes("abc123")),
-                                    new ColumnNetTypeArrowTypeValue("date", typeof(DateTime), typeof(Date64Type), new DateTime(2023, 9, 8)),
+                                    new ColumnNetTypeArrowTypeValue("date", typeof(DateTime), typeof(Date32Type), new DateTime(2023, 9, 8)),
             #if NET6_0_OR_GREATER
                                     new ColumnNetTypeArrowTypeValue("time", typeof(TimeOnly), typeof(Time64Type), new TimeOnly(12, 34, 56)), //'12:34:56'
             #else
@@ -134,7 +134,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
                                     new ColumnNetTypeArrowTypeValue("is_active", typeof(bool), typeof(BooleanType), null),
                                     new ColumnNetTypeArrowTypeValue("name", typeof(string), typeof(StringType), null),
                                     new ColumnNetTypeArrowTypeValue("data", typeof(byte[]), typeof(BinaryType), null),
-                                    new ColumnNetTypeArrowTypeValue("date", typeof(DateTime), typeof(Date64Type), null),
+                                    new ColumnNetTypeArrowTypeValue("date", typeof(DateTime), typeof(Date32Type), null),
             #if NET6_0_OR_GREATER
                                     new ColumnNetTypeArrowTypeValue("time", typeof(TimeOnly), typeof(Time64Type), null),
             #else


### PR DESCRIPTION
fixes https://github.com/apache/arrow-adbc/issues/2444