### PR TITLE
chore(rust): include more metadata fields in Cargo manifests

### DIFF
--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -14,13 +14,25 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 [package]
 name = "adbc_core"
 description = "Public abstract API, driver manager and driver exporter"
-version = { workspace = true }
-edition = { workspace = true }
-authors = { workspace = true }
-license = { workspace = true }
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+readme = "../README.md"
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[features]
+default = []
+driver_manager = ["dep:libloading"]
 
 [dependencies]
 arrow-array.workspace = true
@@ -30,6 +42,3 @@ once_cell = "1.20.2"
 
 [dev-dependencies]
 arrow-select.workspace = true
-
-[features]
-driver_manager = ["dep:libloading"]

--- a/rust/driver/datafusion/Cargo.toml
+++ b/rust/driver/datafusion/Cargo.toml
@@ -18,10 +18,17 @@
 [package]
 name = "adbc_datafusion"
 description = "ADBC driver for Apache DataFusion"
-version = { workspace = true }
-edition = { workspace = true }
-authors = { workspace = true }
-license = { workspace = true }
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+documentation = "http://docs.rs/adbc_datafusion/"
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 adbc_core = { path = "../../core" }

--- a/rust/driver/dummy/Cargo.toml
+++ b/rust/driver/dummy/Cargo.toml
@@ -18,10 +18,11 @@
 [package]
 name = "adbc_dummy"
 description = "A dummy ADBC driver for testing purposes"
-version = { workspace = true }
-edition = { workspace = true }
-authors = { workspace = true }
-license = { workspace = true }
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
 
 [dependencies]
 adbc_core = { path = "../../core" }

--- a/rust/driver/snowflake/Cargo.toml
+++ b/rust/driver/snowflake/Cargo.toml
@@ -20,15 +20,15 @@ name = "adbc_snowflake"
 description = "Snowflake Arrow Database Connectivity (ADBC) driver"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
+readme.workspace = true
+documentation = "http://docs.rs/adbc_snowflake/"
 homepage.workspace = true
 repository.workspace = true
-rust-version.workspace = true
 keywords.workspace = true
 categories.workspace = true
-documentation = "http://docs.rs/adbc_snowflake/"
-readme = "README.md"
 
 [features]
 default = ["bundled", "env", "dotenv"]


### PR DESCRIPTION
Closes #2469.
