### PR TITLE
fix(go/adbc/driver/snowflake): fix GetObjects for VECTOR cols

### DIFF
--- a/go/adbc/driver/internal/shared_utils.go
+++ b/go/adbc/driver/internal/shared_utils.go
@@ -694,6 +694,10 @@ const (
 )
 
 func ToXdbcDataType(dt arrow.DataType) (xdbcType XdbcDataType) {
+	if dt == nil {
+		return XdbcDataType_XDBC_UNKNOWN_TYPE
+	}
+
 	switch dt.ID() {
 	case arrow.EXTENSION:
 		return ToXdbcDataType(dt.(arrow.ExtensionType).StorageType())

--- a/go/adbc/driver/snowflake/connection.go
+++ b/go/adbc/driver/snowflake/connection.go
@@ -350,7 +350,9 @@ func (c *connectionImpl) GetObjects(ctx context.Context, depth adbc.ObjectDepth,
 						field := c.toArrowField(col)
 						xdbcDataType := internal.ToXdbcDataType(field.Type)
 
-						getObjectsCatalog.CatalogDbSchemas[i].DbSchemaTables[j].TableColumns[k].XdbcDataType = driverbase.Nullable(int16(field.Type.ID()))
+						if field.Type != nil {
+							getObjectsCatalog.CatalogDbSchemas[i].DbSchemaTables[j].TableColumns[k].XdbcDataType = driverbase.Nullable(int16(field.Type.ID()))
+						}
 						getObjectsCatalog.CatalogDbSchemas[i].DbSchemaTables[j].TableColumns[k].XdbcSqlDataType = driverbase.Nullable(int16(xdbcDataType))
 					}
 				}
@@ -475,6 +477,11 @@ func (c *connectionImpl) toArrowField(columnInfo driverbase.ColumnInfo) arrow.Fi
 		fallthrough
 	case "GEOMETRY":
 		field.Type = arrow.BinaryTypes.String
+	case "VECTOR":
+		// despite the fact that Snowflake *does* support returning data
+		// for VECTOR typed columns as Arrow FixedSizeLists, there's no way
+		// currently to retrieve enough metadata to construct the proper type
+		// for it
 	}
 
 	return field


### PR DESCRIPTION
Fixes #2544 by eliminating the null pointer dereference for unknown column types