### PR TITLE
fix(go/adbc/driver/snowflake): try to suppress stray logs

### DIFF
--- a/go/adbc/driver/snowflake/driver.go
+++ b/go/adbc/driver/snowflake/driver.go
@@ -131,6 +131,10 @@ func init() {
 			}
 		}
 	}
+
+	// Disable some stray logs
+	// https://github.com/snowflakedb/gosnowflake/pull/1332
+	_ = gosnowflake.GetLogger().SetLogLevel("warn")
 }
 
 func errToAdbcErr(code adbc.Status, err error) error {


### PR DESCRIPTION
It turns out gosnowflake also exposes a log level control; set this to "warn".

I also filed https://github.com/snowflakedb/gosnowflake/pull/1332. We need the fix to be upstream since ultimately the log message is triggered by constructing a global, so we're powerless to suppress it. It was ultimately fixed by https://github.com/snowflakedb/gosnowflake/pull/1327.