### PR TITLE
chore(glib): improve Vala API availability check

### DIFF
--- a/ci/scripts/glib_build.sh
+++ b/ci/scripts/glib_build.sh
@@ -38,7 +38,8 @@ build_subproject() {
         cmake_prefix_path="${CONDA_PREFIX}:${cmake_prefix_path}"
         pkg_config_path="${pkg_config_path}:${CONDA_PREFIX}/lib/pkgconfig"
     fi
-    if type valac > /dev/null 2>&1; then
+    if type valac > /dev/null 2>&1 && \
+            [[ -n "$(pkg-config --variable=vapidir arrow-glib)" ]]; then
         enable_vapi=true
     else
         enable_vapi=false


### PR DESCRIPTION
Fixes #2584

If we want to enable Vala support in ADBC GLib, we require Apache Arrow GLib with Vala support.