### PR TITLE
docs: update java quickstart to use the PARAM_URI instead of the legacy PARAM_URL

### DIFF
--- a/docs/source/java/quickstart.rst
+++ b/docs/source/java/quickstart.rst
@@ -55,7 +55,7 @@ Usage
 .. code-block:: java
 
    final Map<String, Object> parameters = new HashMap<>();
-   parameters.put(AdbcDriver.PARAM_URL, "jdbc:postgresql://localhost:5432/postgres");
+   parameters.put(AdbcDriver.PARAM_URI.key, "jdbc:postgresql://localhost:5432/postgres");
    try (
        BufferAllocator allocator = new RootAllocator();
        AdbcDatabase db = new JdbcDriver(allocator).open(parameters);


### PR DESCRIPTION
Fixes #2528