### PR TITLE
docs(rust): show driver_manager features on docs.rs

### DIFF
--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -41,3 +41,6 @@ libloading = { version = "0.8", optional = true }
 
 [dev-dependencies]
 arrow-select.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
Currently, `driver_manager` module is not shown on [docs.rs](https://docs.rs/adbc_core/0.17.0/adbc_core/index.html). This pull request adds `[package.metadata.docs.rs]` option to enable the feature.

If this is just as intended (e.g., you don't want to expose a module that is not matured yet), please ignore!