### PR TITLE
feat(rust)!: use GATs for return types in `Connection` and `Statement` traits

### DIFF
--- a/rust/core/src/driver_exporter.rs
+++ b/rust/core/src/driver_exporter.rs
@@ -98,7 +98,24 @@ pub trait FFIDriver {
     fn ffi_driver() -> FFI_AdbcDriver;
 }
 
-impl<DriverType: Driver + Default + 'static> FFIDriver for DriverType {
+impl<DriverType: Driver + Default + 'static> FFIDriver for DriverType
+where
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::InfoReader<'a>:
+        Send,
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::ObjectsReader<'a>:
+        Send,
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::TableTypesReader<'a>:
+        Send,
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::StatisticNamesReader<
+        'a,
+    >: Send,
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::StatisticsReader<'a>:
+        Send,
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::PartitionReader<'a>:
+        Send,
+    for<'a> <<<DriverType::DatabaseType as Database>::ConnectionType as Connection>::StatementType as Statement>::Reader<'a>:
+        Send,
+{
     fn ffi_driver() -> FFI_AdbcDriver {
         FFI_AdbcDriver {
             private_data: std::ptr::null_mut(),
@@ -950,7 +967,11 @@ unsafe extern "C" fn connection_get_table_types<DriverType: Driver + 'static>(
     connection: *mut FFI_AdbcConnection,
     out: *mut FFI_ArrowArrayStream,
     error: *mut FFI_AdbcError,
-) -> FFI_AdbcStatusCode {
+) -> FFI_AdbcStatusCode
+where
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::TableTypesReader<'a>:
+        Send,
+{
     check_not_null!(connection, error);
     check_not_null!(out, error);
 
@@ -998,7 +1019,11 @@ unsafe extern "C" fn connection_get_info<DriverType: Driver + 'static>(
     info_codes_length: usize,
     out: *mut FFI_ArrowArrayStream,
     error: *mut FFI_AdbcError,
-) -> FFI_AdbcStatusCode {
+) -> FFI_AdbcStatusCode
+where
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::InfoReader<'a>:
+        Send,
+{
     check_not_null!(connection, error);
     check_not_null!(out, error);
 
@@ -1066,7 +1091,12 @@ unsafe extern "C" fn connection_get_statistic_names<DriverType: Driver + 'static
     connection: *mut FFI_AdbcConnection,
     out: *mut FFI_ArrowArrayStream,
     error: *mut FFI_AdbcError,
-) -> FFI_AdbcStatusCode {
+) -> FFI_AdbcStatusCode
+where
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::StatisticNamesReader<
+        'a,
+    >: Send,
+{
     check_not_null!(connection, error);
     check_not_null!(out, error);
 
@@ -1087,7 +1117,11 @@ unsafe extern "C" fn connection_read_partition<DriverType: Driver + 'static>(
     serialized_length: usize,
     out: *mut FFI_ArrowArrayStream,
     error: *mut FFI_AdbcError,
-) -> FFI_AdbcStatusCode {
+) -> FFI_AdbcStatusCode
+where
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::PartitionReader<'a>:
+        Send,
+{
     check_not_null!(connection, error);
     check_not_null!(serialized_partition, error);
     check_not_null!(out, error);
@@ -1112,7 +1146,11 @@ unsafe extern "C" fn connection_get_statistics<DriverType: Driver + 'static>(
     approximate: c_char,
     out: *mut FFI_ArrowArrayStream,
     error: *mut FFI_AdbcError,
-) -> FFI_AdbcStatusCode {
+) -> FFI_AdbcStatusCode
+where
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::StatisticsReader<'a>:
+        Send,
+{
     check_not_null!(connection, error);
     check_not_null!(out, error);
 
@@ -1143,7 +1181,11 @@ unsafe extern "C" fn connection_get_objects<DriverType: Driver + 'static>(
     column_name: *const c_char,
     out: *mut FFI_ArrowArrayStream,
     error: *mut FFI_AdbcError,
-) -> FFI_AdbcStatusCode {
+) -> FFI_AdbcStatusCode
+where
+    for<'a> <<DriverType::DatabaseType as Database>::ConnectionType as Connection>::ObjectsReader<'a>:
+        Send,
+{
     check_not_null!(connection, error);
     check_not_null!(out, error);
 
@@ -1455,7 +1497,10 @@ unsafe extern "C" fn statement_execute_query<DriverType: Driver + 'static>(
     out: *mut FFI_ArrowArrayStream,
     rows_affected: *mut i64,
     error: *mut FFI_AdbcError,
-) -> FFI_AdbcStatusCode {
+) -> FFI_AdbcStatusCode where
+    for<'a> <<<DriverType::DatabaseType as Database>::ConnectionType as Connection>::StatementType as Statement>::Reader<'a>:
+    Send,
+{
     check_not_null!(statement, error);
 
     let exported = check_err!(statement_private_data::<DriverType>(statement), error);

--- a/rust/driver/snowflake/src/connection.rs
+++ b/rust/driver/snowflake/src/connection.rs
@@ -27,7 +27,6 @@ use adbc_core::{
     options::{InfoCode, OptionConnection, OptionValue},
     Optionable,
 };
-use arrow_array::RecordBatchReader;
 use arrow_schema::Schema;
 
 use crate::Statement;
@@ -74,9 +73,15 @@ impl adbc_core::Connection for Connection {
         self.0.cancel()
     }
 
-    fn get_info(&self, codes: Option<HashSet<InfoCode>>) -> Result<impl RecordBatchReader + Send> {
+    type InfoReader<'connection> =
+        <ManagedConnection as adbc_core::Connection>::InfoReader<'connection>;
+
+    fn get_info(&self, codes: Option<HashSet<InfoCode>>) -> Result<Self::InfoReader<'_>> {
         self.0.get_info(codes)
     }
+
+    type ObjectsReader<'connection> =
+        <ManagedConnection as adbc_core::Connection>::ObjectsReader<'connection>;
 
     fn get_objects(
         &self,
@@ -86,7 +91,7 @@ impl adbc_core::Connection for Connection {
         table_name: Option<&str>,
         table_type: Option<Vec<&str>>,
         column_name: Option<&str>,
-    ) -> Result<impl RecordBatchReader + Send> {
+    ) -> Result<Self::ObjectsReader<'_>> {
         self.0.get_objects(
             depth,
             catalog,
@@ -106,13 +111,22 @@ impl adbc_core::Connection for Connection {
         self.0.get_table_schema(catalog, db_schema, table_name)
     }
 
-    fn get_table_types(&self) -> Result<impl RecordBatchReader + Send> {
+    type TableTypesReader<'connection> =
+        <ManagedConnection as adbc_core::Connection>::TableTypesReader<'connection>;
+
+    fn get_table_types(&self) -> Result<Self::TableTypesReader<'_>> {
         self.0.get_table_types()
     }
 
-    fn get_statistic_names(&self) -> Result<impl RecordBatchReader + Send> {
+    type StatisticNamesReader<'connection> =
+        <ManagedConnection as adbc_core::Connection>::StatisticNamesReader<'connection>;
+
+    fn get_statistic_names(&self) -> Result<Self::StatisticNamesReader<'_>> {
         self.0.get_statistic_names()
     }
+
+    type StatisticsReader<'connection> =
+        <ManagedConnection as adbc_core::Connection>::StatisticsReader<'connection>;
 
     fn get_statistics(
         &self,
@@ -120,7 +134,7 @@ impl adbc_core::Connection for Connection {
         db_schema: Option<&str>,
         table_name: Option<&str>,
         approximate: bool,
-    ) -> Result<impl RecordBatchReader + Send> {
+    ) -> Result<Self::StatisticsReader<'_>> {
         self.0
             .get_statistics(catalog, db_schema, table_name, approximate)
     }
@@ -133,7 +147,10 @@ impl adbc_core::Connection for Connection {
         self.0.rollback()
     }
 
-    fn read_partition(&self, partition: impl AsRef<[u8]>) -> Result<impl RecordBatchReader + Send> {
+    type PartitionReader<'connection> =
+        <ManagedConnection as adbc_core::Connection>::PartitionReader<'connection>;
+
+    fn read_partition(&self, partition: impl AsRef<[u8]>) -> Result<Self::PartitionReader<'_>> {
         self.0.read_partition(partition)
     }
 }

--- a/rust/driver/snowflake/src/statement.rs
+++ b/rust/driver/snowflake/src/statement.rs
@@ -60,11 +60,13 @@ impl adbc_core::Statement for Statement {
         self.0.bind(batch)
     }
 
-    fn bind_stream(&mut self, reader: Box<dyn RecordBatchReader + Send>) -> Result<()> {
+    fn bind_stream(&mut self, reader: impl RecordBatchReader + Send + 'static) -> Result<()> {
         self.0.bind_stream(reader)
     }
 
-    fn execute(&mut self) -> Result<impl RecordBatchReader + Send> {
+    type Reader<'statement> = <ManagedStatement as adbc_core::Statement>::Reader<'statement>;
+
+    fn execute(&mut self) -> Result<Self::Reader<'_>> {
         self.0.execute()
     }
 


### PR DESCRIPTION
Following the discussion in #2694 - this changes the `impl Trait` return types to use generic associated types. This is a breaking change.