### PR TITLE
feat(csharp/src/Drivers/Apache/Spark): Enable trimming arrow batches to limit by default

### DIFF
--- a/csharp/src/Drivers/Apache/Spark/SparkStatement.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkStatement.cs
@@ -50,6 +50,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
                 ComplexTypesAsArrow = false,
                 IntervalTypesAsArrow = false,
             };
+            statement.TrimArrowBatchesToLimit = true;
         }
 
         /// <summary>


### PR DESCRIPTION
Enable trimming arrow batches to limit by default. This is the same setting in Databricks JDBC driver.

Tested locally with a program that executes a single query

```
dotnet run "SELECT * FROM main.schema.table LIMIT 11000"                             
Connected to Databricks successfully.
Read 4096 rows.
Read 4096 rows.
Read 2129 rows.
Read 679 rows.
Read 11000 rows.
```

Closes https://github.com/apache/arrow-adbc/issues/2612