### PR TITLE
fix(ci): fix MacOS builds for C#

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -62,9 +62,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Install Source Link
-        shell: bash
-        run: dotnet tool install --global sourcelink
       - name: Build
         shell: bash
         run: ci/scripts/csharp_build.sh $(pwd)

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -23,5 +23,4 @@ source_dir=${1}/csharp/test/Apache.Arrow.Adbc.Tests
 
 pushd ${source_dir}
 dotnet test
-# TODO: consider sourcelink
 popd

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -44,6 +44,10 @@
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
   </PropertyGroup>
 
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible($(TargetFramework), 'net8.0'))">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+  </ItemGroup>
+
   <!-- NuGet properties -->
   <PropertyGroup>
     <Authors>The Apache Software Foundation</Authors>

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -279,16 +279,6 @@ install_dotnet() {
     show_info "Installed C# at $(which csharp) (.NET $(dotnet --version))"
   fi
 
-  # Ensure to have sourcelink installed
-  if ! dotnet tool list | grep sourcelink > /dev/null 2>&1; then
-    dotnet new tool-manifest
-    dotnet tool install --local sourcelink
-    PATH=${csharp_bin}:${PATH}
-    if ! dotnet tool run sourcelink --help > /dev/null 2>&1; then
-      export DOTNET_ROOT=${csharp_bin}
-    fi
-  fi
-
   DOTNET_ALREADY_INSTALLED=1
 }
 


### PR DESCRIPTION
Fix MacOS builds for C# by moving to newer SourceLink

Closes #2568.