### PR TITLE
fix(csharp/src/Drivers/Databricks): Fix Lz4 compression logic for DatabricksReader

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -66,7 +66,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             }
             else
             {
-                return new DatabricksReader(databricksStatement, schema);
+                return new DatabricksReader(databricksStatement, schema, isLz4Compressed);
             }
         }
 

--- a/csharp/src/Drivers/Databricks/DatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksReader.cs
@@ -34,11 +34,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         IArrowReader? reader;
         bool isLz4Compressed;
 
-        public DatabricksReader(DatabricksStatement statement, Schema schema)
-            : this(statement, schema, false)
-        {
-        }
-
         public DatabricksReader(DatabricksStatement statement, Schema schema, bool isLz4Compressed)
         {
             this.statement = statement;


### PR DESCRIPTION
This PR https://github.com/apache/arrow-adbc/commit/9ba6bdb8bd42e35237dadfae758419846e6c442c introduce a regression for DatabricksReader.
Fix it, also remove the unneeded constructor to prevent any misuse in the future.