### PR TITLE
feat(c/driver/postgresql): avoid commit/rollback when idle

### DIFF
--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -1136,7 +1136,7 @@ AdbcStatusCode PostgresConnection::Rollback(struct AdbcError* error) {
     return ADBC_STATUS_OK;
   }
 
-  PGresult* result = PQexec(conn_, "ROLLBACK");
+  PGresult* result = PQexec(conn_, "ROLLBACK AND CHAIN");
   if (PQresultStatus(result) != PGRES_COMMAND_OK) {
     SetError(error, "%s%s", "[libpq] Failed to rollback: ", PQerrorMessage(conn_));
     PQclear(result);

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1022,7 +1022,7 @@ TEST_F(PostgresStatementTest, TransactionStatus) {
     ASSERT_EQ("active", ConnectionGetOption(&connection, txn_status, &error));
 
     ASSERT_THAT(AdbcConnectionRollback(&connection, &error), IsOkStatus(&error));
-    ASSERT_EQ("idle", ConnectionGetOption(&connection, txn_status, &error));
+    ASSERT_EQ("intrans", ConnectionGetOption(&connection, txn_status, &error));
   }
   {
     adbc_validation::StreamReader reader;
@@ -1035,8 +1035,6 @@ TEST_F(PostgresStatementTest, TransactionStatus) {
 
     ASSERT_EQ("active", ConnectionGetOption(&connection, txn_status, &error));
 
-    // Note that despite the status being "active", this commit still
-    // generates a warning on the server.
     ASSERT_THAT(AdbcConnectionCommit(&connection, &error), IsOkStatus(&error));
     ASSERT_EQ("intrans", ConnectionGetOption(&connection, txn_status, &error));
   }

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -995,6 +995,66 @@ class PostgresStatementTest : public ::testing::Test,
 };
 ADBCV_TEST_STATEMENT(PostgresStatementTest)
 
+TEST_F(PostgresStatementTest, TransactionStatus) {
+  using adbc_validation::ConnectionGetOption;
+  const char* txn_status = "adbc.postgresql.transaction_status";
+  ASSERT_THAT(quirks()->DropTable(&connection, "txntest", &error), IsOkStatus(&error));
+
+  ASSERT_EQ("idle", ConnectionGetOption(&connection, txn_status, &error));
+
+  ASSERT_THAT(AdbcConnectionSetOption(&connection, ADBC_CONNECTION_OPTION_AUTOCOMMIT,
+                                      ADBC_OPTION_VALUE_DISABLED, &error),
+              IsOkStatus(&error));
+
+  ASSERT_EQ("intrans", ConnectionGetOption(&connection, txn_status, &error));
+
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+
+  {
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT 1", &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+
+    ASSERT_EQ("active", ConnectionGetOption(&connection, txn_status, &error));
+
+    ASSERT_THAT(AdbcConnectionRollback(&connection, &error), IsOkStatus(&error));
+    ASSERT_EQ("idle", ConnectionGetOption(&connection, txn_status, &error));
+  }
+
+  {
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT 1", &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+
+    ASSERT_EQ("active", ConnectionGetOption(&connection, txn_status, &error));
+  }
+
+  {
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT 1", &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+
+    ASSERT_EQ("active", ConnectionGetOption(&connection, txn_status, &error));
+
+    // Note that despite the status being "active", this commit still
+    // generates a warning on the server.
+    ASSERT_THAT(AdbcConnectionCommit(&connection, &error), IsOkStatus(&error));
+    ASSERT_EQ("intrans", ConnectionGetOption(&connection, txn_status, &error));
+  }
+}
+
 TEST_F(PostgresStatementTest, SqlIngestSchema) {
   const std::string schema_name = "testschema";
 

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1024,19 +1024,6 @@ TEST_F(PostgresStatementTest, TransactionStatus) {
     ASSERT_THAT(AdbcConnectionRollback(&connection, &error), IsOkStatus(&error));
     ASSERT_EQ("idle", ConnectionGetOption(&connection, txn_status, &error));
   }
-
-  {
-    adbc_validation::StreamReader reader;
-    ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT 1", &error),
-                IsOkStatus(&error));
-    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
-                                          &reader.rows_affected, &error),
-                IsOkStatus(&error));
-    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
-
-    ASSERT_EQ("active", ConnectionGetOption(&connection, txn_status, &error));
-  }
-
   {
     adbc_validation::StreamReader reader;
     ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT 1", &error),

--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -2677,6 +2677,9 @@ void StatementTest::TestTransactions() {
               })(),
               ::testing::Not(IsOkStatus(&error)));
 
+  // Rollback
+  ASSERT_THAT(AdbcConnectionRollback(&connection, &error), IsOkStatus(&error));
+
   // Commit
   ASSERT_THAT(quirks()->CreateSampleTable(&connection, "bulk_ingest", &error),
               IsOkStatus(&error));

--- a/python/adbc_driver_postgresql/adbc_driver_postgresql/__init__.py
+++ b/python/adbc_driver_postgresql/adbc_driver_postgresql/__init__.py
@@ -22,7 +22,19 @@ import adbc_driver_manager
 
 from ._version import __version__
 
-__all__ = ["StatementOptions", "connect", "__version__"]
+__all__ = [
+    "ConnectionOptions",
+    "StatementOptions",
+    "connect",
+    "__version__",
+]
+
+
+class ConnectionOptions(enum.Enum):
+    """Connection options specific to the PostgreSQL driver."""
+
+    #: Get the transaction status.
+    TRANSACTION_STATUS = "adbc.postgresql.transaction_status"
 
 
 class StatementOptions(enum.Enum):

--- a/python/adbc_driver_postgresql/tests/test_dbapi.py
+++ b/python/adbc_driver_postgresql/tests/test_dbapi.py
@@ -191,6 +191,7 @@ def test_stmt_ingest(postgres: dbapi.Connection) -> None:
         cur.adbc_ingest("test_ingest", table, mode="replace")
         cur.execute("SELECT * FROM test_ingest ORDER BY ints")
         assert cur.fetch_arrow_table() == table
+        postgres.commit()
 
         with pytest.raises(
             postgres.ProgrammingError, match='"test_ingest" already exists'

--- a/python/adbc_driver_postgresql/tests/test_dbapi.py
+++ b/python/adbc_driver_postgresql/tests/test_dbapi.py
@@ -196,6 +196,7 @@ def test_stmt_ingest(postgres: dbapi.Connection) -> None:
             postgres.ProgrammingError, match='"test_ingest" already exists'
         ):
             cur.adbc_ingest("test_ingest", table, mode="create")
+        postgres.rollback()
 
         cur.adbc_ingest("test_ingest", table, mode="create_append")
         cur.execute("SELECT * FROM test_ingest ORDER BY ints")
@@ -458,7 +459,7 @@ def test_txn_status(postgres: dbapi.Connection) -> None:
 
     assert status() == "intrans"
     postgres.rollback()
-    assert status() == "idle"
+    assert status() == "intrans"
 
     with postgres.cursor() as cur:
         cur.execute("SELECT 1")
@@ -468,4 +469,4 @@ def test_txn_status(postgres: dbapi.Connection) -> None:
         cur.execute("SELECT 1")
         assert status() == "active"
         postgres.rollback()
-        assert status() == "idle"
+        assert status() == "intrans"


### PR DESCRIPTION
This avoids spamming the server-side log with "WARNING: there is no transaction in progress" messages.

Also, fix ConnectionRollback not properly starting a new transaction afterwards.

Fixes #2673.