### PR TITLE
feat(go/adbc/sqldriver): read from union types

### DIFF
--- a/go/adbc/sqldriver/driver.go
+++ b/go/adbc/sqldriver/driver.go
@@ -606,7 +606,9 @@ func (r *rows) Next(dest []driver.Value) error {
 			dest[i] = nil
 			continue
 		}
-
+		if colUnion, ok := col.(array.Union); ok {
+			col = colUnion.Field(colUnion.ChildID(int(r.curRow)))
+		}
 		switch col := col.(type) {
 		case *array.Boolean:
 			dest[i] = col.Value(int(r.curRow))


### PR DESCRIPTION
Implements reading from union types and adds a unit test. All tests pass, except those with C shared object dependencies. I did not build the code outside go/adbc - let me know if needed for this PR.

In addition to the added unit test, I tested the scenario from the issue with DuckDB.

Closes #2636