### PR TITLE
[WIP] feat(rust): Let the returned RecordBatchReader outlive & parameters

### DIFF
--- a/rust/core/src/driver_manager.rs
+++ b/rust/core/src/driver_manager.rs
@@ -826,7 +826,7 @@ impl Connection for ManagedConnection {
         Ok(reader)
     }
 
-    fn get_objects(
+    fn get_objects<'a>(
         &self,
         depth: crate::options::ObjectDepth,
         catalog: Option<&str>,
@@ -834,7 +834,7 @@ impl Connection for ManagedConnection {
         table_name: Option<&str>,
         table_type: Option<Vec<&str>>,
         column_name: Option<&str>,
-    ) -> Result<impl RecordBatchReader> {
+    ) -> Result<impl RecordBatchReader + 'a> {
         let catalog = catalog.map(CString::new).transpose()?;
         let db_schema = db_schema.map(CString::new).transpose()?;
         let table_name = table_name.map(CString::new).transpose()?;

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -277,15 +277,15 @@ pub trait Connection: Optionable<Option = OptionConnection> {
     /// | fk_table                 | utf8 not null           |
     /// | fk_column_name           | utf8 not null           |
     ///
-    fn get_objects(
-        &self,
+    fn get_objects<'a>(
+        &'_ self,
         depth: options::ObjectDepth,
-        catalog: Option<&str>,
-        db_schema: Option<&str>,
-        table_name: Option<&str>,
-        table_type: Option<Vec<&str>>,
-        column_name: Option<&str>,
-    ) -> Result<impl RecordBatchReader + Send>;
+        catalog: Option<&'_ str>,
+        db_schema: Option<&'_ str>,
+        table_name: Option<&'_ str>,
+        table_type: Option<Vec<&'_ str>>,
+        column_name: Option<&'_ str>,
+    ) -> Result<impl RecordBatchReader + Send + 'a>;
 
     /// Get the Arrow schema of a table.
     ///

--- a/rust/driver/datafusion/src/lib.rs
+++ b/rust/driver/datafusion/src/lib.rs
@@ -725,15 +725,15 @@ impl Connection for DataFusionConnection {
         Ok(reader)
     }
 
-    fn get_objects(
-        &self,
+    fn get_objects<'a>(
+        &'_ self,
         depth: adbc_core::options::ObjectDepth,
-        _catalog: Option<&str>,
-        _db_schema: Option<&str>,
-        _table_name: Option<&str>,
-        _table_type: Option<Vec<&str>>,
-        _column_name: Option<&str>,
-    ) -> Result<impl RecordBatchReader + Send> {
+        _catalog: Option<&'_ str>,
+        _db_schema: Option<&'_ str>,
+        _table_name: Option<&'_ str>,
+        _table_type: Option<Vec<&'_ str>>,
+        _column_name: Option<&'_ str>,
+    ) -> Result<impl RecordBatchReader + Send + 'a> {
         let batch = GetObjectsBuilder::new().build(&self.runtime, &self.ctx, &depth)?;
         let reader = SingleBatchReader::new(batch);
         Ok(reader)

--- a/rust/driver/dummy/src/lib.rs
+++ b/rust/driver/dummy/src/lib.rs
@@ -396,15 +396,15 @@ impl Connection for DummyConnection {
         Ok(reader)
     }
 
-    fn get_objects(
-        &self,
+    fn get_objects<'a>(
+        &'_ self,
         _depth: ObjectDepth,
-        _catalog: Option<&str>,
-        _db_schema: Option<&str>,
-        _table_name: Option<&str>,
-        _table_type: Option<Vec<&str>>,
-        _column_name: Option<&str>,
-    ) -> Result<impl RecordBatchReader> {
+        _catalog: Option<&'_ str>,
+        _db_schema: Option<&'_ str>,
+        _table_name: Option<&'_ str>,
+        _table_type: Option<Vec<&'_ str>>,
+        _column_name: Option<&'_ str>,
+    ) -> Result<impl RecordBatchReader + 'a> {
         let constraint_column_usage_array_inner = StructArray::from(vec![
             (
                 Arc::new(Field::new("fk_catalog", DataType::Utf8, true)),

--- a/rust/driver/dummy/tests/driver_exporter_dummy.rs
+++ b/rust/driver/dummy/tests/driver_exporter_dummy.rs
@@ -480,14 +480,14 @@ struct BoxedReaderConnection(DummyConnection);
 
 impl BoxedReaderConnection {
     pub fn get_objects<'a>(
-        &'a self,
+        &'_ self,
         depth: ObjectDepth,
-        catalog: Option<&'a str>,
-        db_schema: Option<&'a str>,
-        table_name: Option<&'a str>,
-        table_type: Option<Vec<&'a str>>,
-        column_name: Option<&'a str>,
-    ) -> Result<Box<dyn RecordBatchReader + Send + 'a>> {
+        catalog: Option<&'_ str>,
+        db_schema: Option<&'_ str>,
+        table_name: Option<&'_ str>,
+        table_type: Option<Vec<&'_ str>>,
+        column_name: Option<&'_ str>,
+    ) -> Result<Box<dyn RecordBatchReader + Send>> {
         let reader = self.0.get_objects(
             depth,
             catalog,
@@ -496,7 +496,7 @@ impl BoxedReaderConnection {
             table_type,
             column_name,
         )?;
-        let boxed_reader: Box<dyn RecordBatchReader + Send + 'a> = Box::new(reader);
+        let boxed_reader = Box::new(reader);
         Ok(boxed_reader)
     }
 }

--- a/rust/driver/snowflake/src/connection.rs
+++ b/rust/driver/snowflake/src/connection.rs
@@ -78,15 +78,15 @@ impl adbc_core::Connection for Connection {
         self.0.get_info(codes)
     }
 
-    fn get_objects(
-        &self,
+    fn get_objects<'a>(
+        &'_ self,
         depth: adbc_core::options::ObjectDepth,
-        catalog: Option<&str>,
-        db_schema: Option<&str>,
-        table_name: Option<&str>,
-        table_type: Option<Vec<&str>>,
-        column_name: Option<&str>,
-    ) -> Result<impl RecordBatchReader + Send> {
+        catalog: Option<&'_ str>,
+        db_schema: Option<&'_ str>,
+        table_name: Option<&'_ str>,
+        table_type: Option<Vec<&'_ str>>,
+        column_name: Option<&'_ str>,
+    ) -> Result<impl RecordBatchReader + Send + 'a> {
         self.0.get_objects(
             depth,
             catalog,


### PR DESCRIPTION
This is a draft PR showing a problem with the annotations of functions that return `impl RecordBatchReader` and take `&` paramemeters.

The first commit shows how I work around it. When I try to make a Box'd `RecordBatchReader`, the compiler complains because there is a possibility that the `impl RecordBatchReader` returned might be holding any of `&` passed in the parameters:

![Screenshot 2025-04-09 at 17 50 28](https://github.com/user-attachments/assets/3b368abf-7bb6-4dc2-8021-e13e4375b62c)

When I'm forced to be explicit about lifetimes, I end up with:

```rust
struct BoxedReaderConnection(DummyConnection);

impl BoxedReaderConnection {
    pub fn get_objects<'a>(
        &'a self,
        depth: ObjectDepth,
        catalog: Option<&'a str>,
        db_schema: Option<&'a str>,
        table_name: Option<&'a str>,
        table_type: Option<Vec<&'a str>>,
        column_name: Option<&'a str>,
    ) -> Result<Box<dyn RecordBatchReader + Send + 'a>> {
        let reader = self.0.get_objects(
            depth,
            catalog,
            db_schema,
            table_name,
            table_type,
            column_name,
        )?;
        let boxed_reader: Box<dyn RecordBatchReader + Send + 'a> = Box::new(reader);
        Ok(boxed_reader)
    }
}
```

This is not ideal because I don't want to tie the lifetime of `table_name: Option<&'a str>` to the lifetime of the returned `RecordBatchReader`.

So I believe the proper solution is to change the `adbc_core` traits to explicitly declare that the `RecordBatchReader` can outlive the input references. Like this:

```rust
    fn get_objects<'a>(
        &'_ self,
        depth: options::ObjectDepth,
        catalog: Option<&'_ str>,
        db_schema: Option<&'_ str>,
        table_name: Option<&'_ str>,
        table_type: Option<Vec<&'_ str>>,
        column_name: Option<&'_ str>,
    ) -> Result<impl RecordBatchReader + Send + 'a>;
```

allowing a wrapper that boxes the `RecordBatchReader` to be written as

```rust
impl BoxedReaderConnection {
    pub fn get_objects<'a>(
        &'_ self,
        depth: ObjectDepth,
        catalog: Option<&'_ str>,
        db_schema: Option<&'_ str>,
        table_name: Option<&'_ str>,
        table_type: Option<Vec<&'_ str>>,
        column_name: Option<&'_ str>,
    ) -> Result<Box<dyn RecordBatchReader + Send>> {
        let reader = self.0.get_objects(
            depth,
            catalog,
            db_schema,
            table_name,
            table_type,
            column_name,
        )?;
        let boxed_reader = Box::new(reader);
        Ok(boxed_reader)
    }
}
```