### PR TITLE
chore: merge `arrow` and `datafusion` update groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,11 +58,8 @@ updates:
     commit-message:
       prefix: "chore(rust): "
     groups:
-      arrow:
+      arrow-datafusion:
         applies-to: version-updates
         patterns:
           - "arrow-*"
-      datafusion:
-        applies-to: version-updates
-        patterns:
           - "datafusion*"


### PR DESCRIPTION
Until we fix https://github.com/apache/arrow-adbc/pull/2525, this merges the `arrow` and `datafusion` dependabot update PRs.