### PR TITLE
fix(go): Use arrow-go in templates instead of arrow/go

### DIFF
--- a/go/adbc/pkg/Makefile
+++ b/go/adbc/pkg/Makefile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 GO_BUILD=go build
-RM=rm
+RM=rm -f
 ifeq ($(shell go env GOOS),linux)
 	SUFFIX=so
 else ifeq ($(shell go env GOOS),windows)

--- a/go/adbc/pkg/_tmpl/driver.go.tmpl
+++ b/go/adbc/pkg/_tmpl/driver.go.tmpl
@@ -59,10 +59,10 @@ import (
 	"unsafe"
 
 	"github.com/apache/arrow-adbc/go/adbc"
-	"github.com/apache/arrow/go/v18/arrow/array"
-	"github.com/apache/arrow/go/v18/arrow/cdata"
-	"github.com/apache/arrow/go/v18/arrow/memory"
-	"github.com/apache/arrow/go/v18/arrow/memory/mallocator"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/cdata"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/memory/mallocator"
 )
 
 // Must use malloc() to respect CGO rules


### PR DESCRIPTION
This makes the templates consistent with the generated (then manually edited code).