### PR TITLE
chore(dev/release): update the Java release upload process

### DIFF
--- a/dev/release/04-java-upload.sh
+++ b/dev/release/04-java-upload.sh
@@ -25,15 +25,29 @@ SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SOURCE_DIR}/utils-common.sh"
 source "${SOURCE_DIR}/utils-prepare.sh"
 
+# arrow-c-data-18.2.0-sources.jar ->
+# jar
+extract_type() {
+  local path="$1"
+  echo "${path}" | grep -o "[^.]*$"
+}
+
+# arrow-c-data-18.2.0-sources.jar arrow-c-data-18.2.0 ->
+# sources
+extract_classifier() {
+  local path="$1"
+  local base="$2"
+  basename "${path}" | sed -e "s/^${base}-//g" -e "s/\.[^.]*$//g"
+}
+
 main() {
-    if [ $# -ne 2 ]; then
-        echo "Usage: $0 <arrow-dir> <rc-number>"
-        echo "Usage: $0 ../arrow 0"
+    if [ $# -ne 1 ]; then
+        echo "Usage: $0 <rc-number>"
+        echo "Usage: $0 0"
         exit
     fi
 
-    local -r arrow_dir="$(cd "$1" && pwd)"
-    local -r rc_number="$2"
+    local -r rc_number="$1"
     local -r tag="apache-arrow-adbc-${RELEASE}-rc${rc_number}"
 
     export ARROW_ARTIFACTS_DIR="$(pwd)/packages/${tag}/java"
@@ -48,8 +62,72 @@ main() {
        --repo "${REPOSITORY}" \
        "${tag}"
 
-    export UPLOAD_FORCE_SIGN=0
-    "${arrow_dir}/dev/release/06-java-upload.sh" "${RELEASE}" "${rc_number}"
+    pushd "${ARROW_ARTIFACTS_DIR}"
+
+    for pom in *.pom; do
+        base=$(basename "${pom}" .pom)
+        files=()
+        types=()
+        classifiers=()
+        args=()  # Args to Maven
+        args+=(deploy:deploy-file)
+        args+=(-Durl=https://repository.apache.org/service/local/staging/deploy/maven2)
+        args+=(-DrepositoryId=apache.releases.https)
+        args+=(-DretryFailedDeploymentCount=10)
+        args+=(-DpomFile="${pom}")
+        if [ -f "${base}.jar" ]; then
+            jar="${base}.jar"
+            args+=(-Dfile="${jar}")
+            files+=("${base}.jar.asc")
+            types+=("jar.asc")
+            classifiers+=("")
+        else
+            args+=(-Dfile="${pom}")
+        fi
+        files+=("${base}.pom.asc")
+        types+=("pom.asc")
+        classifiers+=("")
+        if [ "$(echo "${base}"-*)" != "${base}-*" ]; then
+            for other_file in "${base}"-*; do
+                type="$(extract_type "${other_file}")"
+                case "${type}" in
+                    asc | sha256 | sha512)
+                        continue
+                        ;;
+                esac
+                classifier=$(extract_classifier "${other_file}" "${base}")
+                files+=("${other_file}")
+                types+=("${type}")
+                classifiers+=("${classifier}")
+                other_file_base="$(basename "${other_file}")"
+                files+=("${other_file_base}.asc")
+                types+=("${type}.asc")
+                classifiers+=("${classifier}")
+            done
+        fi
+        args+=(-Dfiles="$(
+      IFS=,
+      echo "${files[*]}"
+    )")
+        args+=(-Dtypes="$(
+      IFS=,
+      echo "${types[*]}"
+    )")
+        args+=(-Dclassifiers="$(
+      IFS=,
+      echo "${classifiers[*]}"
+    )")
+        mvn "${args[@]}"
+    done
+
+    popd
+
+    echo "Success!"
+    echo "Press the 'Close' button in the web interface:"
+    echo "    https://repository.apache.org/#stagingRepositories"
+    echo "It publishes the artifacts to the staging repository:"
+    echo "    https://repository.apache.org/content/repositories/staging/org/apache/arrow/"
+    read -p "After publishing the artifacts, press ENTER to continue..." ignored
 }
 
 main "$@"

--- a/docs/source/development/releasing.rst
+++ b/docs/source/development/releasing.rst
@@ -171,10 +171,10 @@ Build source and binaries and submit them
 
     # Upload the Java artifacts
     #
-    # Note that you need to press the "Close" button manually by Web interface
-    # after you complete the script:
+    # Note that you need to press the "Close" button manually in the Web
+    # interface after you complete the script:
     #   https://repository.apache.org/#stagingRepositories
-    dev/release/04-java-upload.sh <arrow-dir> <rc-number>
+    dev/release/04-java-upload.sh <rc-number>
 
     # Sign and upload the deb/rpm packages and APT/Yum repositories
     #


### PR DESCRIPTION
The script was removed from apache/arrow after Java as moved to apache/arrow-java.  The new script is not as easily reused so inline it here instead.

Fixes #2451.