### PR TITLE
docs: update java quickstart to use the PARAM_URI instead of the legacy PARAM_URL

### DIFF
--- a/docs/source/driver/jdbc.rst
+++ b/docs/source/driver/jdbc.rst
@@ -57,7 +57,7 @@ or an instance of a ``javax.sql.DataSource`` as the
       .. code-block:: java
 
          final Map<String, Object> parameters = new HashMap<>();
-         parameters.put(AdbcDriver.PARAM_URL, "jdbc:postgresql://localhost:5432/postgres");
+         AdbcDriver.PARAM_URI.set(parameters, "jdbc:postgresql://localhost:5432/postgres");
          AdbcDatabase db = new JdbcDriver(allocator).open(parameters);
 
 Supported Features

--- a/docs/source/java/quickstart.rst
+++ b/docs/source/java/quickstart.rst
@@ -55,7 +55,7 @@ Usage
 .. code-block:: java
 
    final Map<String, Object> parameters = new HashMap<>();
-   parameters.put(AdbcDriver.PARAM_URL, "jdbc:postgresql://localhost:5432/postgres");
+   AdbcDriver.PARAM_URI.set(parameters, "jdbc:postgresql://localhost:5432/postgres");
    try (
        BufferAllocator allocator = new RootAllocator();
        AdbcDatabase db = new JdbcDriver(allocator).open(parameters);


### PR DESCRIPTION
Fixes #2528