### PR TITLE
chore(r): Update CI setup to silence warnings for Go-based drivers

### DIFF
--- a/.github/workflows/r-basic.yml
+++ b/.github/workflows/r-basic.yml
@@ -38,15 +38,29 @@ permissions:
   contents: read
 
 jobs:
-  check:
+  check-c:
     strategy:
       matrix:
         os: [ubuntu]
-        pkg: [adbcdrivermanager, adbcsqlite, adbcpostgresql, adbcflightsql, adbcsnowflake]
+        pkg: [adbcdrivermanager, adbcsqlite, adbcpostgresql]
 
     uses: ./.github/workflows/r-check.yml
     with:
       os: ${{ matrix.os }}
       pkg: ${{ matrix.pkg }}
+
+  check-go:
+    strategy:
+      matrix:
+        os: [ubuntu]
+        pkg: [adbcflightsql, adbcsnowflake, adbcbigquery]
+
+    uses: ./.github/workflows/r-check.yml
+    with:
+      os: ${{ matrix.os }}
+      pkg: ${{ matrix.pkg }}
+      # For the r-basic check (that runs on many PRs), just check ERRORs
+      # (e.g., build failure, test failure)
+      error-on: error
     secrets:
       SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -31,6 +31,10 @@ on:
         required: false
         default: release
         type: string
+      error-on:
+        required: false
+        default: warning
+        type: string
     secrets:
       SNOWFLAKE_URI:
         required: false
@@ -100,6 +104,7 @@ jobs:
           R_KEEP_PKG_SOURCE: yes
         with:
           working-directory: r/${{ inputs.pkg }}
+          error-on: '"${{ inputs.error-on }}"'
 
       - name: Shutdown docker compose services
         if: runner.os == 'Linux'

--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -52,8 +52,6 @@ jobs:
       os: ${{ matrix.os }}
       pkg: ${{ matrix.pkg }}
       rversion: ${{ matrix.rversion }}
-    secrets:
-      SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
 
   # Go-based drivers are not distributed on CRAN and are checked with error-on error only
   cran-go:
@@ -75,7 +73,6 @@ jobs:
     secrets:
       SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
 
-
   # Check older versions of R on Linux. This catches accidental use of newer R functions.
   # We don't check Go drivers here because they don't have much R API surface area.
   rversions:
@@ -91,8 +88,6 @@ jobs:
       os: ${{ matrix.os }}
       pkg: ${{ matrix.pkg }}
       rversion: ${{ matrix.rversion }}
-    secrets:
-      SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
 
   # Checks on older verions of R on Windows. The Windows build system changed
   # several times so we need to check packages on every version. Go-based
@@ -112,8 +107,6 @@ jobs:
       os: ${{ matrix.os }}
       pkg: ${{ matrix.pkg }}
       rversion: ${{ matrix.rversion }}
-    secrets:
-      SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
 
   # Runs tests with valgrind. Go does not support valgrind, so we don't run
   # those tests here.

--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -39,12 +39,12 @@ permissions:
 jobs:
 
   # Runs R CMD check on the same platforms/R versions CRAN does
-  cran:
+  cran-c:
     strategy:
       matrix:
         rversion: [oldrel, release, devel]
         os: [macOS, windows, ubuntu]
-        pkg: [adbcdrivermanager, adbcsqlite, adbcpostgresql, adbcflightsql, adbcsnowflake, adbcbigquery]
+        pkg: [adbcdrivermanager, adbcsqlite, adbcpostgresql]
       fail-fast: false
 
     uses: ./.github/workflows/r-check.yml
@@ -54,6 +54,27 @@ jobs:
       rversion: ${{ matrix.rversion }}
     secrets:
       SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
+
+  # Go-based drivers are not distributed on CRAN and are checked with error-on error only
+  cran-go:
+    strategy:
+      matrix:
+        rversion: [oldrel, release, devel]
+        os: [macOS, windows, ubuntu]
+        pkg: [adbcflightsql, adbcsnowflake, adbcbigquery]
+      fail-fast: false
+
+    uses: ./.github/workflows/r-check.yml
+    with:
+      os: ${{ matrix.os }}
+      pkg: ${{ matrix.pkg }}
+      rversion: ${{ matrix.rversion }}
+      # Go based drivers generate WARNINGs because some symbols
+      # are linked in that R CMD check does not allow.
+      error-on: error
+    secrets:
+      SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
+
 
   # Check older versions of R on Linux. This catches accidental use of newer R functions.
   rversions:
@@ -75,12 +96,12 @@ jobs:
   # Checks on older verions of R on Windows. The Windows build system changed
   # several times so we need to check packages on every version. Go-based
   # drivers aren't supported before 4.2, so we don't check them here.
-  # We don't need to check R 4.1 because the build system for R 4.0 and R 4.1
-  # are the same.
+  # The test dependencies support the released version and the four previous
+  # versions (e.g., 4.1 is the minimum supported version as of R 4.5).
   winrversions:
     strategy:
       matrix:
-        rversion: ["3.6", "4.0"]
+        rversion: ["4.1"]
         os: [windows]
         pkg: [adbcdrivermanager, adbcsqlite, adbcpostgresql]
       fail-fast: false

--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -77,12 +77,13 @@ jobs:
 
 
   # Check older versions of R on Linux. This catches accidental use of newer R functions.
+  # We don't check Go drivers here because they don't have much R API surface area.
   rversions:
     strategy:
       matrix:
         rversion: ["3.6", "4.0", "4.1"]
         os: [ubuntu]
-        pkg: [adbcdrivermanager, adbcsqlite, adbcpostgresql, adbcflightsql, adbcsnowflake, adbcbigquery]
+        pkg: [adbcdrivermanager, adbcsqlite, adbcpostgresql]
       fail-fast: false
 
     uses: ./.github/workflows/r-check.yml

--- a/.github/workflows/r-standard.yml
+++ b/.github/workflows/r-standard.yml
@@ -56,8 +56,6 @@ jobs:
     with:
       os: ${{ matrix.os }}
       pkg: ${{ matrix.pkg }}
-    secrets:
-      SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
 
   # Go-based drivers are not distributed on CRAN and are checked with error-on error only
   check-go:

--- a/.github/workflows/r-standard.yml
+++ b/.github/workflows/r-standard.yml
@@ -72,6 +72,6 @@ jobs:
       pkg: ${{ matrix.pkg }}
       # Go based drivers generate WARNINGs because some symbols
       # are linked in that R CMD check does not allow.
-      error-on: warning
+      error-on: error
     secrets:
       SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}

--- a/.github/workflows/r-standard.yml
+++ b/.github/workflows/r-standard.yml
@@ -46,15 +46,32 @@ permissions:
   contents: read
 
 jobs:
-  check:
+  check-c:
     strategy:
       matrix:
         os: [ubuntu, macOS, windows]
-        pkg: [adbcdrivermanager, adbcsqlite, adbcpostgresql, adbcflightsql, adbcsnowflake, adbcbigquery]
+        pkg: [adbcdrivermanager, adbcsqlite, adbcpostgresql]
 
     uses: ./.github/workflows/r-check.yml
     with:
       os: ${{ matrix.os }}
       pkg: ${{ matrix.pkg }}
+    secrets:
+      SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
+
+  # Go-based drivers are not distributed on CRAN and are checked with error-on error only
+  check-go:
+    strategy:
+      matrix:
+        os: [ubuntu, macOS, windows]
+        pkg: [adbcflightsql, adbcsnowflake, adbcbigquery]
+
+    uses: ./.github/workflows/r-check.yml
+    with:
+      os: ${{ matrix.os }}
+      pkg: ${{ matrix.pkg }}
+      # Go based drivers generate WARNINGs because some symbols
+      # are linked in that R CMD check does not allow.
+      error-on: warning
     secrets:
       SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}


### PR DESCRIPTION
Closes #2707.

This is more likely to be a change in Adbc somewhere since it's showing up in all versions. Did we add anything recently that logged anything to stderr or called assert or abort?

In the event it can't be avoided (it often can't), we can update the warning fail level for go-based drivers since we don't distribute them on CRAN.