### PR TITLE
feat(csharp): improve handling of structs

### DIFF
--- a/csharp/src/Client/AdbcDataReader.cs
+++ b/csharp/src/Client/AdbcDataReader.cs
@@ -86,10 +86,12 @@ namespace Apache.Arrow.Adbc.Client
             this.DecimalBehavior = decimalBehavior;
             this.StructBehavior = structBehavior;
 
+            StructResultType structResultType = this.StructBehavior == StructBehavior.JsonString ? StructResultType.JsonString : StructResultType.Object;
+
             this.converters = new Func<IArrowArray, int, object?>[this.schema.FieldsList.Count];
             for (int i = 0; i < this.converters.Length; i++)
             {
-                this.converters[i] = this.schema.FieldsList[i].DataType.GetValueConverter();
+                this.converters[i] = this.schema.FieldsList[i].DataType.GetValueConverter(structResultType);
             }
         }
 
@@ -372,7 +374,9 @@ namespace Apache.Arrow.Adbc.Client
                 }
                 else
                 {
-                    dbColumns.Add(new AdbcColumn(f.Name, t, f.DataType, f.IsNullable));
+                    IArrowType arrowType = SchemaConverter.GetArrowTypeBasedOnRequestedBehavior(f.DataType, this.StructBehavior);
+
+                    dbColumns.Add(new AdbcColumn(f.Name, t, arrowType, f.IsNullable));
                 }
             }
 

--- a/csharp/src/Client/SchemaConverter.cs
+++ b/csharp/src/Client/SchemaConverter.cs
@@ -19,6 +19,7 @@ using System;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlTypes;
+using System.Dynamic;
 using Apache.Arrow.Scalars;
 using Apache.Arrow.Types;
 
@@ -60,7 +61,7 @@ namespace Apache.Arrow.Adbc.Client
                 row[SchemaTableColumn.ColumnName] = f.Name;
                 row[SchemaTableColumn.ColumnOrdinal] = columnOrdinal;
                 row[SchemaTableColumn.AllowDBNull] = f.IsNullable;
-                row[SchemaTableColumn.ProviderType] = f.DataType;
+                row[SchemaTableColumn.ProviderType] = SchemaConverter.GetArrowTypeBasedOnRequestedBehavior(f.DataType, structBehavior);
                 Type t = ConvertArrowType(f, decimalBehavior, structBehavior);
 
                 row[SchemaTableColumn.DataType] = t;
@@ -193,10 +194,7 @@ namespace Apache.Arrow.Adbc.Client
                     return typeof(string);
 
                 case ArrowTypeId.Struct:
-                    if (structBehavior == StructBehavior.JsonString)
-                        return typeof(string);
-                    else
-                        goto default;
+                    return  structBehavior == StructBehavior.JsonString ? typeof(string) : typeof(ExpandoObject);
 
                 case ArrowTypeId.Timestamp:
                     return typeof(DateTimeOffset);
@@ -270,6 +268,19 @@ namespace Apache.Arrow.Adbc.Client
             }
 
             throw new InvalidCastException($"Cannot determine the array type for {dataType.Name}");
+        }
+
+        /// <summary>
+        /// Get the IArrowType based on the input IArrowType and the desired <see cref="StructBehavior"/>.
+        /// If it's a StructType and the desired behavior is a JsonString then this returns StringType.
+        /// Otherwise, it returns the input IArrowType.
+        /// </summary>
+        /// <param name="defaultType">The default IArrowType to return.</param>
+        /// <param name="structBehavior">Desired behavior if the IArrowType is a StructType.</param>
+        /// <returns></returns>
+        public static IArrowType GetArrowTypeBasedOnRequestedBehavior(IArrowType defaultType, StructBehavior structBehavior)
+        {
+            return defaultType.TypeId == ArrowTypeId.Struct && structBehavior == StructBehavior.JsonString ? StringType.Default : defaultType;
         }
     }
 }

--- a/csharp/src/Client/StructBehavior.cs
+++ b/csharp/src/Client/StructBehavior.cs
@@ -17,6 +17,9 @@
 
 namespace Apache.Arrow.Adbc.Client
 {
+    /// <summary>
+    /// Controls the behavior of how StructArrays should be handled in the results.
+    /// </summary>
     public enum StructBehavior
     {
         /// <summary>

--- a/csharp/src/Client/readme.md
+++ b/csharp/src/Client/readme.md
@@ -80,5 +80,5 @@ These properties are:
 
 - __AdbcConnectionTimeout__ - This specifies the connection timeout value. The value needs to be in the form (driver.property.name, integer, unit) where the unit is one of `s` or `ms`, For example, `AdbcConnectionTimeout=(adbc.snowflake.sql.client_option.client_timeout,30,s)` would set the connection timeout to 30 seconds.
 - __AdbcCommandTimeout__ - This specifies the command timeout value. This follows the same pattern as `AdbcConnectionTimeout` and sets the `AdbcCommandTimeoutProperty` and `CommandTimeout` values on the `AdbcCommand` object.
-- __StructBehavior__ - This specifies the StructBehavior when working with Arrow Struct arrays. The valid values are `JsonString` (the default) or `Strict` (treat the struct as a native type).
+- __StructBehavior__ - This specifies the StructBehavior when working with Arrow Struct arrays. The valid values are `JsonString` (the default) or `Strict` (treat the struct as a native type). If using JsonString, the return ArrowType will be StringType and a string value. If using Strict, the return ArrowType will be StructType and an ExpandoObject.
 - __DecimalBehavior__ - This specifies the DecimalBehavior when parsing decimal values from Arrow libraries. The valid values are `UseSqlDecimal` or `OverflowDecimalAsString` where values like Decimal256 are treated as strings.

--- a/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
@@ -112,7 +112,13 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             ReadSession rrs = readClient.CreateReadSession("projects/" + results.TableReference.ProjectId, rs, maxStreamCount);
 
             long totalRows = results.TotalRows == null ? -1L : (long)results.TotalRows.Value;
-            IArrowArrayStream stream = new MultiArrowReader(TranslateSchema(results.Schema), rrs.Streams.Select(s => ReadChunk(readClient, s.Name)));
+
+            var readers = rrs.Streams
+                             .Select(s => ReadChunk(readClient, s.Name))
+                             .Where(chunk => chunk != null)
+                             .Cast<IArrowReader>();
+
+            IArrowArrayStream stream = new MultiArrowReader(TranslateSchema(results.Schema), readers);
 
             return new QueryResult(totalRows, stream);
         }
@@ -176,7 +182,8 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                     return GetType(field, Date32Type.Default);
                 case "RECORD" or "STRUCT":
                     // its a json string
-                    return GetType(field, StringType.Default);
+                    //return GetType(field, StringType.Default);
+                    return GetType(field, BuildStructType(field));
 
                 // treat these values as strings
                 case "GEOGRAPHY" or "JSON":
@@ -200,6 +207,19 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             }
         }
 
+        private StructType BuildStructType(TableFieldSchema field)
+        {
+            List<Field> arrowFields = new List<Field>();
+
+            foreach (TableFieldSchema subfield in field.Fields)
+            {
+                Field arrowField = TranslateField(subfield);
+                arrowFields.Add(arrowField);
+            }
+
+            return new StructType(arrowFields.AsReadOnly());
+        }
+
         private IArrowType GetType(TableFieldSchema field, IArrowType type)
         {
             if (field.Mode == "REPEATED")
@@ -208,7 +228,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             return type;
         }
 
-        static IArrowReader ReadChunk(BigQueryReadClient readClient, string streamName)
+        static IArrowReader? ReadChunk(BigQueryReadClient readClient, string streamName)
         {
             // Ideally we wouldn't need to indirect through a stream, but the necessary APIs in Arrow
             // are internal. (TODO: consider changing Arrow).
@@ -217,7 +237,14 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
 
             ReadRowsStream stream = new ReadRowsStream(enumerator);
 
-            return new ArrowStreamReader(stream);
+            if (stream.HasRows)
+            {
+                return new ArrowStreamReader(stream);
+            }
+            else
+            {
+                return null;
+            }
         }
 
         private QueryOptions ValidateOptions()
@@ -349,14 +376,26 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             ReadOnlyMemory<byte> currentBuffer;
             bool first;
             int position;
+            bool hasRows = true;
 
             public ReadRowsStream(IAsyncEnumerator<ReadRowsResponse> response)
             {
                 if (!response.MoveNextAsync().Result) { }
-                this.currentBuffer = response.Current.ArrowSchema.SerializedSchema.Memory;
+
+                if (response.Current != null)
+                {
+                    this.currentBuffer = response.Current.ArrowSchema.SerializedSchema.Memory;
+                }
+                else
+                {
+                    this.hasRows = false;
+                }
+
                 this.response = response;
                 this.first = true;
             }
+
+            public bool HasRows { get => this.hasRows; }
 
             public override bool CanRead => true;
 

--- a/csharp/test/Apache.Arrow.Adbc.Tests/SampleDataBuilder.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/SampleDataBuilder.cs
@@ -57,6 +57,14 @@ namespace Apache.Arrow.Adbc.Tests
         /// </summary>
         public List<string> PostQueryCommands { get; set; } = new List<string>();
 
+        /// <summary>
+        /// Optional value to indicate how structs should be treated in the sample data.
+        /// </summary>
+        /// <example>
+        /// JsonString
+        /// Strict
+        /// </example>
+        public string? StructBehavior { get; set; }
 
         /// <summary>
         /// The expected values.

--- a/csharp/test/Drivers/BigQuery/BigQueryData.cs
+++ b/csharp/test/Drivers/BigQuery/BigQueryData.cs
@@ -18,7 +18,9 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SqlTypes;
+using System.Dynamic;
 using System.Text;
+using System.Text.Json;
 using Apache.Arrow.Types;
 
 namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
@@ -42,6 +44,35 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
 
             SampleDataBuilder sampleDataBuilder = new SampleDataBuilder();
 
+            ExpandoObject person = new ExpandoObject();
+            IDictionary<string, object?> keyValues = (IDictionary<string, object?>)person;
+            keyValues["name"] = "John Doe";
+            keyValues["age"] = 30L;
+
+            // StructBehavior = "Strict"
+            sampleDataBuilder.Samples.Add(
+               new SampleData()
+               {
+                   Query = "SELECT " +
+                           "STRUCT('John Doe' as name, 30 as age) as person",
+                   StructBehavior = "Strict",
+                   ExpectedValues = new List<ColumnNetTypeArrowTypeValue>()
+                   {
+                        new ColumnNetTypeArrowTypeValue("person", typeof(ExpandoObject), typeof(StructType), person),
+                   }
+               });
+
+            sampleDataBuilder.Samples.Add(
+                new SampleData()
+                {
+                    Query = "SELECT " +
+                            "STRUCT('John Doe' as name, 30 as age) as person",
+                    StructBehavior = "JsonString",
+                    ExpectedValues = new List<ColumnNetTypeArrowTypeValue>()
+                    {
+                        new ColumnNetTypeArrowTypeValue("person", typeof(string), typeof(StringType), JsonSerializer.Serialize(person)),
+                    }
+                });
 
             // standard values
             sampleDataBuilder.Samples.Add(
@@ -63,6 +94,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
                             "ARRAY[1, 2, 3] as numbers, " +
                             "STRUCT('John Doe' as name, 30 as age) as person," +
                             "PARSE_JSON('{\"name\":\"Jane Doe\",\"age\":29}') as json",
+                    StructBehavior = "Strict",
                     ExpectedValues = new List<ColumnNetTypeArrowTypeValue>()
                     {
                                     new ColumnNetTypeArrowTypeValue("id", typeof(long), typeof(Int64Type), 1L),
@@ -82,7 +114,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
                                     new ColumnNetTypeArrowTypeValue("timestamp", typeof(DateTimeOffset), typeof(TimestampType), new DateTimeOffset(new DateTime(2023, 9, 8, 12, 34, 56), TimeSpan.Zero)),
                                     new ColumnNetTypeArrowTypeValue("point", typeof(string), typeof(StringType), "POINT(1 2)"),
                                     new ColumnNetTypeArrowTypeValue("numbers", typeof(Int64Array), typeof(ListType), numbersArray),
-                                    new ColumnNetTypeArrowTypeValue("person", typeof(string), typeof(StringType), "{\"name\":\"John Doe\",\"age\":30}"),
+
+                                    new ColumnNetTypeArrowTypeValue("person", typeof(ExpandoObject), typeof(StructType), person),
                                     new ColumnNetTypeArrowTypeValue("json", typeof(string), typeof(StringType), "{\"age\":29,\"name\":\"Jane Doe\"}")
                     }
                 });
@@ -125,6 +158,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
                             "ST_GEOGPOINT(NULL, NULL) as point, " +
                             "CAST(NULL as ARRAY<INT64>) as numbers, " +
                             "STRUCT(CAST(NULL as STRING) as name, CAST(NULL as INT64) as age) as person",
+                    StructBehavior = "JsonString",
                     ExpectedValues = new List<ColumnNetTypeArrowTypeValue>()
                     {
                                     new ColumnNetTypeArrowTypeValue("id", typeof(long), typeof(Int64Type), null),
@@ -148,62 +182,61 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
                     }
                 });
 
-
             // complex struct
             sampleDataBuilder.Samples.Add(
-            new SampleData()
-            {
-                Query = "SELECT " +
-                         "STRUCT(" +
-                         "\"Iron Man\" as name," +
-                         "\"Avengers\" as team," +
-                         "[\"Genius\", \"Billionaire\", \"Playboy\", \"Philanthropist\"] as powers," +
-                         "[" +
-                         "  STRUCT(" +
-                         "    \"Captain America\" as name, " +
-                         "    \"Avengers\" as team, " +
-                         "    [\"Super Soldier Serum\", \"Vibranium Shield\"] as powers, " +
-                         "    [" +
-                         "     STRUCT(" +
-                         "       \"Thanos\" as name, " +
-                         "       \"Black Order\" as team, " +
-                         "       [\"Infinity Gauntlet\", \"Super Strength\", \"Teleportation\"] as powers, " +
-                         "       [" +
-                         "         STRUCT(" +
-                         "           \"Loki\" as name, " +
-                         "           \"Asgard\" as team, " +
-                         "           [\"Magic\", \"Shapeshifting\", \"Trickery\"] as powers " +
-                         "          )" +
-                         "        ] as allies" +
-                         "      )" +
-                         "    ] as enemies" +
-                         " )," +
-                         " STRUCT(" +
-                         "    \"Spider-Man\" as name, " +
-                         "    \"Avengers\" as team, " +
-                         "    [\"Spider-Sense\", \"Web-Shooting\", \"Wall-Crawling\"] as powers, " +
-                         "    [" +
-                         "      STRUCT(" +
-                         "        \"Green Goblin\" as name, " +
-                         "        \"Sinister Six\" as team, " +
-                         "        [\"Glider\", \"Pumpkin Bombs\", \"Super Strength\"] as powers, " +
-                         "         [" +
-                         "          STRUCT(" +
-                         "            \"Doctor Octopus\" as name, " +
-                         "            \"Sinister Six\" as team, " +
-                         "            [\"Mechanical Arms\", \"Genius\", \"Madness\"] as powers " +
-                         "          )" +
-                         "        ] as allies" +
-                         "      )" +
-                         "    ] as enemies" +
-                         "  )" +
-                         " ] as friends" +
-                         ") as iron_man",
-                ExpectedValues = new List<ColumnNetTypeArrowTypeValue>()
-                   {
+                new SampleData()
+                {
+                    Query = "SELECT " +
+                                "STRUCT(" +
+                                "\"Iron Man\" as name," +
+                                "\"Avengers\" as team," +
+                                "[\"Genius\", \"Billionaire\", \"Playboy\", \"Philanthropist\"] as powers," +
+                                "[" +
+                                "  STRUCT(" +
+                                "    \"Captain America\" as name, " +
+                                "    \"Avengers\" as team, " +
+                                "    [\"Super Soldier Serum\", \"Vibranium Shield\"] as powers, " +
+                                "    [" +
+                                "     STRUCT(" +
+                                "       \"Thanos\" as name, " +
+                                "       \"Black Order\" as team, " +
+                                "       [\"Infinity Gauntlet\", \"Super Strength\", \"Teleportation\"] as powers, " +
+                                "       [" +
+                                "         STRUCT(" +
+                                "           \"Loki\" as name, " +
+                                "           \"Asgard\" as team, " +
+                                "           [\"Magic\", \"Shapeshifting\", \"Trickery\"] as powers " +
+                                "          )" +
+                                "        ] as allies" +
+                                "      )" +
+                                "    ] as enemies" +
+                                " )," +
+                                " STRUCT(" +
+                                "    \"Spider-Man\" as name, " +
+                                "    \"Avengers\" as team, " +
+                                "    [\"Spider-Sense\", \"Web-Shooting\", \"Wall-Crawling\"] as powers, " +
+                                "    [" +
+                                "      STRUCT(" +
+                                "        \"Green Goblin\" as name, " +
+                                "        \"Sinister Six\" as team, " +
+                                "        [\"Glider\", \"Pumpkin Bombs\", \"Super Strength\"] as powers, " +
+                                "         [" +
+                                "          STRUCT(" +
+                                "            \"Doctor Octopus\" as name, " +
+                                "            \"Sinister Six\" as team, " +
+                                "            [\"Mechanical Arms\", \"Genius\", \"Madness\"] as powers " +
+                                "          )" +
+                                "        ] as allies" +
+                                "      )" +
+                                "    ] as enemies" +
+                                "  )" +
+                                " ] as friends" +
+                                ") as iron_man",
+                    ExpectedValues = new List<ColumnNetTypeArrowTypeValue>()
+                    {
                         new ColumnNetTypeArrowTypeValue("iron_man", typeof(string), typeof(StringType), "{\"name\":\"Iron Man\",\"team\":\"Avengers\",\"powers\":[\"Genius\",\"Billionaire\",\"Playboy\",\"Philanthropist\"],\"friends\":[{\"name\":\"Captain America\",\"team\":\"Avengers\",\"powers\":[\"Super Soldier Serum\",\"Vibranium Shield\"],\"enemies\":[{\"name\":\"Thanos\",\"team\":\"Black Order\",\"powers\":[\"Infinity Gauntlet\",\"Super Strength\",\"Teleportation\"],\"allies\":[{\"name\":\"Loki\",\"team\":\"Asgard\",\"powers\":[\"Magic\",\"Shapeshifting\",\"Trickery\"]}]}]},{\"name\":\"Spider-Man\",\"team\":\"Avengers\",\"powers\":[\"Spider-Sense\",\"Web-Shooting\",\"Wall-Crawling\"],\"enemies\":[{\"name\":\"Green Goblin\",\"team\":\"Sinister Six\",\"powers\":[\"Glider\",\"Pumpkin Bombs\",\"Super Strength\"],\"allies\":[{\"name\":\"Doctor Octopus\",\"team\":\"Sinister Six\",\"powers\":[\"Mechanical Arms\",\"Genius\",\"Madness\"]}]}]}]}")
-                   }
-            });
+                    }
+                });
 
             return sampleDataBuilder;
         }

--- a/csharp/test/Drivers/BigQuery/BigQueryTestConfiguration.cs
+++ b/csharp/test/Drivers/BigQuery/BigQueryTestConfiguration.cs
@@ -96,5 +96,14 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
 
         [JsonPropertyName("maxStreamCount")]
         public int? MaxStreamCount { get; set; }
+
+        /// <summary>
+        /// How structs should be handled by the ADO.NET client for this environment.
+        /// </summary>
+        /// <remarks>
+        /// JsonString or Strict
+        /// </remarks>
+        [JsonPropertyName("structBehavior")]
+        public string? StructBehavior { get; set; }
     }
 }


### PR DESCRIPTION
- improves the handling of structs to return objects or JsonString (defaults to JsonString to not break existing callers)
- additional testing for each return type
- updates to the ADO.NET wrapper to support both struct types
- fixes https://github.com/apache/arrow-adbc/issues/2586 