### PR TITLE
fix(csharp/src/Drivers/Apache/Thrift): Generated Thrift-based code should not be exposed publicly

### DIFF
--- a/csharp/src/Drivers/Apache/Thrift/IPeekableTransport.cs
+++ b/csharp/src/Drivers/Apache/Thrift/IPeekableTransport.cs
@@ -19,7 +19,7 @@ using System.IO;
 
 namespace Apache.Arrow.Adbc.Drivers.Apache
 {
-    public interface IPeekableTransport
+    internal interface IPeekableTransport
     {
         Stream Input { get; }
         Stream Output { get; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TArrayTypeEntry.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TArrayTypeEntry.cs
@@ -41,7 +41,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TArrayTypeEntry : TBase
+  internal partial class TArrayTypeEntry : TBase
   {
 
     public int ObjectTypePtr { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TBinaryColumn.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TBinaryColumn.cs
@@ -30,7 +30,7 @@ using Thrift.Protocol.Utilities;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-    public partial class TBinaryColumn : TBase
+    internal partial class TBinaryColumn : TBase
   {
     public BinaryArray Values { get; set; }
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TBoolColumn.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TBoolColumn.cs
@@ -28,7 +28,7 @@ using Thrift.Protocol.Utilities;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TBoolColumn : TBase
+  internal partial class TBoolColumn : TBase
   {
 
     public BooleanArray Values { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TBoolValue.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TBoolValue.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TBoolValue : TBase
+  internal partial class TBoolValue : TBase
   {
     private bool _value;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TByteColumn.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TByteColumn.cs
@@ -30,7 +30,7 @@ using Thrift.Protocol.Utilities;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TByteColumn : TBase
+  internal partial class TByteColumn : TBase
   {
 
     public Int8Array Values { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TByteValue.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TByteValue.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TByteValue : TBase
+  internal partial class TByteValue : TBase
   {
     private sbyte _value;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCLIService.Constants.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCLIService.Constants.cs
@@ -32,7 +32,7 @@ using Thrift.Collections;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public static class TCLIServiceConstants
+  internal static class TCLIServiceConstants
   {
     public static HashSet<global::Apache.Hive.Service.Rpc.Thrift.TTypeId> PRIMITIVE_TYPES = new HashSet<global::Apache.Hive.Service.Rpc.Thrift.TTypeId>();
     public static HashSet<global::Apache.Hive.Service.Rpc.Thrift.TTypeId> COMPLEX_TYPES = new HashSet<global::Apache.Hive.Service.Rpc.Thrift.TTypeId>();

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCLIService.Extensions.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCLIService.Extensions.cs
@@ -33,7 +33,7 @@ using Thrift.Protocol;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public static class TCLIServiceExtensions
+  internal static class TCLIServiceExtensions
   {
     public static bool Equals(this Dictionary<string, double> instance, object that)
     {

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCLIService.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCLIService.cs
@@ -39,9 +39,9 @@ using Thrift.Processor;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public partial class TCLIService
+  internal partial class TCLIService
   {
-    public interface IAsync
+    internal interface IAsync
     {
       global::System.Threading.Tasks.Task<global::Apache.Hive.Service.Rpc.Thrift.TOpenSessionResp> OpenSession(global::Apache.Hive.Service.Rpc.Thrift.TOpenSessionReq @req, CancellationToken cancellationToken = default);
 
@@ -96,7 +96,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
     }
 
 
-    public class Client : TBaseClient, IDisposable, IAsync
+    internal class Client : TBaseClient, IDisposable, IAsync
     {
       public Client(TProtocol protocol) : this(protocol, protocol)
       {
@@ -1108,7 +1108,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
 
     }
 
-    public class AsyncProcessor : ITAsyncProcessor
+    internal class AsyncProcessor : ITAsyncProcessor
     {
       private readonly IAsync _iAsync;
       private readonly ILogger<AsyncProcessor> _logger;
@@ -1960,10 +1960,10 @@ namespace Apache.Hive.Service.Rpc.Thrift
 
     }
 
-    public class InternalStructs
+    internal class InternalStructs
     {
 
-      public partial class OpenSession_args : TBase
+      internal partial class OpenSession_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TOpenSessionReq _req;
 
@@ -2095,7 +2095,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class OpenSession_result : TBase
+      internal partial class OpenSession_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TOpenSessionResp _success;
 
@@ -2231,7 +2231,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class CloseSession_args : TBase
+      internal partial class CloseSession_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TCloseSessionReq _req;
 
@@ -2363,7 +2363,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class CloseSession_result : TBase
+      internal partial class CloseSession_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TCloseSessionResp _success;
 
@@ -2499,7 +2499,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetInfo_args : TBase
+      internal partial class GetInfo_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetInfoReq _req;
 
@@ -2631,7 +2631,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetInfo_result : TBase
+      internal partial class GetInfo_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetInfoResp _success;
 
@@ -2767,7 +2767,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class ExecuteStatement_args : TBase
+      internal partial class ExecuteStatement_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TExecuteStatementReq _req;
 
@@ -2899,7 +2899,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class ExecuteStatement_result : TBase
+      internal partial class ExecuteStatement_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TExecuteStatementResp _success;
 
@@ -3035,7 +3035,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetTypeInfo_args : TBase
+      internal partial class GetTypeInfo_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetTypeInfoReq _req;
 
@@ -3167,7 +3167,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetTypeInfo_result : TBase
+      internal partial class GetTypeInfo_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetTypeInfoResp _success;
 
@@ -3303,7 +3303,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetCatalogs_args : TBase
+      internal partial class GetCatalogs_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetCatalogsReq _req;
 
@@ -3435,7 +3435,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetCatalogs_result : TBase
+      internal partial class GetCatalogs_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetCatalogsResp _success;
 
@@ -3571,7 +3571,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetSchemas_args : TBase
+      internal partial class GetSchemas_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetSchemasReq _req;
 
@@ -3703,7 +3703,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetSchemas_result : TBase
+      internal partial class GetSchemas_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetSchemasResp _success;
 
@@ -3839,7 +3839,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetTables_args : TBase
+      internal partial class GetTables_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetTablesReq _req;
 
@@ -3971,7 +3971,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetTables_result : TBase
+      internal partial class GetTables_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetTablesResp _success;
 
@@ -4107,7 +4107,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetTableTypes_args : TBase
+      internal partial class GetTableTypes_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetTableTypesReq _req;
 
@@ -4239,7 +4239,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetTableTypes_result : TBase
+      internal partial class GetTableTypes_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetTableTypesResp _success;
 
@@ -4375,7 +4375,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetColumns_args : TBase
+      internal partial class GetColumns_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetColumnsReq _req;
 
@@ -4507,7 +4507,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetColumns_result : TBase
+      internal partial class GetColumns_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetColumnsResp _success;
 
@@ -4643,7 +4643,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetFunctions_args : TBase
+      internal partial class GetFunctions_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetFunctionsReq _req;
 
@@ -4775,7 +4775,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetFunctions_result : TBase
+      internal partial class GetFunctions_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetFunctionsResp _success;
 
@@ -4911,7 +4911,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetPrimaryKeys_args : TBase
+      internal partial class GetPrimaryKeys_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetPrimaryKeysReq _req;
 
@@ -5043,7 +5043,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetPrimaryKeys_result : TBase
+      internal partial class GetPrimaryKeys_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetPrimaryKeysResp _success;
 
@@ -5179,7 +5179,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetCrossReference_args : TBase
+      internal partial class GetCrossReference_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetCrossReferenceReq _req;
 
@@ -5311,7 +5311,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetCrossReference_result : TBase
+      internal partial class GetCrossReference_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetCrossReferenceResp _success;
 
@@ -5447,7 +5447,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetOperationStatus_args : TBase
+      internal partial class GetOperationStatus_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetOperationStatusReq _req;
 
@@ -5579,7 +5579,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetOperationStatus_result : TBase
+      internal partial class GetOperationStatus_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetOperationStatusResp _success;
 
@@ -5715,7 +5715,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class CancelOperation_args : TBase
+      internal partial class CancelOperation_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TCancelOperationReq _req;
 
@@ -5847,7 +5847,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class CancelOperation_result : TBase
+      internal partial class CancelOperation_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TCancelOperationResp _success;
 
@@ -5983,7 +5983,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class CloseOperation_args : TBase
+      internal partial class CloseOperation_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TCloseOperationReq _req;
 
@@ -6115,7 +6115,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class CloseOperation_result : TBase
+      internal partial class CloseOperation_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TCloseOperationResp _success;
 
@@ -6251,7 +6251,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetResultSetMetadata_args : TBase
+      internal partial class GetResultSetMetadata_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetResultSetMetadataReq _req;
 
@@ -6383,7 +6383,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetResultSetMetadata_result : TBase
+      internal partial class GetResultSetMetadata_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetResultSetMetadataResp _success;
 
@@ -6519,7 +6519,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class FetchResults_args : TBase
+      internal partial class FetchResults_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TFetchResultsReq _req;
 
@@ -6651,7 +6651,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class FetchResults_result : TBase
+      internal partial class FetchResults_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TFetchResultsResp _success;
 
@@ -6787,7 +6787,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetDelegationToken_args : TBase
+      internal partial class GetDelegationToken_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetDelegationTokenReq _req;
 
@@ -6919,7 +6919,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetDelegationToken_result : TBase
+      internal partial class GetDelegationToken_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetDelegationTokenResp _success;
 
@@ -7055,7 +7055,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class CancelDelegationToken_args : TBase
+      internal partial class CancelDelegationToken_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TCancelDelegationTokenReq _req;
 
@@ -7187,7 +7187,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class CancelDelegationToken_result : TBase
+      internal partial class CancelDelegationToken_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TCancelDelegationTokenResp _success;
 
@@ -7323,7 +7323,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class RenewDelegationToken_args : TBase
+      internal partial class RenewDelegationToken_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TRenewDelegationTokenReq _req;
 
@@ -7455,7 +7455,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class RenewDelegationToken_result : TBase
+      internal partial class RenewDelegationToken_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TRenewDelegationTokenResp _success;
 
@@ -7591,7 +7591,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetQueryId_args : TBase
+      internal partial class GetQueryId_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetQueryIdReq _req;
 
@@ -7723,7 +7723,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class GetQueryId_result : TBase
+      internal partial class GetQueryId_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TGetQueryIdResp _success;
 
@@ -7859,7 +7859,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class SetClientInfo_args : TBase
+      internal partial class SetClientInfo_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TSetClientInfoReq _req;
 
@@ -7991,7 +7991,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class SetClientInfo_result : TBase
+      internal partial class SetClientInfo_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TSetClientInfoResp _success;
 
@@ -8127,7 +8127,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class UploadData_args : TBase
+      internal partial class UploadData_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TUploadDataReq _req;
 
@@ -8259,7 +8259,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class UploadData_result : TBase
+      internal partial class UploadData_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TUploadDataResp _success;
 
@@ -8395,7 +8395,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class DownloadData_args : TBase
+      internal partial class DownloadData_args : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TDownloadDataReq _req;
 
@@ -8527,7 +8527,7 @@ namespace Apache.Hive.Service.Rpc.Thrift
       }
 
 
-      public partial class DownloadData_result : TBase
+      internal partial class DownloadData_result : TBase
       {
         private global::Apache.Hive.Service.Rpc.Thrift.TDownloadDataResp _success;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCacheLookupResult.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCacheLookupResult.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TCacheLookupResult
+  internal enum TCacheLookupResult
   {
     CACHE_INELIGIBLE = 0,
     LOCAL_CACHE_HIT = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCancelDelegationTokenReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCancelDelegationTokenReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TCancelDelegationTokenReq : TBase
+  internal partial class TCancelDelegationTokenReq : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TDBSqlSessionConf _sessionConf;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCancelDelegationTokenResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCancelDelegationTokenResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TCancelDelegationTokenResp : TBase
+  internal partial class TCancelDelegationTokenResp : TBase
   {
 
     public global::Apache.Hive.Service.Rpc.Thrift.TStatus Status { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCancelOperationReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCancelOperationReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TCancelOperationReq : TBase
+  internal partial class TCancelOperationReq : TBase
   {
     private short _executionVersion;
     private bool _replacedByNextAttempt;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCancelOperationResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCancelOperationResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TCancelOperationResp : TBase
+  internal partial class TCancelOperationResp : TBase
   {
 
     public global::Apache.Hive.Service.Rpc.Thrift.TStatus Status { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCloseOperationReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCloseOperationReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TCloseOperationReq : TBase
+  internal partial class TCloseOperationReq : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TDBSqlCloseOperationReason _closeReason;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCloseOperationResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCloseOperationResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TCloseOperationResp : TBase
+  internal partial class TCloseOperationResp : TBase
   {
 
     public global::Apache.Hive.Service.Rpc.Thrift.TStatus Status { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCloseSessionReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCloseSessionReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TCloseSessionReq : TBase
+  internal partial class TCloseSessionReq : TBase
   {
 
     public global::Apache.Hive.Service.Rpc.Thrift.TSessionHandle SessionHandle { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCloseSessionResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCloseSessionResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TCloseSessionResp : TBase
+  internal partial class TCloseSessionResp : TBase
   {
 
     public global::Apache.Hive.Service.Rpc.Thrift.TStatus Status { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCloudFetchDisabledReason.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TCloudFetchDisabledReason.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TCloudFetchDisabledReason
+  internal enum TCloudFetchDisabledReason
   {
     ARROW_SUPPORT = 0,
     CLOUD_FETCH_SUPPORT = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TColumn.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TColumn.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TColumn : TBase
+  internal partial class TColumn : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TBoolColumn _boolVal;
     private global::Apache.Hive.Service.Rpc.Thrift.TByteColumn _byteVal;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TColumnDesc.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TColumnDesc.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TColumnDesc : TBase
+  internal partial class TColumnDesc : TBase
   {
     private string _comment;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TColumnValue.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TColumnValue.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TColumnValue : TBase
+  internal partial class TColumnValue : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TBoolValue _boolVal;
     private global::Apache.Hive.Service.Rpc.Thrift.TByteValue _byteVal;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlArrowFormat.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlArrowFormat.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDBSqlArrowFormat : TBase
+  internal partial class TDBSqlArrowFormat : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TDBSqlArrowLayout _arrowLayout;
     private global::Apache.Hive.Service.Rpc.Thrift.TDBSqlCompressionCodec _compressionCodec;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlArrowLayout.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlArrowLayout.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TDBSqlArrowLayout
+  internal enum TDBSqlArrowLayout
   {
     ARROW_BATCH = 0,
     ARROW_STREAMING = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlCloseOperationReason.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlCloseOperationReason.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TDBSqlCloseOperationReason
+  internal enum TDBSqlCloseOperationReason
   {
     NONE = 0,
     COMMAND_INACTIVITY_TIMEOUT = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlCloudResultFile.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlCloudResultFile.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDBSqlCloudResultFile : TBase
+  internal partial class TDBSqlCloudResultFile : TBase
   {
     private string _filePath;
     private long _startRowOffset;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlCompressionCodec.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlCompressionCodec.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TDBSqlCompressionCodec
+  internal enum TDBSqlCompressionCodec
   {
     NONE = 0,
     LZ4_FRAME = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlConfValue.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlConfValue.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDBSqlConfValue : TBase
+  internal partial class TDBSqlConfValue : TBase
   {
     private string _value;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlCsvFormat.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlCsvFormat.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDBSqlCsvFormat : TBase
+  internal partial class TDBSqlCsvFormat : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TDBSqlCompressionCodec _compressionCodec;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlFetchDisposition.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlFetchDisposition.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TDBSqlFetchDisposition
+  internal enum TDBSqlFetchDisposition
   {
     DISPOSITION_UNSPECIFIED = 0,
     DISPOSITION_INLINE = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlJsonArrayFormat.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlJsonArrayFormat.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDBSqlJsonArrayFormat : TBase
+  internal partial class TDBSqlJsonArrayFormat : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TDBSqlCompressionCodec _compressionCodec;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlManifestFileFormat.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlManifestFileFormat.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TDBSqlManifestFileFormat
+  internal enum TDBSqlManifestFileFormat
   {
     THRIFT_GET_RESULT_SET_METADATA_RESP = 0,
   }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlResultFormat.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlResultFormat.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDBSqlResultFormat : TBase
+  internal partial class TDBSqlResultFormat : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TDBSqlArrowFormat _arrowFormat;
     private global::Apache.Hive.Service.Rpc.Thrift.TDBSqlCsvFormat _csvFormat;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlSessionCapabilities.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlSessionCapabilities.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDBSqlSessionCapabilities : TBase
+  internal partial class TDBSqlSessionCapabilities : TBase
   {
     private bool _supportsMultipleCatalogs;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlSessionConf.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlSessionConf.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDBSqlSessionConf : TBase
+  internal partial class TDBSqlSessionConf : TBase
   {
     private Dictionary<string, string> _confs;
     private List<global::Apache.Hive.Service.Rpc.Thrift.TDBSqlTempView> _tempViews;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlStatement.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlStatement.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDBSqlStatement : TBase
+  internal partial class TDBSqlStatement : TBase
   {
     private string _statement;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlTempView.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDBSqlTempView.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDBSqlTempView : TBase
+  internal partial class TDBSqlTempView : TBase
   {
     private string _name;
     private string _sqlStatement;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDoubleColumn.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDoubleColumn.cs
@@ -29,7 +29,7 @@ using Thrift.Protocol.Utilities;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDoubleColumn : TBase
+  internal partial class TDoubleColumn : TBase
   {
     public DoubleArray Values { get; set; }
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDoubleValue.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDoubleValue.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDoubleValue : TBase
+  internal partial class TDoubleValue : TBase
   {
     private double _value;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDownloadDataReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDownloadDataReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDownloadDataReq : TBase
+  internal partial class TDownloadDataReq : TBase
   {
     private string _tableName;
     private string _query;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDownloadDataResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TDownloadDataResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TDownloadDataResp : TBase
+  internal partial class TDownloadDataResp : TBase
   {
 
     public global::Apache.Hive.Service.Rpc.Thrift.TStatus Status { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TExecuteStatementReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TExecuteStatementReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TExecuteStatementReq : TBase
+  internal partial class TExecuteStatementReq : TBase
   {
     private Dictionary<string, string> _confOverlay;
     private bool _runAsync;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TExecuteStatementResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TExecuteStatementResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TExecuteStatementResp : TBase
+  internal partial class TExecuteStatementResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TOperationHandle _operationHandle;
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkDirectResults _directResults;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TExpressionInfo.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TExpressionInfo.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TExpressionInfo : TBase
+  internal partial class TExpressionInfo : TBase
   {
     private string _className;
     private string _usage;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TFetchOrientation.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TFetchOrientation.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TFetchOrientation
+  internal enum TFetchOrientation
   {
     FETCH_NEXT = 0,
     FETCH_PRIOR = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TFetchResultsReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TFetchResultsReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TFetchResultsReq : TBase
+  internal partial class TFetchResultsReq : TBase
   {
     private short _fetchType;
     private long _maxBytes;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TFetchResultsResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TFetchResultsResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TFetchResultsResp : TBase
+  internal partial class TFetchResultsResp : TBase
   {
     private bool _hasMoreRows;
     private global::Apache.Hive.Service.Rpc.Thrift.TRowSet _results;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetCatalogsReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetCatalogsReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetCatalogsReq : TBase
+  internal partial class TGetCatalogsReq : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkGetDirectResults _getDirectResults;
     private bool _runAsync;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetCatalogsResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetCatalogsResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetCatalogsResp : TBase
+  internal partial class TGetCatalogsResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TOperationHandle _operationHandle;
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkDirectResults _directResults;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetColumnsReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetColumnsReq.cs
@@ -41,7 +41,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetColumnsReq : TBase
+  internal partial class TGetColumnsReq : TBase
   {
     private string _catalogName;
     private string _schemaName;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetColumnsResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetColumnsResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetColumnsResp : TBase
+  internal partial class TGetColumnsResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TOperationHandle _operationHandle;
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkDirectResults _directResults;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetCrossReferenceReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetCrossReferenceReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetCrossReferenceReq : TBase
+  internal partial class TGetCrossReferenceReq : TBase
   {
     private string _parentCatalogName;
     private string _parentSchemaName;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetCrossReferenceResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetCrossReferenceResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetCrossReferenceResp : TBase
+  internal partial class TGetCrossReferenceResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TOperationHandle _operationHandle;
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkDirectResults _directResults;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetDelegationTokenReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetDelegationTokenReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetDelegationTokenReq : TBase
+  internal partial class TGetDelegationTokenReq : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TDBSqlSessionConf _sessionConf;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetDelegationTokenResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetDelegationTokenResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetDelegationTokenResp : TBase
+  internal partial class TGetDelegationTokenResp : TBase
   {
     private string _delegationToken;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetFunctionsReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetFunctionsReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetFunctionsReq : TBase
+  internal partial class TGetFunctionsReq : TBase
   {
     private string _catalogName;
     private string _schemaName;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetFunctionsResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetFunctionsResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetFunctionsResp : TBase
+  internal partial class TGetFunctionsResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TOperationHandle _operationHandle;
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkDirectResults _directResults;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetInfoReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetInfoReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetInfoReq : TBase
+  internal partial class TGetInfoReq : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TDBSqlSessionConf _sessionConf;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetInfoResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetInfoResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetInfoResp : TBase
+  internal partial class TGetInfoResp : TBase
   {
 
     public global::Apache.Hive.Service.Rpc.Thrift.TStatus Status { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetInfoType.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetInfoType.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TGetInfoType
+  internal enum TGetInfoType
   {
     CLI_MAX_DRIVER_CONNECTIONS = 0,
     CLI_MAX_CONCURRENT_ACTIVITIES = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetInfoValue.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetInfoValue.cs
@@ -41,7 +41,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetInfoValue : TBase
+  internal partial class TGetInfoValue : TBase
   {
     private string _stringValue;
     private short _smallIntValue;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetOperationStatusReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetOperationStatusReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetOperationStatusReq : TBase
+  internal partial class TGetOperationStatusReq : TBase
   {
     private bool _getProgressUpdate;
     private bool _getResultSetMetadataOnCompletion;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetOperationStatusResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetOperationStatusResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetOperationStatusResp : TBase
+  internal partial class TGetOperationStatusResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TOperationState _operationState;
     private string _sqlState;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetPrimaryKeysReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetPrimaryKeysReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetPrimaryKeysReq : TBase
+  internal partial class TGetPrimaryKeysReq : TBase
   {
     private string _catalogName;
     private string _schemaName;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetPrimaryKeysResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetPrimaryKeysResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetPrimaryKeysResp : TBase
+  internal partial class TGetPrimaryKeysResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TOperationHandle _operationHandle;
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkDirectResults _directResults;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetQueryIdReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetQueryIdReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetQueryIdReq : TBase
+  internal partial class TGetQueryIdReq : TBase
   {
 
     public global::Apache.Hive.Service.Rpc.Thrift.TOperationHandle OperationHandle { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetQueryIdResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetQueryIdResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetQueryIdResp : TBase
+  internal partial class TGetQueryIdResp : TBase
   {
 
     public string QueryId { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetResultSetMetadataReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetResultSetMetadataReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetResultSetMetadataReq : TBase
+  internal partial class TGetResultSetMetadataReq : TBase
   {
     private bool _includeCloudResultFiles;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetResultSetMetadataResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetResultSetMetadataResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetResultSetMetadataResp : TBase
+  internal partial class TGetResultSetMetadataResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TTableSchema _schema;
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkRowSetType _resultFormat;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetSchemasReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetSchemasReq.cs
@@ -41,7 +41,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetSchemasReq : TBase
+  internal partial class TGetSchemasReq : TBase
   {
     private string _catalogName;
     private string _schemaName;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetSchemasResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetSchemasResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetSchemasResp : TBase
+  internal partial class TGetSchemasResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TOperationHandle _operationHandle;
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkDirectResults _directResults;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTableTypesReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTableTypesReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetTableTypesReq : TBase
+  internal partial class TGetTableTypesReq : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkGetDirectResults _getDirectResults;
     private bool _runAsync;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTableTypesResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTableTypesResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetTableTypesResp : TBase
+  internal partial class TGetTableTypesResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TOperationHandle _operationHandle;
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkDirectResults _directResults;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTablesReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTablesReq.cs
@@ -41,7 +41,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetTablesReq : TBase
+  internal partial class TGetTablesReq : TBase
   {
     private string _catalogName;
     private string _schemaName;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTablesResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTablesResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetTablesResp : TBase
+  internal partial class TGetTablesResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TOperationHandle _operationHandle;
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkDirectResults _directResults;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTypeInfoReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTypeInfoReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetTypeInfoReq : TBase
+  internal partial class TGetTypeInfoReq : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkGetDirectResults _getDirectResults;
     private bool _runAsync;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTypeInfoResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TGetTypeInfoResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TGetTypeInfoResp : TBase
+  internal partial class TGetTypeInfoResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TOperationHandle _operationHandle;
     private global::Apache.Hive.Service.Rpc.Thrift.TSparkDirectResults _directResults;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/THandleIdentifier.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/THandleIdentifier.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class THandleIdentifier : TBase
+  internal partial class THandleIdentifier : TBase
   {
     private short _executionVersion;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI16Column.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI16Column.cs
@@ -30,7 +30,7 @@ using Thrift.Protocol.Utilities;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TI16Column : TBase
+  internal partial class TI16Column : TBase
   {
 
     public Int16Array Values { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI16Value.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI16Value.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TI16Value : TBase
+  internal partial class TI16Value : TBase
   {
     private short _value;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI32Column.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI32Column.cs
@@ -30,7 +30,7 @@ using Thrift.Protocol.Utilities;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TI32Column : TBase
+  internal partial class TI32Column : TBase
   {
 
     public Int32Array Values { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI32Value.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI32Value.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TI32Value : TBase
+  internal partial class TI32Value : TBase
   {
     private int _value;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI64Column.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI64Column.cs
@@ -30,7 +30,7 @@ using Thrift.Protocol.Utilities;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TI64Column : TBase
+  internal partial class TI64Column : TBase
   {
     public Int64Array Values { get; set; }
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI64Value.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TI64Value.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TI64Value : TBase
+  internal partial class TI64Value : TBase
   {
     private long _value;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TJobExecutionStatus.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TJobExecutionStatus.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TJobExecutionStatus
+  internal enum TJobExecutionStatus
   {
     IN_PROGRESS = 0,
     COMPLETE = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TMapTypeEntry.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TMapTypeEntry.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TMapTypeEntry : TBase
+  internal partial class TMapTypeEntry : TBase
   {
 
     public int KeyTypePtr { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TNamespace.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TNamespace.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TNamespace : TBase
+  internal partial class TNamespace : TBase
   {
     private string _catalogName;
     private string _schemaName;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOpenSessionReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOpenSessionReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TOpenSessionReq : TBase
+  internal partial class TOpenSessionReq : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TProtocolVersion _client_protocol;
     private string _username;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOpenSessionResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOpenSessionResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TOpenSessionResp : TBase
+  internal partial class TOpenSessionResp : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TSessionHandle _sessionHandle;
     private Dictionary<string, string> _configuration;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOperationHandle.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOperationHandle.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TOperationHandle : TBase
+  internal partial class TOperationHandle : TBase
   {
     private double _modifiedRowCount;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOperationIdempotencyType.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOperationIdempotencyType.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TOperationIdempotencyType
+  internal enum TOperationIdempotencyType
   {
     UNKNOWN = 0,
     NON_IDEMPOTENT = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOperationState.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOperationState.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TOperationState
+  internal enum TOperationState
   {
     INITIALIZED_STATE = 0,
     RUNNING_STATE = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOperationTimeoutLevel.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOperationTimeoutLevel.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TOperationTimeoutLevel
+  internal enum TOperationTimeoutLevel
   {
     CLUSTER = 0,
     SESSION = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOperationType.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TOperationType.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TOperationType
+  internal enum TOperationType
   {
     EXECUTE_STATEMENT = 0,
     GET_TYPE_INFO = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TPrimitiveTypeEntry.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TPrimitiveTypeEntry.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TPrimitiveTypeEntry : TBase
+  internal partial class TPrimitiveTypeEntry : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TTypeQualifiers _typeQualifiers;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TProgressUpdateResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TProgressUpdateResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TProgressUpdateResp : TBase
+  internal partial class TProgressUpdateResp : TBase
   {
 
     public List<string> HeaderNames { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TProtocolVersion.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TProtocolVersion.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TProtocolVersion
+  internal enum TProtocolVersion
   {
     __HIVE_JDBC_WORKAROUND = -7,
     __TEST_PROTOCOL_VERSION = 65281,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TRenewDelegationTokenReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TRenewDelegationTokenReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TRenewDelegationTokenReq : TBase
+  internal partial class TRenewDelegationTokenReq : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TDBSqlSessionConf _sessionConf;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TRenewDelegationTokenResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TRenewDelegationTokenResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TRenewDelegationTokenResp : TBase
+  internal partial class TRenewDelegationTokenResp : TBase
   {
 
     public global::Apache.Hive.Service.Rpc.Thrift.TStatus Status { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TResultPersistenceMode.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TResultPersistenceMode.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TResultPersistenceMode
+  internal enum TResultPersistenceMode
   {
     ONLY_LARGE_RESULTS = 0,
     ALL_QUERY_RESULTS = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TRow.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TRow.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TRow : TBase
+  internal partial class TRow : TBase
   {
 
     public List<global::Apache.Hive.Service.Rpc.Thrift.TColumnValue> ColVals { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TRowSet.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TRowSet.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TRowSet : TBase
+  internal partial class TRowSet : TBase
   {
     private List<global::Apache.Hive.Service.Rpc.Thrift.TColumn> _columns;
     private byte[] _binaryColumns;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSQLVariable.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSQLVariable.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSQLVariable : TBase
+  internal partial class TSQLVariable : TBase
   {
     private string _catalogName;
     private string _schemaName;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSessionHandle.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSessionHandle.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSessionHandle : TBase
+  internal partial class TSessionHandle : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TProtocolVersion _serverProtocolVersion;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSetClientInfoReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSetClientInfoReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSetClientInfoReq : TBase
+  internal partial class TSetClientInfoReq : TBase
   {
     private Dictionary<string, string> _configuration;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSetClientInfoResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSetClientInfoResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSetClientInfoResp : TBase
+  internal partial class TSetClientInfoResp : TBase
   {
 
     public global::Apache.Hive.Service.Rpc.Thrift.TStatus Status { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkArrowBatch.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkArrowBatch.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSparkArrowBatch : TBase
+  internal partial class TSparkArrowBatch : TBase
   {
 
     public byte[] Batch { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkArrowResultLink.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkArrowResultLink.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSparkArrowResultLink : TBase
+  internal partial class TSparkArrowResultLink : TBase
   {
     private Dictionary<string, string> _httpHeaders;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkArrowTypes.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkArrowTypes.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSparkArrowTypes : TBase
+  internal partial class TSparkArrowTypes : TBase
   {
     private bool _timestampAsArrow;
     private bool _decimalAsArrow;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkDirectResults.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkDirectResults.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSparkDirectResults : TBase
+  internal partial class TSparkDirectResults : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TGetOperationStatusResp _operationStatus;
     private global::Apache.Hive.Service.Rpc.Thrift.TGetResultSetMetadataResp _resultSetMetadata;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkGetDirectResults.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkGetDirectResults.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSparkGetDirectResults : TBase
+  internal partial class TSparkGetDirectResults : TBase
   {
     private long _maxBytes;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkParameter.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkParameter.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSparkParameter : TBase
+  internal partial class TSparkParameter : TBase
   {
     private int _ordinal;
     private string _name;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkParameterValue.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkParameterValue.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSparkParameterValue : TBase
+  internal partial class TSparkParameterValue : TBase
   {
     private string _stringValue;
     private double _doubleValue;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkParameterValueArg.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkParameterValueArg.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TSparkParameterValueArg : TBase
+  internal partial class TSparkParameterValueArg : TBase
   {
     private string _type;
     private string _value;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkRowSetType.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TSparkRowSetType.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TSparkRowSetType
+  internal enum TSparkRowSetType
   {
     ARROW_BASED_SET = 0,
     COLUMN_BASED_SET = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStatementConf.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStatementConf.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TStatementConf : TBase
+  internal partial class TStatementConf : TBase
   {
     private bool _sessionless;
     private global::Apache.Hive.Service.Rpc.Thrift.TNamespace _initialNamespace;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStatus.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStatus.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TStatus : TBase
+  internal partial class TStatus : TBase
   {
     private List<string> _infoMessages;
     private string _sqlState;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStatusCode.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStatusCode.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TStatusCode
+  internal enum TStatusCode
   {
     SUCCESS_STATUS = 0,
     SUCCESS_WITH_INFO_STATUS = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStringColumn.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStringColumn.cs
@@ -29,7 +29,7 @@ using Thrift.Protocol.Utilities;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TStringColumn : TBase
+  internal partial class TStringColumn : TBase
   {
 
     public StringArray Values { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStringValue.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStringValue.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TStringValue : TBase
+  internal partial class TStringValue : TBase
   {
     private string _value;
 

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStructTypeEntry.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TStructTypeEntry.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TStructTypeEntry : TBase
+  internal partial class TStructTypeEntry : TBase
   {
 
     public Dictionary<string, int> NameToTypePtr { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTableSchema.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTableSchema.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TTableSchema : TBase
+  internal partial class TTableSchema : TBase
   {
 
     public List<global::Apache.Hive.Service.Rpc.Thrift.TColumnDesc> Columns { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTypeDesc.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTypeDesc.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TTypeDesc : TBase
+  internal partial class TTypeDesc : TBase
   {
 
     public List<global::Apache.Hive.Service.Rpc.Thrift.TTypeEntry> Types { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTypeEntry.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTypeEntry.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TTypeEntry : TBase
+  internal partial class TTypeEntry : TBase
   {
     private global::Apache.Hive.Service.Rpc.Thrift.TPrimitiveTypeEntry _primitiveEntry;
     private global::Apache.Hive.Service.Rpc.Thrift.TArrayTypeEntry _arrayEntry;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTypeId.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTypeId.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace Apache.Hive.Service.Rpc.Thrift
 {
-  public enum TTypeId
+  internal enum TTypeId
   {
     BOOLEAN_TYPE = 0,
     TINYINT_TYPE = 1,

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTypeQualifierValue.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTypeQualifierValue.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TTypeQualifierValue : TBase
+  internal partial class TTypeQualifierValue : TBase
   {
     private int _i32Value;
     private string _stringValue;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTypeQualifiers.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TTypeQualifiers.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TTypeQualifiers : TBase
+  internal partial class TTypeQualifiers : TBase
   {
 
     public Dictionary<string, global::Apache.Hive.Service.Rpc.Thrift.TTypeQualifierValue> Qualifiers { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TUnionTypeEntry.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TUnionTypeEntry.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TUnionTypeEntry : TBase
+  internal partial class TUnionTypeEntry : TBase
   {
 
     public Dictionary<string, int> NameToTypePtr { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TUploadDataReq.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TUploadDataReq.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TUploadDataReq : TBase
+  internal partial class TUploadDataReq : TBase
   {
     private string _tableName;
     private string _path;

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TUploadDataResp.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TUploadDataResp.cs
@@ -40,7 +40,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TUploadDataResp : TBase
+  internal partial class TUploadDataResp : TBase
   {
 
     public global::Apache.Hive.Service.Rpc.Thrift.TStatus Status { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TUserDefinedTypeEntry.cs
+++ b/csharp/src/Drivers/Apache/Thrift/Service/Rpc/Thrift/TUserDefinedTypeEntry.cs
@@ -41,7 +41,7 @@ using Thrift.Processor;
 namespace Apache.Hive.Service.Rpc.Thrift
 {
 
-  public partial class TUserDefinedTypeEntry : TBase
+  internal partial class TUserDefinedTypeEntry : TBase
   {
 
     public string TypeClassName { get; set; }

--- a/csharp/src/Drivers/Apache/Thrift/StreamExtensions.cs
+++ b/csharp/src/Drivers/Apache/Thrift/StreamExtensions.cs
@@ -24,7 +24,7 @@ using System.Threading.Tasks;
 
 namespace Apache.Arrow.Adbc.Drivers.Apache.Thrift
 {
-    public static class StreamExtensions
+    internal static class StreamExtensions
     {
         public static void WriteInt32LittleEndian(int value, Span<byte> buffer, int offset)
         {


### PR DESCRIPTION
The Thrift classes in the HiveServer2-based drivers are intended to be internal implementation details and not exposed publicly. This PR changes their visibility from public to internal.