### PR TITLE
feat(python/adbc_driver_manager): add cursor() arg to set options

### DIFF
--- a/docs/source/python/recipe/postgresql_execute_nocopy.py
+++ b/docs/source/python/recipe/postgresql_execute_nocopy.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# RECIPE CATEGORY: PostgreSQL
+# RECIPE KEYWORDS: statement options
+# RECIPE STARTS HERE
+
+#: PostgreSQL does not support ``COPY`` for all kinds of queries, for example,
+#: queries that use ``SHOW``.  But the ADBC driver tries to execute queries
+#: with COPY by default since it is faster for large result sets.  In this
+#: case, you can explicitly disable the ``COPY`` optimization.
+
+import os
+
+import adbc_driver_postgresql.dbapi
+
+uri = os.environ["ADBC_POSTGRESQL_TEST_URI"]
+conn = adbc_driver_postgresql.dbapi.connect(uri)
+
+#: The option can be set when creating the cursor:
+
+with conn.cursor(
+    adbc_stmt_kwargs={
+        adbc_driver_postgresql.StatementOptions.USE_COPY.value: False,
+    }
+) as cur:
+    cur.execute("SHOW ALL")
+    print(cur.fetch_arrow_table().schema)
+    # Output:
+    # name: string
+    # setting: string
+    # description: string
+
+#: Or it can be set afterwards:
+
+with conn.cursor() as cur:
+    cur.adbc_statement.set_options(
+        **{
+            adbc_driver_postgresql.StatementOptions.USE_COPY.value: False,
+        }
+    )
+    cur.execute("SHOW ALL")
+    print(cur.fetch_arrow_table().schema)
+    # Output:
+    # name: string
+    # setting: string
+    # description: string
+
+#: Without the option, the query fails as the driver attempts to execute the
+#: query with ``COPY``:
+
+with conn.cursor() as cur:
+    try:
+        cur.execute("SHOW ALL")
+    except conn.Error:
+        pass
+    else:
+        raise RuntimeError("Expected error")
+
+conn.close()

--- a/docs/source/python/recipe/postgresql_execute_nocopy.py.stdout.txt
+++ b/docs/source/python/recipe/postgresql_execute_nocopy.py.stdout.txt
@@ -1,0 +1,6 @@
+name: string
+setting: string
+description: string
+name: string
+setting: string
+description: string

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -637,6 +637,15 @@ cdef class AdbcDatabase(_AdbcHandle):
                 c_value = value
                 status = AdbcDatabaseSetOption(
                     &self.database, c_key, c_value, &c_error)
+            elif isinstance(value, bool):
+                if value:
+                    value = ADBC_OPTION_VALUE_ENABLED
+                else:
+                    value = ADBC_OPTION_VALUE_DISABLED
+                value = _to_bytes(value, "option value")
+                c_value = value
+                status = AdbcDatabaseSetOption(
+                    &self.database, c_key, c_value, &c_error)
             elif isinstance(value, bytes):
                 c_value = value
                 status = AdbcDatabaseSetOptionBytes(
@@ -1017,6 +1026,15 @@ cdef class AdbcConnection(_AdbcHandle):
                 status = AdbcConnectionSetOption(
                     &self.connection, c_key, c_value, &c_error)
             elif isinstance(value, str):
+                value = _to_bytes(value, "option value")
+                c_value = value
+                status = AdbcConnectionSetOption(
+                    &self.connection, c_key, c_value, &c_error)
+            elif isinstance(value, bool):
+                if value:
+                    value = ADBC_OPTION_VALUE_ENABLED
+                else:
+                    value = ADBC_OPTION_VALUE_DISABLED
                 value = _to_bytes(value, "option value")
                 c_value = value
                 status = AdbcConnectionSetOption(
@@ -1463,6 +1481,15 @@ cdef class AdbcStatement(_AdbcHandle):
                 status = AdbcStatementSetOption(
                     &self.statement, c_key, c_value, &c_error)
             elif isinstance(value, str):
+                value = _to_bytes(value, "option value")
+                c_value = value
+                status = AdbcStatementSetOption(
+                    &self.statement, c_key, c_value, &c_error)
+            elif isinstance(value, bool):
+                if value:
+                    value = ADBC_OPTION_VALUE_ENABLED
+                else:
+                    value = ADBC_OPTION_VALUE_DISABLED
                 value = _to_bytes(value, "option value")
                 c_value = value
                 status = AdbcStatementSetOption(

--- a/python/adbc_driver_postgresql/adbc_driver_postgresql/__init__.py
+++ b/python/adbc_driver_postgresql/adbc_driver_postgresql/__init__.py
@@ -34,6 +34,12 @@ class StatementOptions(enum.Enum):
     #: actual size may differ.
     BATCH_SIZE_HINT_BYTES = "adbc.postgresql.batch_size_hint_bytes"
 
+    #: Enable or disable the ``COPY`` optimization (default: enabled).
+    #:
+    #: This is necessary for some queries since PostgreSQL does not support
+    #: ``COPY`` with those queries, e.g. queries using ``SHOW``.
+    USE_COPY = "adbc.postgresql.use_copy"
+
 
 def connect(uri: str) -> adbc_driver_manager.AdbcDatabase:
     """Create a low level ADBC connection to PostgreSQL."""


### PR DESCRIPTION
- Add a keyword-only argument to set statement options directly when creating a cursor, which makes it a little clearer what's going on.
- Allow using True and False directly as option values (they will get converted to ENABLED and DISABLED, respectively).
- Add the `use_copy` option to the PostgreSQL options enum.
- Add an example of this with PostgreSQL.

Fixes #2093.
Fixes #2146.