### PR TITLE
feat(csharp/src/Drivers/Apache/Spark): add user agent entry + thrift version for spark http connections

### DIFF
--- a/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
@@ -255,13 +255,33 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
         
         private string GetUserAgent()
         {
+            // Build the base user agent string with Thrift version
+            string thriftVersion = GetThriftVersion();
+            string thriftComponent = string.IsNullOrEmpty(thriftVersion) ? "Thrift" : $"Thrift/{thriftVersion}";
+            string baseUserAgent = $"{DriverName.Replace(" ", "")}/{ProductVersionDefault} {thriftComponent}"; // consider using ProductVersion instead of ProductVersionDefault
+            
             // Check if a client has provided a user-agent entry
             if (Properties.TryGetValue(SparkParameters.UserAgentEntry, out string? userAgentEntry) && !string.IsNullOrWhiteSpace(userAgentEntry))
             {
-                return $"{s_baseUserAgent} {userAgentEntry}";
+                return $"{baseUserAgent} {userAgentEntry}";
             }
             
-            return s_baseUserAgent;
+            return baseUserAgent;
+        }
+        
+        private string GetThriftVersion()
+        {
+            try
+            {
+                var thriftAssembly = typeof(TProtocol).Assembly;
+                var version = thriftAssembly.GetName().Version;
+                return version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "";
+            }
+            catch
+            {
+                // Return empty string if there's any issue retrieving the assembly version
+                return "";
+            }
         }
     }
 }

--- a/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
@@ -35,7 +35,6 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
 {
     internal class SparkHttpConnection : SparkConnection
     {
-        private static readonly string s_baseUserAgent = $"{DriverName.Replace(" ", "")}/{ProductVersionDefault}";
         private const string BasicAuthenticationScheme = "Basic";
         private const string BearerAuthenticationScheme = "Bearer";
 
@@ -258,7 +257,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
             // Build the base user agent string with Thrift version
             string thriftVersion = GetThriftVersion();
             string thriftComponent = string.IsNullOrEmpty(thriftVersion) ? "Thrift" : $"Thrift/{thriftVersion}";
-            string baseUserAgent = $"{DriverName.Replace(" ", "")}/{ProductVersionDefault} {thriftComponent}"; // consider using ProductVersion instead of ProductVersionDefault
+            string baseUserAgent = $"{DriverName.Replace(" ", "")}/{ProductVersionDefault} {thriftComponent}";
             
             // Check if a client has provided a user-agent entry
             if (Properties.TryGetValue(SparkParameters.UserAgentEntry, out string? userAgentEntry) && !string.IsNullOrWhiteSpace(userAgentEntry))

--- a/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
@@ -35,7 +35,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
 {
     internal class SparkHttpConnection : SparkConnection
     {
-        private static readonly string s_userAgent = $"{DriverName.Replace(" ", "")}/{ProductVersionDefault}";
+        private static readonly string s_baseUserAgent = $"{DriverName.Replace(" ", "")}/{ProductVersionDefault}";
         private const string BasicAuthenticationScheme = "Basic";
         private const string BearerAuthenticationScheme = "Bearer";
 
@@ -164,7 +164,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
             HttpClient httpClient = new(httpClientHandler);
             httpClient.BaseAddress = baseAddress;
             httpClient.DefaultRequestHeaders.Authorization = authenticationHeaderValue;
-            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(s_userAgent);
+            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(GetUserAgent());
             httpClient.DefaultRequestHeaders.AcceptEncoding.Clear();
             httpClient.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("identity"));
             httpClient.DefaultRequestHeaders.ExpectContinue = false;
@@ -252,5 +252,16 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
         internal override SparkServerType ServerType => SparkServerType.Http;
 
         protected override int ColumnMapIndexOffset => 1;
+        
+        private string GetUserAgent()
+        {
+            // Check if a client has provided a user-agent entry
+            if (Properties.TryGetValue(SparkParameters.UserAgentEntry, out string userAgentEntry) && !string.IsNullOrWhiteSpace(userAgentEntry))
+            {
+                return $"{s_baseUserAgent} {userAgentEntry}";
+            }
+            
+            return s_baseUserAgent;
+        }
     }
 }

--- a/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
@@ -256,7 +256,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
         private string GetUserAgent()
         {
             // Check if a client has provided a user-agent entry
-            if (Properties.TryGetValue(SparkParameters.UserAgentEntry, out string userAgentEntry) && !string.IsNullOrWhiteSpace(userAgentEntry))
+            if (Properties.TryGetValue(SparkParameters.UserAgentEntry, out string? userAgentEntry) && !string.IsNullOrWhiteSpace(userAgentEntry))
             {
                 return $"{s_baseUserAgent} {userAgentEntry}";
             }

--- a/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
@@ -251,23 +251,23 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
         internal override SparkServerType ServerType => SparkServerType.Http;
 
         protected override int ColumnMapIndexOffset => 1;
-        
+
         private string GetUserAgent()
         {
             // Build the base user agent string with Thrift version
             string thriftVersion = GetThriftVersion();
             string thriftComponent = string.IsNullOrEmpty(thriftVersion) ? "Thrift" : $"Thrift/{thriftVersion}";
             string baseUserAgent = $"{DriverName.Replace(" ", "")}/{ProductVersionDefault} {thriftComponent}";
-            
+
             // Check if a client has provided a user-agent entry
             if (Properties.TryGetValue(SparkParameters.UserAgentEntry, out string? userAgentEntry) && !string.IsNullOrWhiteSpace(userAgentEntry))
             {
                 return $"{baseUserAgent} {userAgentEntry}";
             }
-            
+
             return baseUserAgent;
         }
-        
+
         private string GetThriftVersion()
         {
             try

--- a/csharp/src/Drivers/Apache/Spark/SparkParameters.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkParameters.cs
@@ -33,6 +33,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
         public const string Type = "adbc.spark.type";
         public const string DataTypeConv = "adbc.spark.data_type_conv";
         public const string ConnectTimeoutMilliseconds = "adbc.spark.connect_timeout_ms";
+        public const string UserAgentEntry = "adbc.spark.user_agent_entry";
     }
 
     public static class SparkAuthTypeConstants

--- a/csharp/test/Drivers/Apache/Spark/SparkHttpConnectionUserAgentTest.cs
+++ b/csharp/test/Drivers/Apache/Spark/SparkHttpConnectionUserAgentTest.cs
@@ -123,7 +123,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
             }
             
             // Invoke the method
-            return (string)getUserAgentMethod.Invoke(connection, null);
+            return (string)getUserAgentMethod.Invoke(connection, null)!;
         }
     }
 }

--- a/csharp/test/Drivers/Apache/Spark/SparkHttpConnectionUserAgentTest.cs
+++ b/csharp/test/Drivers/Apache/Spark/SparkHttpConnectionUserAgentTest.cs
@@ -131,16 +131,15 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
         {
             // Create the connection
             var connection = new SparkHttpConnection(properties);
-            
+
             // Use reflection to access the private GetUserAgent method
-            var getUserAgentMethod = typeof(SparkHttpConnection).GetMethod("GetUserAgent", 
-                BindingFlags.NonPublic | BindingFlags.Instance);
-            
+            var getUserAgentMethod = typeof(SparkHttpConnection).GetMethod("GetUserAgent", BindingFlags.NonPublic | BindingFlags.Instance);
+
             if (getUserAgentMethod == null)
             {
                 throw new InvalidOperationException("GetUserAgent method not found");
             }
-            
+
             // Invoke the method
             return (string)getUserAgentMethod.Invoke(connection, null)!;
         }

--- a/csharp/test/Drivers/Apache/Spark/SparkHttpConnectionUserAgentTest.cs
+++ b/csharp/test/Drivers/Apache/Spark/SparkHttpConnectionUserAgentTest.cs
@@ -30,7 +30,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
     public class SparkHttpConnectionUserAgentTest
     {
         [Fact]
-        public void UserAgentEntry_WhenNotProvided_UsesBaseUserAgent()
+        public void UserAgentEntry_WhenNotProvided_UsesBaseUserAgentWithThrift()
         {
             // Arrange
             var properties = new Dictionary<string, string>
@@ -45,7 +45,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
             string userAgent = GetUserAgentFromConnection(properties);
 
             // Assert
-            Assert.Equal("ADBCSparkDriver/1.0.0", userAgent);
+            Assert.Matches(@"ADBCSparkDriver/[\d\.]+ Thrift(/[\d\.]+)?", userAgent);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
             string userAgent = GetUserAgentFromConnection(properties);
 
             // Assert
-            Assert.Equal("ADBCSparkDriver/1.0.0 PowerBI", userAgent);
+            Assert.Matches(@"ADBCSparkDriver/[\d\.]+ Thrift(/[\d\.]+)? PowerBI", userAgent);
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
             string userAgent = GetUserAgentFromConnection(properties);
 
             // Assert
-            Assert.Equal("ADBCSparkDriver/1.0.0", userAgent);
+            Assert.Matches(@"ADBCSparkDriver/[\d\.]+ Thrift(/[\d\.]+)?", userAgent);
         }
 
         [Fact]
@@ -105,7 +105,26 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
             string userAgent = GetUserAgentFromConnection(properties);
 
             // Assert
-            Assert.Equal("ADBCSparkDriver/1.0.0", userAgent);
+            Assert.Matches(@"ADBCSparkDriver/[\d\.]+ Thrift(/[\d\.]+)?", userAgent);
+        }
+
+        [Fact]
+        public void UserAgent_IncludesThriftComponent()
+        {
+            // Arrange
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.Type] = SparkServerTypeConstants.Http,
+                [SparkParameters.HostName] = "valid.server.com",
+                [SparkParameters.Path] = "/path",
+                [SparkParameters.AuthType] = SparkAuthTypeConstants.None
+            };
+
+            // Act
+            string userAgent = GetUserAgentFromConnection(properties);
+
+            // Assert
+            Assert.Contains("Thrift", userAgent);
         }
 
         private string GetUserAgentFromConnection(Dictionary<string, string> properties)

--- a/csharp/test/Drivers/Apache/Spark/SparkHttpConnectionUserAgentTest.cs
+++ b/csharp/test/Drivers/Apache/Spark/SparkHttpConnectionUserAgentTest.cs
@@ -1,0 +1,129 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
+using Apache.Arrow.Adbc.Drivers.Apache.Spark;
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
+{
+    /// <summary>
+    /// Tests for the SparkHttpConnection user agent functionality.
+    /// </summary>
+    public class SparkHttpConnectionUserAgentTest
+    {
+        [Fact]
+        public void UserAgentEntry_WhenNotProvided_UsesBaseUserAgent()
+        {
+            // Arrange
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.Type] = SparkServerTypeConstants.Http,
+                [SparkParameters.HostName] = "valid.server.com",
+                [SparkParameters.Path] = "/path",
+                [SparkParameters.AuthType] = SparkAuthTypeConstants.None
+            };
+
+            // Act
+            string userAgent = GetUserAgentFromConnection(properties);
+
+            // Assert
+            Assert.Equal("ADBCSparkDriver/1.0.0", userAgent);
+        }
+
+        [Fact]
+        public void UserAgentEntry_WhenProvided_AppendsToBaseUserAgent()
+        {
+            // Arrange
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.Type] = SparkServerTypeConstants.Http,
+                [SparkParameters.HostName] = "valid.server.com",
+                [SparkParameters.Path] = "/path",
+                [SparkParameters.AuthType] = SparkAuthTypeConstants.None,
+                [SparkParameters.UserAgentEntry] = "PowerBI"
+            };
+
+            // Act
+            string userAgent = GetUserAgentFromConnection(properties);
+
+            // Assert
+            Assert.Equal("ADBCSparkDriver/1.0.0 PowerBI", userAgent);
+        }
+
+        [Fact]
+        public void UserAgentEntry_WhenEmpty_UsesBaseUserAgent()
+        {
+            // Arrange
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.Type] = SparkServerTypeConstants.Http,
+                [SparkParameters.HostName] = "valid.server.com",
+                [SparkParameters.Path] = "/path",
+                [SparkParameters.AuthType] = SparkAuthTypeConstants.None,
+                [SparkParameters.UserAgentEntry] = ""
+            };
+
+            // Act
+            string userAgent = GetUserAgentFromConnection(properties);
+
+            // Assert
+            Assert.Equal("ADBCSparkDriver/1.0.0", userAgent);
+        }
+
+        [Fact]
+        public void UserAgentEntry_WhenWhitespace_UsesBaseUserAgent()
+        {
+            // Arrange
+            var properties = new Dictionary<string, string>
+            {
+                [SparkParameters.Type] = SparkServerTypeConstants.Http,
+                [SparkParameters.HostName] = "valid.server.com",
+                [SparkParameters.Path] = "/path",
+                [SparkParameters.AuthType] = SparkAuthTypeConstants.None,
+                [SparkParameters.UserAgentEntry] = "   "
+            };
+
+            // Act
+            string userAgent = GetUserAgentFromConnection(properties);
+
+            // Assert
+            Assert.Equal("ADBCSparkDriver/1.0.0", userAgent);
+        }
+
+        private string GetUserAgentFromConnection(Dictionary<string, string> properties)
+        {
+            // Create the connection
+            var connection = new SparkHttpConnection(properties);
+            
+            // Use reflection to access the private GetUserAgent method
+            var getUserAgentMethod = typeof(SparkHttpConnection).GetMethod("GetUserAgent", 
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            
+            if (getUserAgentMethod == null)
+            {
+                throw new InvalidOperationException("GetUserAgent method not found");
+            }
+            
+            // Invoke the method
+            return (string)getUserAgentMethod.Invoke(connection, null);
+        }
+    }
+}


### PR DESCRIPTION
Enables user agent entry to be passed via SparkParameters, such as "user_agent_entry = PowerBi".
Also adds Thrift version to user agent header

Verified in Databricks HTTP Logs for the user agent:
ADBCSparkDriver/1.0.0 Thrift/0.21.0 PowerBI