### PR TITLE
test(python/adbc_driver_postgresql): fix typecheck error on py3.9

### DIFF
--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -20,6 +20,7 @@ importlib-resources
 # nodejs is required by pyright
 nodejs >=13.0.0
 pandas
+pip
 pyarrow-all
 pyright
 pytest

--- a/python/adbc_driver_postgresql/tests/test_dbapi.py
+++ b/python/adbc_driver_postgresql/tests/test_dbapi.py
@@ -430,7 +430,7 @@ def test_ingest_large(postgres: dbapi.Connection) -> None:
 def test_timestamp_txn(postgres: dbapi.Connection) -> None:
     """Regression test for #2410."""
     ts = datetime.datetime.now()
-    ts_with_tz = datetime.datetime.now(tz=datetime.UTC)
+    ts_with_tz = datetime.datetime.now(tz=datetime.timezone.utc)
 
     with postgres.cursor() as cur:
         cur.execute("DROP TABLE IF EXISTS ts_txn")


### PR DESCRIPTION
`datetime.UTC` only exists on Python >= 3.11 (we only run this test on a single Python version so we didn't notice it earlier). Use `datetime.timezone.utc` which should always exist.