### PR TITLE
chore: bump versions of Go, pre-commit hooks

### DIFF
--- a/.env
+++ b/.env
@@ -33,8 +33,8 @@ MANYLINUX=2014
 MAVEN=3.6.3
 PLATFORM=linux/amd64
 PYTHON=3.9
-GO=1.22.9
-ARROW_MAJOR_VERSION=14
+GO=1.23.6
+ARROW_MAJOR_VERSION=18
 DOTNET=8.0
 
 # Used through compose.yaml and serves as the default version for the

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # v5.0.0
     hooks:
     - id: check-xml
     - id: check-yaml
@@ -50,39 +50,42 @@ repos:
     - id: cmake-format
       args: [--in-place]
   - repo: https://github.com/cpplint/cpplint
-    rev: 1.6.1
+    rev: f4363d7fc0d5f38c4fd41b658e069e96583da0d5  # 2.0.0
     hooks:
     - id: cpplint
+      types_or: [c++]
       args:
         # From Arrow's config
         - "--filter=-whitespace/comments,-whitespace/indent,-readability/braces,-readability/casting,-readability/todo,-readability/alt_tokens,-build/header_guard,-build/c++11,-build/include_order,-build/include_subdir,-runtime/references"
         - "--linelength=90"
         - "--verbose=2"
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.61.0
+    rev: v1.64.5
     hooks:
     - id: golangci-lint
       entry: bash -c 'cd go/adbc && golangci-lint run --fix --timeout 5m'
       types_or: [go, go-mod]
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.13.0
+    rev: v2.14.0
     hooks:
     - id: pretty-format-golang
+      args: [--autofix]
+      types_or: [go]
     - id: pretty-format-java
       args: [--autofix]
       types_or: [java]
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 25.1.0
     hooks:
     - id: black
       types_or: [pyi, python]
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.0
+    rev: 7.1.2
     hooks:
     - id: flake8
       types_or: [python]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
     - id: isort
       types_or: [python]

--- a/c/driver/bigquery/bigquery_test.cc
+++ b/c/driver/bigquery/bigquery_test.cc
@@ -18,7 +18,9 @@
 #include <algorithm>
 #include <cstring>
 #include <random>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include <arrow-adbc/adbc.h>
 #include <gmock/gmock-matchers.h>

--- a/c/driver/flightsql/dremio_flightsql_test.cc
+++ b/c/driver/flightsql/dremio_flightsql_test.cc
@@ -15,12 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <string>
+
 #include <arrow-adbc/adbc.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest-matchers.h>
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 #include <nanoarrow/nanoarrow.h>
+
 #include "validation/adbc_validation.h"
 #include "validation/adbc_validation_util.h"
 

--- a/c/driver/flightsql/sqlite_flightsql_test.cc
+++ b/c/driver/flightsql/sqlite_flightsql_test.cc
@@ -18,7 +18,9 @@
 #include <chrono>
 #include <optional>
 #include <random>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include <arrow-adbc/adbc.h>
 #include <gmock/gmock-matchers.h>

--- a/c/driver/framework/objects.cc
+++ b/c/driver/framework/objects.cc
@@ -18,6 +18,7 @@
 #include "driver/framework/objects.h"
 
 #include <string_view>
+#include <vector>
 
 #include "nanoarrow/nanoarrow.hpp"
 

--- a/c/driver/postgresql/copy/postgres_copy_reader_test.cc
+++ b/c/driver/postgresql/copy/postgres_copy_reader_test.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <string>
+
 #include <gtest/gtest.h>
 #include <nanoarrow/nanoarrow.hpp>
 

--- a/c/driver/postgresql/copy/postgres_copy_writer_test.cc
+++ b/c/driver/postgresql/copy/postgres_copy_writer_test.cc
@@ -16,8 +16,11 @@
 // under the License.
 
 #include <limits>
+#include <memory>
 #include <optional>
+#include <string>
 #include <tuple>
+#include <vector>
 
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>

--- a/c/driver/postgresql/database.cc
+++ b/c/driver/postgresql/database.cc
@@ -22,6 +22,7 @@
 #include <cinttypes>
 #include <cstring>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/c/driver/postgresql/error.cc
+++ b/c/driver/postgresql/error.cc
@@ -18,7 +18,7 @@
 #include "error.h"
 
 #include <stdarg.h>
-#include <stdio.h>
+#include <cstdio>
 #include <cstring>
 #include <string>
 #include <vector>

--- a/c/driver/postgresql/postgres_type_test.cc
+++ b/c/driver/postgresql/postgres_type_test.cc
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <string>
 #include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 #include <nanoarrow/nanoarrow.hpp>

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -22,7 +22,10 @@
 #include <cstring>
 #include <limits>
 #include <optional>
+#include <string>
+#include <utility>
 #include <variant>
+#include <vector>
 
 #include <arrow-adbc/adbc.h>
 #include <gtest/gtest-param-test.h>

--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -19,6 +19,8 @@
 
 #include <charconv>
 #include <memory>
+#include <string>
+#include <vector>
 
 #define ADBC_FRAMEWORK_USE_FMT
 #include "driver/framework/status.h"

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/c/driver/snowflake/snowflake_test.cc
+++ b/c/driver/snowflake/snowflake_test.cc
@@ -15,15 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <algorithm>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
 #include <arrow-adbc/adbc.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest-matchers.h>
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 #include <nanoarrow/nanoarrow.h>
-#include <algorithm>
-#include <cstring>
-#include <random>
+
 #include "validation/adbc_validation.h"
 #include "validation/adbc_validation_util.h"
 

--- a/c/driver/sqlite/sqlite.cc
+++ b/c/driver/sqlite/sqlite.cc
@@ -15,7 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <cstdio>
 #include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <arrow-adbc/adbc.h>
 #include <sqlite3.h>

--- a/c/driver/sqlite/sqlite_test.cc
+++ b/c/driver/sqlite/sqlite_test.cc
@@ -20,6 +20,8 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include <arrow-adbc/adbc.h>
 #include <gmock/gmock-matchers.h>

--- a/c/integration/duckdb/duckdb_test.cc
+++ b/c/integration/duckdb/duckdb_test.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <cstdlib>
+#include <string>
 
 #include <arrow-adbc/adbc.h>
 #include <arrow-adbc/adbc_driver_manager.h>

--- a/c/validation/adbc_validation_connection.cc
+++ b/c/validation/adbc_validation_connection.cc
@@ -17,7 +17,11 @@
 
 #include "adbc_validation.h"
 
+#include <algorithm>
 #include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <arrow-adbc/adbc.h>
 #include <gmock/gmock.h>

--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -18,6 +18,9 @@
 #include "adbc_validation.h"
 
 #include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include <arrow-adbc/adbc.h>
 #include <gmock/gmock.h>

--- a/c/validation/adbc_validation_util.cc
+++ b/c/validation/adbc_validation_util.cc
@@ -16,6 +16,11 @@
 // under the License.
 
 #include "adbc_validation_util.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <arrow-adbc/adbc.h>
 
 #include "adbc_validation.h"

--- a/ci/docker/golang-flightsql-sqlite.dockerfile
+++ b/ci/docker/golang-flightsql-sqlite.dockerfile
@@ -20,7 +20,7 @@ FROM golang:${GO}
 
 ARG ARROW_MAJOR_VERSION
 
-RUN go install github.com/apache/arrow/go/v${ARROW_MAJOR_VERSION}/arrow/flight/flightsql/example/cmd/sqlite_flightsql_server@latest
+RUN go install github.com/apache/arrow-go/v${ARROW_MAJOR_VERSION}/arrow/flight/flightsql/example/cmd/sqlite_flightsql_server@latest
 EXPOSE 8080
 
 ENTRYPOINT /go/bin/sqlite_flightsql_server -host 0.0.0.0 -port 8080

--- a/go/adbc/go.mod
+++ b/go/adbc/go.mod
@@ -17,9 +17,7 @@
 
 module github.com/apache/arrow-adbc/go/adbc
 
-go 1.22.7
-
-toolchain go1.22.9
+go 1.23.0
 
 require (
 	cloud.google.com/go/bigquery v1.66.2

--- a/python/adbc_driver_manager/adbc_driver_manager/_blocking_impl.cc
+++ b/python/adbc_driver_manager/adbc_driver_manager/_blocking_impl.cc
@@ -36,6 +36,7 @@
 #include <cstring>
 #include <iostream>
 #include <mutex>
+#include <string>
 #include <thread>
 
 namespace pyadbc_driver_manager {

--- a/r/adbcdrivermanager/src/driver_test.cc
+++ b/r/adbcdrivermanager/src/driver_test.cc
@@ -20,6 +20,7 @@
 #include <Rinternals.h>
 
 #include <cstring>
+#include <string>
 #include <unordered_map>
 
 #include "driver/framework/base_driver.h"


### PR DESCRIPTION
Go 1.22 is EOL with the release of 1.24.

Various pre-commit hooks have seen major updates. Bump them to the latest versions.