### PR TITLE
fix(csharp/src): Add missing override to ImportedAdbcConnection

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
+++ b/csharp/src/Apache.Arrow.Adbc/C/CAdbcDriverImporter.cs
@@ -683,6 +683,40 @@ namespace Apache.Arrow.Adbc.C
                 }
             }
 
+            public override AdbcStatement BulkIngest(
+                string? targetCatalog,
+                string? targetDbSchema,
+                string targetTableName,
+                BulkIngestMode mode,
+                bool isTemporary)
+            {
+                AdbcStatement statement = CreateStatement();
+                bool succeeded = false;
+                try
+                {
+                    statement.SetOption(AdbcOptions.Ingest.TargetTable, targetTableName);
+                    if (targetCatalog != null)
+                    {
+                        statement.SetOption(AdbcOptions.Ingest.TargetCatalog, targetCatalog);
+                    }
+                    if (targetDbSchema != null)
+                    {
+                        statement.SetOption(AdbcOptions.Ingest.TargetDbSchema, targetDbSchema);
+                    }
+                    if (isTemporary)
+                    {
+                        statement.SetOption(AdbcOptions.Ingest.Temporary, AdbcOptions.GetEnabled(isTemporary));
+                    }
+                    statement.SetOption(AdbcOptions.Ingest.Mode, AdbcOptions.GetIngestMode(mode));
+                    succeeded = true;
+                    return statement;
+                }
+                finally
+                {
+                    if (!succeeded) { statement.Dispose(); }
+                }
+            }
+
             public unsafe override void Commit()
             {
                 using (CallHelper caller = new CallHelper())

--- a/csharp/test/Apache.Arrow.Adbc.Tests/ImportedDuckDbTests.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/ImportedDuckDbTests.cs
@@ -196,7 +196,7 @@ namespace Apache.Arrow.Adbc.Tests
 
             Assert.Equal(5, GetResultCount(statement2, "SELECT * from ingested"));
 
-            // TODO: Pass a schema once the DuckDB "quoting identifiers bug has been fixed
+            // TODO: Pass a schema once the DuckDB "quoting identifiers" bug has been fixed
             using var statement3 = connection.BulkIngest(null, null, "ingested", BulkIngestMode.Append, isTemporary: false);
 
             recordBatch = new RecordBatch(schema, [

--- a/csharp/test/Apache.Arrow.Adbc.Tests/ImportedDuckDbTests.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/ImportedDuckDbTests.cs
@@ -195,6 +195,18 @@ namespace Apache.Arrow.Adbc.Tests
             statement2.ExecuteUpdate();
 
             Assert.Equal(5, GetResultCount(statement2, "SELECT * from ingested"));
+
+            // TODO: Pass a schema once the DuckDB "quoting identifiers bug has been fixed
+            using var statement3 = connection.BulkIngest(null, null, "ingested", BulkIngestMode.Append, isTemporary: false);
+
+            recordBatch = new RecordBatch(schema, [
+                new Int32Array.Builder().AppendRange([6]).Build(),
+                new StringArray.Builder().AppendRange(["antidisestablishmentarianism"]).Build()
+                ], 1);
+            statement3.Bind(recordBatch, schema);
+            statement3.ExecuteUpdate();
+
+            Assert.Equal(6, GetResultCount(statement3, "SELECT * from main.ingested"));
         }
 
         [Fact]


### PR DESCRIPTION
An override was missing from `ImportedAdbcConnection`.