### PR TITLE
fix(c/driver/sqlite): don't rely on double-quoted strings feature

### DIFF
--- a/c/driver/sqlite/sqlite.cc
+++ b/c/driver/sqlite/sqlite.cc
@@ -312,7 +312,7 @@ struct SqliteGetObjectsHelper : public driver::GetObjectsHelper {
     // XXX: because we're saving the SqliteQuery, we also need to save the string builder
     columns_query.Reset();
     columns_query.Append(
-        R"(SELECT cid, name, type, "notnull", dflt_value FROM pragma_table_info("%w" , "%w") WHERE NAME LIKE ?)",
+        R"(SELECT cid, name, type, 'notnull', dflt_value FROM pragma_table_info(%Q, %Q) WHERE NAME LIKE ?)",
         table.data(), catalog.data());
     UNWRAP_RESULT(auto query, columns_query.GetString());
     assert(!query.empty());
@@ -343,7 +343,7 @@ struct SqliteGetObjectsHelper : public driver::GetObjectsHelper {
     {
       SqliteStringBuilder builder;
       builder.Append(
-          R"(SELECT name FROM pragma_table_info("%w" , "%w") WHERE pk > 0 ORDER BY pk ASC)",
+          R"(SELECT name FROM pragma_table_info(%Q, %Q) WHERE pk > 0 ORDER BY pk ASC)",
           table.data(), catalog.data());
       UNWRAP_RESULT(auto pk_query, builder.GetString());
       std::vector<std::string> pk;

--- a/python/adbc_driver_manager/tests/test_dbapi.py
+++ b/python/adbc_driver_manager/tests/test_dbapi.py
@@ -201,10 +201,10 @@ def test_partitions(sqlite):
 @pytest.mark.sqlite
 def test_query_fetch_py(sqlite):
     with sqlite.cursor() as cur:
-        cur.execute('SELECT 1, "foo", 2.0')
+        cur.execute("SELECT 1, 'foo' AS foo, 2.0")
         assert cur.description == [
             ("1", dbapi.NUMBER, None, None, None, None, None),
-            ('"foo"', dbapi.STRING, None, None, None, None, None),
+            ("foo", dbapi.STRING, None, None, None, None, None),
             ("2.0", dbapi.NUMBER, None, None, None, None, None),
         ]
         assert cur.rownumber == 0
@@ -212,26 +212,26 @@ def test_query_fetch_py(sqlite):
         assert cur.rownumber == 1
         assert cur.fetchone() is None
 
-        cur.execute('SELECT 1, "foo", 2.0')
+        cur.execute("SELECT 1, 'foo', 2.0")
         assert cur.fetchmany() == [(1, "foo", 2.0)]
         assert cur.fetchmany() == []
 
-        cur.execute('SELECT 1, "foo", 2.0')
+        cur.execute("SELECT 1, 'foo', 2.0")
         assert cur.fetchall() == [(1, "foo", 2.0)]
         assert cur.fetchall() == []
 
-        cur.execute('SELECT 1, "foo", 2.0')
+        cur.execute("SELECT 1, 'foo', 2.0")
         assert list(cur) == [(1, "foo", 2.0)]
 
 
 @pytest.mark.sqlite
 def test_query_fetch_arrow(sqlite):
     with sqlite.cursor() as cur:
-        cur.execute('SELECT 1, "foo", 2.0')
+        cur.execute("SELECT 1, 'foo' AS foo, 2.0")
         assert cur.fetch_arrow_table() == pyarrow.table(
             {
                 "1": [1],
-                '"foo"': ["foo"],
+                "foo": ["foo"],
                 "2.0": [2.0],
             }
         )
@@ -240,13 +240,13 @@ def test_query_fetch_arrow(sqlite):
 @pytest.mark.sqlite
 def test_query_fetch_df(sqlite):
     with sqlite.cursor() as cur:
-        cur.execute('SELECT 1, "foo", 2.0')
+        cur.execute("SELECT 1, 'foo' AS foo, 2.0")
         assert_frame_equal(
             cur.fetch_df(),
             pandas.DataFrame(
                 {
                     "1": [1],
-                    '"foo"': ["foo"],
+                    "foo": ["foo"],
                     "2.0": [2.0],
                 }
             ),


### PR DESCRIPTION
A recent update to the conda-forge feedstock disabled double-quoted strings, which we were accidentally relying on.

Ref: https://github.com/conda-forge/sqlite-feedstock/commit/302e685b984ea3a36a333a453e75b547007d0f88

Fixes #2554.