### PR TITLE
feat(csharp): Add retry-after behavior for 503 responses in Spark ADBC driver

### DIFF
--- a/csharp/src/Drivers/Apache/Spark/RetryHttpHandler.cs
+++ b/csharp/src/Drivers/Apache/Spark/RetryHttpHandler.cs
@@ -142,12 +142,12 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
 
             // Create a custom exception with the SQL state code and last error message
             var exception = new AdbcException(
-                lastErrorMessage ?? "Service temporarily unavailable and retry timeout exceeded", 
+                lastErrorMessage ?? "Service temporarily unavailable and retry timeout exceeded",
                 AdbcStatusCode.IOError);
-                
+
             // Add SQL state as part of the message since we can't set it directly
             throw new AdbcException(
-                $"[SQLState: 08001] {exception.Message}", 
+                $"[SQLState: 08001] {exception.Message}",
                 AdbcStatusCode.IOError);
         }
 

--- a/csharp/src/Drivers/Apache/Spark/RetryHttpHandler.cs
+++ b/csharp/src/Drivers/Apache/Spark/RetryHttpHandler.cs
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.IO;
+using System.Text;
+using Thrift;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Apache.Hive.Service.Rpc.Thrift;
+
+namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
+{
+    /// <summary>
+    /// HTTP handler that implements retry behavior for 503 responses with Retry-After headers.
+    /// </summary>
+    internal class RetryHttpHandler : DelegatingHandler
+    {
+        private readonly bool _retryEnabled;
+        private readonly int _retryTimeoutSeconds;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetryHttpHandler"/> class.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler to delegate to.</param>
+        /// <param name="retryEnabled">Whether retry behavior is enabled.</param>
+        /// <param name="retryTimeoutSeconds">Maximum total time in seconds to retry before failing.</param>
+        public RetryHttpHandler(HttpMessageHandler innerHandler, bool retryEnabled, int retryTimeoutSeconds)
+            : base(innerHandler)
+        {
+            _retryEnabled = retryEnabled;
+            _retryTimeoutSeconds = retryTimeoutSeconds;
+        }
+
+        /// <summary>
+        /// Sends an HTTP request to the inner handler with retry logic for 503 responses.
+        /// </summary>
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            // If retry is disabled, just pass through to the inner handler
+            if (!_retryEnabled)
+            {
+                return await base.SendAsync(request, cancellationToken);
+            }
+
+            // Clone the request content if it's not null so we can reuse it for retries
+            var requestContentClone = request.Content != null
+                ? await CloneHttpContentAsync(request.Content)
+                : null;
+
+            HttpResponseMessage response;
+            string? lastErrorMessage = null;
+            DateTime startTime = DateTime.UtcNow;
+            int totalRetrySeconds = 0;
+
+            do
+            {
+                // Set the content for each attempt (if needed)
+                if (requestContentClone != null && request.Content == null)
+                {
+                    request.Content = await CloneHttpContentAsync(requestContentClone);
+                }
+
+                response = await base.SendAsync(request, cancellationToken);
+
+                // If it's not a 503 response, return immediately
+                if (response.StatusCode != HttpStatusCode.ServiceUnavailable)
+                {
+                    return response;
+                }
+
+                // Check for Retry-After header
+                if (!response.Headers.TryGetValues("Retry-After", out var retryAfterValues))
+                {
+                    // No Retry-After header, so return the response as is
+                    return response;
+                }
+
+                // Parse the Retry-After value
+                string retryAfterValue = string.Join(",", retryAfterValues);
+                if (!int.TryParse(retryAfterValue, out int retryAfterSeconds) || retryAfterSeconds <= 0)
+                {
+                    // Invalid Retry-After value, return the response as is
+                    return response;
+                }
+
+                // Extract error message from response if possible
+                try
+                {
+                    lastErrorMessage = await ExtractErrorMessageAsync(response);
+                }
+                catch
+                {
+                    // If we can't extract the error message, just use a generic one
+                    lastErrorMessage = $"Service temporarily unavailable (HTTP 503). Retry after {retryAfterSeconds} seconds.";
+                }
+
+                // Check if we've exceeded the timeout
+                totalRetrySeconds += retryAfterSeconds;
+                if (_retryTimeoutSeconds > 0 && totalRetrySeconds > _retryTimeoutSeconds)
+                {
+                    // We've exceeded the timeout, so break out of the loop
+                    break;
+                }
+
+                // Dispose the response before retrying
+                response.Dispose();
+
+                // Wait for the specified retry time
+                await Task.Delay(TimeSpan.FromSeconds(retryAfterSeconds), cancellationToken);
+
+                // Reset the request content for the next attempt
+                request.Content = null;
+
+            } while (!cancellationToken.IsCancellationRequested);
+
+            // If we get here, we've either exceeded the timeout or been cancelled
+            if (cancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException("Request cancelled during retry wait", cancellationToken);
+            }
+
+            // Create a custom exception with the SQL state code and last error message
+            var exception = new AdbcException(
+                lastErrorMessage ?? "Service temporarily unavailable and retry timeout exceeded", 
+                AdbcStatusCode.IOError);
+                
+            // Add SQL state as part of the message since we can't set it directly
+            throw new AdbcException(
+                $"[SQLState: 08001] {exception.Message}", 
+                AdbcStatusCode.IOError);
+        }
+
+        /// <summary>
+        /// Clones an HttpContent object so it can be reused for retries.
+        /// </summary>
+        private static async Task<HttpContent> CloneHttpContentAsync(HttpContent content)
+        {
+            var ms = new MemoryStream();
+            await content.CopyToAsync(ms);
+            ms.Position = 0;
+
+            var clone = new StreamContent(ms);
+            if (content.Headers != null)
+            {
+                foreach (var header in content.Headers)
+                {
+                    clone.Headers.Add(header.Key, header.Value);
+                }
+            }
+            return clone;
+        }
+
+        /// <summary>
+        /// Attempts to extract the error message from a Thrift TApplicationException in the response body.
+        /// </summary>
+        private static async Task<string?> ExtractErrorMessageAsync(HttpResponseMessage response)
+        {
+            if (response.Content == null)
+            {
+                return null;
+            }
+
+            // Check if the content type is application/x-thrift
+            if (response.Content.Headers.ContentType?.MediaType != "application/x-thrift")
+            {
+                // If it's not Thrift, just return the content as a string
+                return await response.Content.ReadAsStringAsync();
+            }
+
+            try
+            {
+                // For Thrift content, just return a generic message
+                // We can't easily parse the Thrift message without access to the specific methods
+                return await response.Content.ReadAsStringAsync();
+            }
+            catch
+            {
+                // If we can't read the content, return null
+                return null;
+            }
+        }
+    }
+}

--- a/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
@@ -146,21 +146,21 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
                     ? connectTimeoutMsValue
                     : throw new ArgumentOutOfRangeException(SparkParameters.ConnectTimeoutMilliseconds, connectTimeoutMs, $"must be a value of 0 (infinite) or between 1 .. {int.MaxValue}. default is 30000 milliseconds.");
             }
-            
+
             // Parse retry configuration parameters
             Properties.TryGetValue(SparkParameters.TemporarilyUnavailableRetry, out string? tempUnavailableRetryStr);
             int tempUnavailableRetryValue = 1; // Default to enabled
             if (tempUnavailableRetryStr != null && !int.TryParse(tempUnavailableRetryStr, out tempUnavailableRetryValue))
             {
-                throw new ArgumentOutOfRangeException(SparkParameters.TemporarilyUnavailableRetry, tempUnavailableRetryStr, 
+                throw new ArgumentOutOfRangeException(SparkParameters.TemporarilyUnavailableRetry, tempUnavailableRetryStr,
                     $"must be a value of 0 (disabled) or 1 (enabled). Default is 1.");
             }
             TemporarilyUnavailableRetry = tempUnavailableRetryValue != 0;
-            
+
             Properties.TryGetValue(SparkParameters.TemporarilyUnavailableRetryTimeout, out string? tempUnavailableRetryTimeoutStr);
             if (tempUnavailableRetryTimeoutStr != null)
             {
-                if (!int.TryParse(tempUnavailableRetryTimeoutStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out int tempUnavailableRetryTimeoutValue) || 
+                if (!int.TryParse(tempUnavailableRetryTimeoutStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out int tempUnavailableRetryTimeoutValue) ||
                     tempUnavailableRetryTimeoutValue < 0)
                 {
                     throw new ArgumentOutOfRangeException(SparkParameters.TemporarilyUnavailableRetryTimeout, tempUnavailableRetryTimeoutStr,
@@ -172,7 +172,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
             {
                 TemporarilyUnavailableRetryTimeout = 900; // Default to 15 minutes
             }
-            
+
             TlsOptions = HiveServer2TlsImpl.GetHttpTlsOptions(Properties);
         }
 
@@ -199,13 +199,13 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
             AuthenticationHeaderValue? authenticationHeaderValue = GetAuthenticationHeaderValue(authTypeValue, token, username, password, access_token);
 
             HttpClientHandler httpClientHandler = HiveServer2TlsImpl.NewHttpClientHandler(TlsOptions);
-            
+
             // Create a RetryHttpHandler that wraps the HttpClientHandler to handle 503 responses
             var retryHandler = new RetryHttpHandler(
-                httpClientHandler, 
-                TemporarilyUnavailableRetry, 
+                httpClientHandler,
+                TemporarilyUnavailableRetry,
                 TemporarilyUnavailableRetryTimeout);
-                
+
             HttpClient httpClient = new(retryHandler);
             httpClient.BaseAddress = baseAddress;
             httpClient.DefaultRequestHeaders.Authorization = authenticationHeaderValue;

--- a/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
@@ -44,6 +44,16 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
         {
         }
 
+        /// <summary>
+        /// Gets a value indicating whether to retry requests that receive a 503 response with a Retry-After header.
+        /// </summary>
+        protected bool TemporarilyUnavailableRetry { get; private set; } = true;
+
+        /// <summary>
+        /// Gets the maximum total time in seconds to retry 503 responses before failing.
+        /// </summary>
+        protected int TemporarilyUnavailableRetryTimeout { get; private set; } = 900;
+
         protected override void ValidateAuthentication()
         {
             // Validate authentication parameters
@@ -136,6 +146,33 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
                     ? connectTimeoutMsValue
                     : throw new ArgumentOutOfRangeException(SparkParameters.ConnectTimeoutMilliseconds, connectTimeoutMs, $"must be a value of 0 (infinite) or between 1 .. {int.MaxValue}. default is 30000 milliseconds.");
             }
+            
+            // Parse retry configuration parameters
+            Properties.TryGetValue(SparkParameters.TemporarilyUnavailableRetry, out string? tempUnavailableRetryStr);
+            int tempUnavailableRetryValue = 1; // Default to enabled
+            if (tempUnavailableRetryStr != null && !int.TryParse(tempUnavailableRetryStr, out tempUnavailableRetryValue))
+            {
+                throw new ArgumentOutOfRangeException(SparkParameters.TemporarilyUnavailableRetry, tempUnavailableRetryStr, 
+                    $"must be a value of 0 (disabled) or 1 (enabled). Default is 1.");
+            }
+            TemporarilyUnavailableRetry = tempUnavailableRetryValue != 0;
+            
+            Properties.TryGetValue(SparkParameters.TemporarilyUnavailableRetryTimeout, out string? tempUnavailableRetryTimeoutStr);
+            if (tempUnavailableRetryTimeoutStr != null)
+            {
+                if (!int.TryParse(tempUnavailableRetryTimeoutStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out int tempUnavailableRetryTimeoutValue) || 
+                    tempUnavailableRetryTimeoutValue < 0)
+                {
+                    throw new ArgumentOutOfRangeException(SparkParameters.TemporarilyUnavailableRetryTimeout, tempUnavailableRetryTimeoutStr,
+                        $"must be a value of 0 (retry indefinitely) or a positive integer representing seconds. Default is 900 seconds (15 minutes).");
+                }
+                TemporarilyUnavailableRetryTimeout = tempUnavailableRetryTimeoutValue;
+            }
+            else
+            {
+                TemporarilyUnavailableRetryTimeout = 900; // Default to 15 minutes
+            }
+            
             TlsOptions = HiveServer2TlsImpl.GetHttpTlsOptions(Properties);
         }
 
@@ -162,7 +199,14 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
             AuthenticationHeaderValue? authenticationHeaderValue = GetAuthenticationHeaderValue(authTypeValue, token, username, password, access_token);
 
             HttpClientHandler httpClientHandler = HiveServer2TlsImpl.NewHttpClientHandler(TlsOptions);
-            HttpClient httpClient = new(httpClientHandler);
+            
+            // Create a RetryHttpHandler that wraps the HttpClientHandler to handle 503 responses
+            var retryHandler = new RetryHttpHandler(
+                httpClientHandler, 
+                TemporarilyUnavailableRetry, 
+                TemporarilyUnavailableRetryTimeout);
+                
+            HttpClient httpClient = new(retryHandler);
             httpClient.BaseAddress = baseAddress;
             httpClient.DefaultRequestHeaders.Authorization = authenticationHeaderValue;
             httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(s_userAgent);

--- a/csharp/src/Drivers/Apache/Spark/SparkParameters.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkParameters.cs
@@ -33,6 +33,18 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
         public const string Type = "adbc.spark.type";
         public const string DataTypeConv = "adbc.spark.data_type_conv";
         public const string ConnectTimeoutMilliseconds = "adbc.spark.connect_timeout_ms";
+        
+        /// <summary>
+        /// Controls whether to retry requests that receive a 503 response with a Retry-After header.
+        /// Default value is 1 (enabled). Set to 0 to disable retry behavior.
+        /// </summary>
+        public const string TemporarilyUnavailableRetry = "adbc.spark.temporarily_unavailable_retry";
+        
+        /// <summary>
+        /// Maximum total time in seconds to retry 503 responses before failing.
+        /// Default value is 900 seconds (15 minutes). Set to 0 to retry indefinitely.
+        /// </summary>
+        public const string TemporarilyUnavailableRetryTimeout = "adbc.spark.temporarily_unavailable_retry_timeout";
     }
 
     public static class SparkAuthTypeConstants

--- a/csharp/src/Drivers/Apache/Spark/SparkParameters.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkParameters.cs
@@ -33,13 +33,13 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
         public const string Type = "adbc.spark.type";
         public const string DataTypeConv = "adbc.spark.data_type_conv";
         public const string ConnectTimeoutMilliseconds = "adbc.spark.connect_timeout_ms";
-        
+
         /// <summary>
         /// Controls whether to retry requests that receive a 503 response with a Retry-After header.
         /// Default value is 1 (enabled). Set to 0 to disable retry behavior.
         /// </summary>
         public const string TemporarilyUnavailableRetry = "adbc.spark.temporarily_unavailable_retry";
-        
+
         /// <summary>
         /// Maximum total time in seconds to retry 503 responses before failing.
         /// Default value is 900 seconds (15 minutes). Set to 0 to retry indefinitely.

--- a/csharp/test/Drivers/Apache/Spark/RetryHttpHandlerTest.cs
+++ b/csharp/test/Drivers/Apache/Spark/RetryHttpHandlerTest.cs
@@ -48,25 +48,25 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
 
             // Create the RetryHttpHandler with retry enabled and a 5-second timeout
             var retryHandler = new RetryHttpHandler(mockHandler, true, 5);
-            
+
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
-            
+
             // Set the mock handler to return a success response after the first retry
             mockHandler.SetResponseAfterRetryCount(1, new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("Success")
             });
-            
+
             // Send a request
             var response = await httpClient.GetAsync("http://test.com");
-            
+
             // Verify the response is OK
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("Success", await response.Content.ReadAsStringAsync());
             Assert.Equal(2, mockHandler.RequestCount); // Initial request + 1 retry
         }
-        
+
         /// <summary>
         /// Tests that the RetryHttpHandler throws an exception when the retry timeout is exceeded.
         /// </summary>
@@ -83,22 +83,22 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
 
             // Create the RetryHttpHandler with retry enabled and a 1-second timeout
             var retryHandler = new RetryHttpHandler(mockHandler, true, 1);
-            
+
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
-            
+
             // Send a request and expect an AdbcException
-            var exception = await Assert.ThrowsAsync<AdbcException>(async () => 
+            var exception = await Assert.ThrowsAsync<AdbcException>(async () =>
                 await httpClient.GetAsync("http://test.com"));
-            
+
             // Verify the exception has the correct SQL state in the message
             Assert.Contains("[SQLState: 08001]", exception.Message);
             Assert.Equal(AdbcStatusCode.IOError, exception.Status);
-            
+
             // Verify we only tried once (since the Retry-After value of 2 exceeds our timeout of 1)
             Assert.Equal(1, mockHandler.RequestCount);
         }
-        
+
         /// <summary>
         /// Tests that the RetryHttpHandler doesn't retry when retry is disabled.
         /// </summary>
@@ -115,19 +115,19 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
 
             // Create the RetryHttpHandler with retry disabled
             var retryHandler = new RetryHttpHandler(mockHandler, false, 5);
-            
+
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
-            
+
             // Send a request
             var response = await httpClient.GetAsync("http://test.com");
-            
+
             // Verify the response is 503
             Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
             Assert.Equal("Service Unavailable", await response.Content.ReadAsStringAsync());
             Assert.Equal(1, mockHandler.RequestCount); // Only the initial request, no retries
         }
-        
+
         /// <summary>
         /// Tests that the RetryHttpHandler handles non-503 responses correctly.
         /// </summary>
@@ -143,19 +143,19 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
 
             // Create the RetryHttpHandler with retry enabled
             var retryHandler = new RetryHttpHandler(mockHandler, true, 5);
-            
+
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
-            
+
             // Send a request
             var response = await httpClient.GetAsync("http://test.com");
-            
+
             // Verify the response is 404
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             Assert.Equal("Not Found", await response.Content.ReadAsStringAsync());
             Assert.Equal(1, mockHandler.RequestCount); // Only the initial request, no retries
         }
-        
+
         /// <summary>
         /// Tests that the RetryHttpHandler handles 503 responses without Retry-After headers correctly.
         /// </summary>
@@ -171,19 +171,19 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
 
             // Create the RetryHttpHandler with retry enabled
             var retryHandler = new RetryHttpHandler(mockHandler, true, 5);
-            
+
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
-            
+
             // Send a request
             var response = await httpClient.GetAsync("http://test.com");
-            
+
             // Verify the response is 503
             Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
             Assert.Equal("Service Unavailable", await response.Content.ReadAsStringAsync());
             Assert.Equal(1, mockHandler.RequestCount); // Only the initial request, no retries
         }
-        
+
         /// <summary>
         /// Tests that the RetryHttpHandler handles invalid Retry-After headers correctly.
         /// </summary>
@@ -207,19 +207,19 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
 
             // Create the RetryHttpHandler with retry enabled
             var retryHandler = new RetryHttpHandler(mockHandler, true, 5);
-            
+
             // Create an HttpClient with our handler
             var httpClient = new HttpClient(retryHandler);
-            
+
             // Send a request
             response = await httpClient.GetAsync("http://test.com");
-            
+
             // Verify the response is 503
             Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
             Assert.Equal("Service Unavailable", await response.Content.ReadAsStringAsync());
             Assert.Equal(1, mockHandler.RequestCount); // Only the initial request, no retries
         }
-        
+
         /// <summary>
         /// Mock HttpMessageHandler for testing the RetryHttpHandler.
         /// </summary>
@@ -228,38 +228,38 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
             private readonly HttpResponseMessage _defaultResponse;
             private HttpResponseMessage? _responseAfterRetryCount;
             private int _retryCountForResponse;
-            
+
             public int RequestCount { get; private set; }
-            
+
             public MockHttpMessageHandler(HttpResponseMessage defaultResponse)
             {
                 _defaultResponse = defaultResponse;
             }
-            
+
             public void SetResponseAfterRetryCount(int retryCount, HttpResponseMessage response)
             {
                 _retryCountForResponse = retryCount;
                 _responseAfterRetryCount = response;
             }
-            
+
             protected override Task<HttpResponseMessage> SendAsync(
                 HttpRequestMessage request,
                 CancellationToken cancellationToken)
             {
                 RequestCount++;
-                
+
                 if (_responseAfterRetryCount != null && RequestCount > _retryCountForResponse)
                 {
                     return Task.FromResult(_responseAfterRetryCount);
                 }
-                
+
                 // Create a new response instance to avoid modifying the original
                 var response = new HttpResponseMessage
                 {
                     StatusCode = _defaultResponse.StatusCode,
                     Content = _defaultResponse.Content
                 };
-                
+
                 // Copy headers only if they exist
                 if (_defaultResponse.Headers.Contains("Retry-After"))
                 {
@@ -268,7 +268,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
                         response.Headers.Add("Retry-After", value);
                     }
                 }
-                
+
                 return Task.FromResult(response);
             }
         }

--- a/csharp/test/Drivers/Apache/Spark/RetryHttpHandlerTest.cs
+++ b/csharp/test/Drivers/Apache/Spark/RetryHttpHandlerTest.cs
@@ -1,0 +1,276 @@
+﻿/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Apache.Spark;
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
+{
+    /// <summary>
+    /// Tests for the RetryHttpHandler class.
+    /// </summary>
+    public class RetryHttpHandlerTest
+    {
+        /// <summary>
+        /// Tests that the RetryHttpHandler properly processes 503 responses with Retry-After headers.
+        /// </summary>
+        [Fact]
+        public async Task RetryAfterHandlerProcesses503Response()
+        {
+            // Create a mock handler that returns a 503 response with a Retry-After header
+            var mockHandler = new MockHttpMessageHandler(
+                new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Headers = { { "Retry-After", "1" } },
+                    Content = new StringContent("Service Unavailable")
+                });
+
+            // Create the RetryHttpHandler with retry enabled and a 5-second timeout
+            var retryHandler = new RetryHttpHandler(mockHandler, true, 5);
+            
+            // Create an HttpClient with our handler
+            var httpClient = new HttpClient(retryHandler);
+            
+            // Set the mock handler to return a success response after the first retry
+            mockHandler.SetResponseAfterRetryCount(1, new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("Success")
+            });
+            
+            // Send a request
+            var response = await httpClient.GetAsync("http://test.com");
+            
+            // Verify the response is OK
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Success", await response.Content.ReadAsStringAsync());
+            Assert.Equal(2, mockHandler.RequestCount); // Initial request + 1 retry
+        }
+        
+        /// <summary>
+        /// Tests that the RetryHttpHandler throws an exception when the retry timeout is exceeded.
+        /// </summary>
+        [Fact]
+        public async Task RetryAfterHandlerThrowsWhenTimeoutExceeded()
+        {
+            // Create a mock handler that always returns a 503 response with a Retry-After header
+            var mockHandler = new MockHttpMessageHandler(
+                new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Headers = { { "Retry-After", "2" } },
+                    Content = new StringContent("Service Unavailable")
+                });
+
+            // Create the RetryHttpHandler with retry enabled and a 1-second timeout
+            var retryHandler = new RetryHttpHandler(mockHandler, true, 1);
+            
+            // Create an HttpClient with our handler
+            var httpClient = new HttpClient(retryHandler);
+            
+            // Send a request and expect an AdbcException
+            var exception = await Assert.ThrowsAsync<AdbcException>(async () => 
+                await httpClient.GetAsync("http://test.com"));
+            
+            // Verify the exception has the correct SQL state in the message
+            Assert.Contains("[SQLState: 08001]", exception.Message);
+            Assert.Equal(AdbcStatusCode.IOError, exception.Status);
+            
+            // Verify we only tried once (since the Retry-After value of 2 exceeds our timeout of 1)
+            Assert.Equal(1, mockHandler.RequestCount);
+        }
+        
+        /// <summary>
+        /// Tests that the RetryHttpHandler doesn't retry when retry is disabled.
+        /// </summary>
+        [Fact]
+        public async Task RetryAfterHandlerDoesNotRetryWhenDisabled()
+        {
+            // Create a mock handler that returns a 503 response with a Retry-After header
+            var mockHandler = new MockHttpMessageHandler(
+                new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Headers = { { "Retry-After", "1" } },
+                    Content = new StringContent("Service Unavailable")
+                });
+
+            // Create the RetryHttpHandler with retry disabled
+            var retryHandler = new RetryHttpHandler(mockHandler, false, 5);
+            
+            // Create an HttpClient with our handler
+            var httpClient = new HttpClient(retryHandler);
+            
+            // Send a request
+            var response = await httpClient.GetAsync("http://test.com");
+            
+            // Verify the response is 503
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+            Assert.Equal("Service Unavailable", await response.Content.ReadAsStringAsync());
+            Assert.Equal(1, mockHandler.RequestCount); // Only the initial request, no retries
+        }
+        
+        /// <summary>
+        /// Tests that the RetryHttpHandler handles non-503 responses correctly.
+        /// </summary>
+        [Fact]
+        public async Task RetryAfterHandlerHandlesNon503Response()
+        {
+            // Create a mock handler that returns a 404 response
+            var mockHandler = new MockHttpMessageHandler(
+                new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    Content = new StringContent("Not Found")
+                });
+
+            // Create the RetryHttpHandler with retry enabled
+            var retryHandler = new RetryHttpHandler(mockHandler, true, 5);
+            
+            // Create an HttpClient with our handler
+            var httpClient = new HttpClient(retryHandler);
+            
+            // Send a request
+            var response = await httpClient.GetAsync("http://test.com");
+            
+            // Verify the response is 404
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Equal("Not Found", await response.Content.ReadAsStringAsync());
+            Assert.Equal(1, mockHandler.RequestCount); // Only the initial request, no retries
+        }
+        
+        /// <summary>
+        /// Tests that the RetryHttpHandler handles 503 responses without Retry-After headers correctly.
+        /// </summary>
+        [Fact]
+        public async Task RetryAfterHandlerHandles503WithoutRetryAfterHeader()
+        {
+            // Create a mock handler that returns a 503 response without a Retry-After header
+            var mockHandler = new MockHttpMessageHandler(
+                new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent("Service Unavailable")
+                });
+
+            // Create the RetryHttpHandler with retry enabled
+            var retryHandler = new RetryHttpHandler(mockHandler, true, 5);
+            
+            // Create an HttpClient with our handler
+            var httpClient = new HttpClient(retryHandler);
+            
+            // Send a request
+            var response = await httpClient.GetAsync("http://test.com");
+            
+            // Verify the response is 503
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+            Assert.Equal("Service Unavailable", await response.Content.ReadAsStringAsync());
+            Assert.Equal(1, mockHandler.RequestCount); // Only the initial request, no retries
+        }
+        
+        /// <summary>
+        /// Tests that the RetryHttpHandler handles invalid Retry-After headers correctly.
+        /// </summary>
+        [Fact]
+        public async Task RetryAfterHandlerHandlesInvalidRetryAfterHeader()
+        {
+            // Create a mock handler that returns a 503 response with an invalid Retry-After header
+            var mockHandler = new MockHttpMessageHandler(
+                new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent("Service Unavailable")
+                });
+
+            // Add the invalid Retry-After header directly in the test
+            var response = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = new StringContent("Service Unavailable")
+            };
+            response.Headers.TryAddWithoutValidation("Retry-After", "invalid");
+            mockHandler.SetResponseAfterRetryCount(0, response);
+
+            // Create the RetryHttpHandler with retry enabled
+            var retryHandler = new RetryHttpHandler(mockHandler, true, 5);
+            
+            // Create an HttpClient with our handler
+            var httpClient = new HttpClient(retryHandler);
+            
+            // Send a request
+            response = await httpClient.GetAsync("http://test.com");
+            
+            // Verify the response is 503
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+            Assert.Equal("Service Unavailable", await response.Content.ReadAsStringAsync());
+            Assert.Equal(1, mockHandler.RequestCount); // Only the initial request, no retries
+        }
+        
+        /// <summary>
+        /// Mock HttpMessageHandler for testing the RetryHttpHandler.
+        /// </summary>
+        private class MockHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly HttpResponseMessage _defaultResponse;
+            private HttpResponseMessage? _responseAfterRetryCount;
+            private int _retryCountForResponse;
+            
+            public int RequestCount { get; private set; }
+            
+            public MockHttpMessageHandler(HttpResponseMessage defaultResponse)
+            {
+                _defaultResponse = defaultResponse;
+            }
+            
+            public void SetResponseAfterRetryCount(int retryCount, HttpResponseMessage response)
+            {
+                _retryCountForResponse = retryCount;
+                _responseAfterRetryCount = response;
+            }
+            
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                RequestCount++;
+                
+                if (_responseAfterRetryCount != null && RequestCount > _retryCountForResponse)
+                {
+                    return Task.FromResult(_responseAfterRetryCount);
+                }
+                
+                // Create a new response instance to avoid modifying the original
+                var response = new HttpResponseMessage
+                {
+                    StatusCode = _defaultResponse.StatusCode,
+                    Content = _defaultResponse.Content
+                };
+                
+                // Copy headers only if they exist
+                if (_defaultResponse.Headers.Contains("Retry-After"))
+                {
+                    foreach (var value in _defaultResponse.Headers.GetValues("Retry-After"))
+                    {
+                        response.Headers.Add("Retry-After", value);
+                    }
+                }
+                
+                return Task.FromResult(response);
+            }
+        }
+    }
+}

--- a/csharp/test/Drivers/Apache/Spark/SparkConnectionTest.cs
+++ b/csharp/test/Drivers/Apache/Spark/SparkConnectionTest.cs
@@ -317,7 +317,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [SparkParameters.ConnectTimeoutMilliseconds] = "non-numeric" }, typeof(ArgumentOutOfRangeException)));
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [SparkParameters.ConnectTimeoutMilliseconds] = "" }, typeof(ArgumentOutOfRangeException)));
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Databricks, [SparkParameters.Token] = "abcdef", [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Uri] = "http://valid.hostname.com" }, typeof(ArgumentOutOfRangeException)));
-                
+
                 // Tests for the new retry configuration parameters
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [SparkParameters.TemporarilyUnavailableRetry] = "invalid" }, typeof(ArgumentOutOfRangeException)));
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [SparkParameters.TemporarilyUnavailableRetryTimeout] = "invalid" }, typeof(ArgumentOutOfRangeException)));

--- a/csharp/test/Drivers/Apache/Spark/SparkConnectionTest.cs
+++ b/csharp/test/Drivers/Apache/Spark/SparkConnectionTest.cs
@@ -317,6 +317,11 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [SparkParameters.ConnectTimeoutMilliseconds] = "non-numeric" }, typeof(ArgumentOutOfRangeException)));
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [SparkParameters.ConnectTimeoutMilliseconds] = "" }, typeof(ArgumentOutOfRangeException)));
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Databricks, [SparkParameters.Token] = "abcdef", [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Uri] = "http://valid.hostname.com" }, typeof(ArgumentOutOfRangeException)));
+                
+                // Tests for the new retry configuration parameters
+                Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [SparkParameters.TemporarilyUnavailableRetry] = "invalid" }, typeof(ArgumentOutOfRangeException)));
+                Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [SparkParameters.TemporarilyUnavailableRetryTimeout] = "invalid" }, typeof(ArgumentOutOfRangeException)));
+                Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [SparkParameters.TemporarilyUnavailableRetryTimeout] = "-1" }, typeof(ArgumentOutOfRangeException)));
             }
         }
     }


### PR DESCRIPTION
## Description

This PR implements retry-after behavior for the Spark ADBC driver when receiving 503 responses with Retry-After headers. This is particularly useful for Databricks clusters that may return 503 responses when a cluster is starting up or experiencing temporary unavailability.

## Changes

- Added new configuration parameters:
  - `adbc.spark.temporarily_unavailable_retry` (default: 1 - enabled)
  - `adbc.spark.temporarily_unavailable_retry_timeout` (default: 900 seconds)
- Created a `RetryHttpHandler` class that wraps the existing `HttpClientHandler` to handle 503 responses
- Modified `SparkHttpConnection` to use the new retry handler
- Added comprehensive unit tests for the retry behavior

## Implementation Details

When a 503 response with a Retry-After header is received:
1. The handler will wait for the number of seconds specified in the header
2. It will then retry the request
3. If another 503 response is received, it will continue retrying
4. If the total retry time exceeds the configured timeout, it will fail with an appropriate error message

## Testing

Added unit tests to verify:
- Retry behavior for 503 responses with Retry-After headers
- Timeout behavior when retry time exceeds the configured limit
- Handling of invalid or missing Retry-After headers
- Disabling retry behavior via configuration
- Parameter validationv