### PR TITLE
ci: explicitly install latest clang for nightly test

### DIFF
--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -23,6 +23,8 @@ on:
       - main
     paths:
       - ".github/workflows/nightly-verify.yml"
+      - "ci/docker/cpp-clang-latest.dockerfile"
+      - "ci/docker/cpp-gcc-latest.dockerfile"
       - "dev/release/verify-release-candidate.sh"
       - "dev/release/verify-release-candidate.ps1"
   schedule:

--- a/ci/docker/cpp-clang-latest.dockerfile
+++ b/ci/docker/cpp-clang-latest.dockerfile
@@ -20,14 +20,24 @@ ARG GO
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y && \
-    apt-get install -y curl gnupg && \
-    echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm main" \
+    apt-get install -y curl gnupg jq && \
+    # llvmorg-19.1.7 ->
+    # 19.1.7 ->
+    # 19
+    latest_llvm_major_version=$( \
+      curl https://api.github.com/repos/llvm/llvm-project/releases/latest | \
+        jq -r .tag_name | \
+        cut -d- -f2 | \
+        cut -d. -f1) && \
+    echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${latest_llvm_major_version} main" \
          > /etc/apt/sources.list.d/llvm.list && \
-    echo "deb-src http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm main" \
+    echo "deb-src http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${latest_llvm_major_version} main" \
          >> /etc/apt/sources.list.d/llvm.list && \
     curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-get update -y && \
-    apt-get install -y clang libc++abi-dev libc++-dev libomp-dev && \
+    apt-get install -y clang-${latest_llvm_major_version} libc++abi-${latest_llvm_major_version}-dev libc++-${latest_llvm_major_version}-dev libomp-${latest_llvm_major_version}-dev && \
+    ln -s /usr/bin/clang-${latest_llvm_major_version} /usr/bin/clang && \
+    ln -s /usr/bin/clang++-${latest_llvm_major_version} /usr/bin/clang++ && \
     apt-get clean
 
 RUN export DEBIAN_FRONTEND=noninteractive && \


### PR DESCRIPTION
It appears LLVM's deb repo is slightly borked and has set the clang package to alias unreleased LLVM instead of latest stable. Explicitly install the latest version by checking the API.

Fixes #2497.