### PR TITLE
fix: Use number of rows (rather than schema) to check if we need an empty arrow iterator

### DIFF
--- a/go/adbc/driver/bigquery/driver_test.go
+++ b/go/adbc/driver/bigquery/driver_test.go
@@ -611,8 +611,21 @@ func (suite *BigQueryTests) TestDropSchema() {
 	suite.Require().NoError(err)
 	rdr.Release()
 
-	// We expect at error as the schema should not exist
+	// We expect an error as the schema should not exist
 	suite.Require().Error(suite.Quirks.client.Dataset(schema).DeleteWithContents(suite.Quirks.ctx))
+}
+
+func (suite *BigQueryTests) TestCreateView() {
+	// Create unique schema to drop via a query
+	suite.Require().NoError(suite.stmt.SetSqlQuery(fmt.Sprintf("CREATE TABLE IF NOT EXISTS a (id int)")))
+	rdr, _, err := suite.stmt.ExecuteQuery(suite.ctx)
+	suite.Require().NoError(err)
+	rdr.Release()
+
+	suite.Require().NoError(suite.stmt.SetSqlQuery(fmt.Sprintf("CREATE VIEW IF NOT EXISTS a_view AS SELECT * FROM a")))
+	rdr, _, err = suite.stmt.ExecuteQuery(suite.ctx)
+	suite.Require().NoError(err)
+	rdr.Release()
 }
 
 func (suite *BigQueryTests) TestNewDatabaseGetSetOptions() {

--- a/go/adbc/driver/bigquery/record_reader.go
+++ b/go/adbc/driver/bigquery/record_reader.go
@@ -72,12 +72,12 @@ func runQuery(ctx context.Context, query *bigquery.Query, executeUpdate bool) (b
 	var arrowIterator bigquery.ArrowIterator
 	// If there is no schema in the row iterator, then arrow
 	// iterator should be empty (#2173)
-	if len(iter.Schema) > 0 {
+	if iter.TotalRows > 0 {
 		if arrowIterator, err = iter.ArrowIterator(); err != nil {
 			return nil, -1, err
 		}
 	} else {
-		arrowIterator = emptyArrowIterator{}
+		arrowIterator = emptyArrowIterator{iter.Schema}
 	}
 	totalRows := int64(iter.TotalRows)
 	return arrowIterator, totalRows, nil
@@ -286,14 +286,16 @@ func (r *reader) Record() arrow.Record {
 	return r.rec
 }
 
-type emptyArrowIterator struct{}
+type emptyArrowIterator struct {
+	schema bigquery.Schema
+}
 
 func (e emptyArrowIterator) Next() (*bigquery.ArrowRecordBatch, error) {
 	return nil, errors.New("Next should never be invoked on an empty iterator")
 }
 
 func (e emptyArrowIterator) Schema() bigquery.Schema {
-	return bigquery.Schema{}
+	return e.schema
 }
 
 func (e emptyArrowIterator) SerializedArrowSchema() []byte {


### PR DESCRIPTION
As the newly added tests shows, we might end up with a schema (`create view`) and yet no rows in which case we would still have an issue #2173 

This PR changes so we check if the number of rows is empty (and keep the schema).

Note: The potential issue with using Schema vs. TotalRows is the same (as the comment says for both of the fields they might not be initialized in some cases before the first call to Next).