### PR TITLE
chore(rust): update lock file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Clippy
         run: |
           pushd rust
-          cargo clippy --workspace --all-targets --all-features -- -Dwarnings
+          cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings
           popd
       - name: Test
         run: |

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -125,6 +125,9 @@ update_versions() {
     "${ADBC_DIR}/rust/Cargo.toml"
   rm "${ADBC_DIR}/rust/Cargo.toml.bak"
   git add "${ADBC_DIR}/rust/Cargo.toml"
+  # Update Cargo.lock file
+  cargo check --manifest-path "${ADBC_DIR}/rust/Cargo.toml"
+  git add "${ADBC_DIR}/rust/Cargo.lock"
 
   if [ ${type} = "release" ]; then
     pushd "${ADBC_DIR}/ci/linux-packages"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adbc_core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "adbc_datafusion"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "adbc_core",
  "arrow-array",
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "adbc_dummy"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "adbc_core",
  "arrow-array",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "adbc_snowflake"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "adbc_core",
  "arrow-array",


### PR DESCRIPTION
The lock file needs to be updated after bumping the crate versions. This also adds `--locked` to CI to make sure the checked-in lock file is updated.