### PR TITLE
fix(go/adbc/driver/bigquery): Avoid creating arrow iterator when schema is empty

### DIFF
--- a/go/adbc/driver/bigquery/driver_test.go
+++ b/go/adbc/driver/bigquery/driver_test.go
@@ -596,6 +596,24 @@ func (suite *BigQueryTests) TearDownTest() {
 	suite.driver = nil
 }
 
+func (suite *BigQueryTests) TestDropSchema() {
+	// Unique schema name
+	schema := fmt.Sprintf("%s_x", suite.Quirks.DBSchema())
+
+	// Create unique schema to drop via a query
+	suite.Require().NoError(suite.stmt.SetSqlQuery(fmt.Sprintf("CREATE SCHEMA %s", schema)))
+	rdr, _, err := suite.stmt.ExecuteQuery(suite.ctx)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.stmt.SetSqlQuery(fmt.Sprintf("DROP SCHEMA %s CASCADE", schema)))
+	rdr, _, err = suite.stmt.ExecuteQuery(suite.ctx)
+	suite.Require().NoError(err)
+	defer rdr.Release()
+
+	// We expect at error as the schema should not exist
+	suite.Require().Error(suite.Quirks.client.Dataset(schema).DeleteWithContents(suite.Quirks.ctx))
+}
+
 func (suite *BigQueryTests) TestNewDatabaseGetSetOptions() {
 	key1, val1 := driver.OptionStringProjectID, "val1"
 	key2, val2 := driver.OptionStringDatasetID, "val2"

--- a/go/adbc/driver/bigquery/driver_test.go
+++ b/go/adbc/driver/bigquery/driver_test.go
@@ -604,11 +604,12 @@ func (suite *BigQueryTests) TestDropSchema() {
 	suite.Require().NoError(suite.stmt.SetSqlQuery(fmt.Sprintf("CREATE SCHEMA %s", schema)))
 	rdr, _, err := suite.stmt.ExecuteQuery(suite.ctx)
 	suite.Require().NoError(err)
+	rdr.Release()
 
 	suite.Require().NoError(suite.stmt.SetSqlQuery(fmt.Sprintf("DROP SCHEMA %s CASCADE", schema)))
 	rdr, _, err = suite.stmt.ExecuteQuery(suite.ctx)
 	suite.Require().NoError(err)
-	defer rdr.Release()
+	rdr.Release()
 
 	// We expect at error as the schema should not exist
 	suite.Require().Error(suite.Quirks.client.Dataset(schema).DeleteWithContents(suite.Quirks.ctx))

--- a/go/adbc/driver/bigquery/record_reader_test.go
+++ b/go/adbc/driver/bigquery/record_reader_test.go
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package bigquery
 
 import (

--- a/go/adbc/driver/bigquery/record_reader_test.go
+++ b/go/adbc/driver/bigquery/record_reader_test.go
@@ -1,0 +1,39 @@
+package bigquery
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+)
+
+func TestEmptyArrowIteratorNext(t *testing.T) {
+	iter := emptyArrowIterator{}
+	res, err := iter.Next()
+
+	if res != nil {
+		t.Errorf("Expected the result from Next to be nil, but got %v", res)
+	}
+	if err == nil {
+		t.Errorf("Expected an error from Next, but got nil")
+	}
+}
+
+func TestEmptyArrowIteratorSchema(t *testing.T) {
+	iter := emptyArrowIterator{}
+	schema := iter.Schema()
+
+	if len(schema) > 0 {
+		t.Errorf("Expected an empty schema, but got %d", len(schema))
+	}
+}
+
+func TestEmptyArrowIteratorSerializedArrowSchema(t *testing.T) {
+	iter := emptyArrowIterator{}
+	bytes := iter.SerializedArrowSchema()
+
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	rdr, _ := ipcReaderFromArrowIterator(iter, alloc)
+	if len(rdr.Schema().Fields()) > 0 {
+		t.Errorf("Expected an empty schema, but got %d bytes", len(bytes))
+	}
+}


### PR DESCRIPTION
This PR avoids creating arrow iterator in case the resulting schema is empty.  The issue was that `IsAccelerated` (in `google-cloud-go/bigquery/storage_iterator.go`)  would return `false` in case there is no result (e.g., one is running `drop schema`) when creating `ArrowIterator`. Now, before we try to get `ArrowIterator`, we check if schema is empty.

The PR also adds tests following (i.e., trying to follow) the existing formats. 

Closes: https://github.com/apache/arrow-adbc/issues/2173