### PR TITLE
build(c): Remove unnecessary test branching from Meson configuration

### DIFF
--- a/c/driver/bigquery/meson.build
+++ b/c/driver/bigquery/meson.build
@@ -55,13 +55,11 @@ pkg.generate(
     filebase: 'adbc-driver-bigquery',
 )
 
-if get_option('tests').enabled()
-    exc = executable(
-        'adbc-driver-bigquery-test',
-        'bigquery_test.cc',
-        include_directories: [c_dir, driver_dir],
-        link_with: [adbc_common_lib, adbc_driver_bigquery_lib],
-        dependencies: [adbc_validation_dep],
-    )
-    test('adbc-driver-bigquery', exc)
-endif
+exc = executable(
+    'adbc-driver-bigquery-test',
+    'bigquery_test.cc',
+    include_directories: [c_dir, driver_dir],
+    link_with: [adbc_common_lib, adbc_driver_bigquery_lib],
+    dependencies: [adbc_validation_dep],
+)
+test('adbc-driver-bigquery', exc)

--- a/c/driver/common/meson.build
+++ b/c/driver/common/meson.build
@@ -23,13 +23,11 @@ adbc_common_lib = library(
     install: true,
 )
 
-if get_option('tests').enabled()
-    exc = executable(
-        'adbc-driver-common-test',
-        'utils_test.cc',
-        include_directories: [include_dir],
-        link_with: [adbc_common_lib],
-        dependencies: [nanoarrow_dep, gtest_main_dep, gmock_dep],
-    )
-    test('adbc-driver-common', exc)
-endif
+exc = executable(
+    'adbc-driver-common-test',
+    'utils_test.cc',
+    include_directories: [include_dir],
+    link_with: [adbc_common_lib],
+    dependencies: [nanoarrow_dep, gtest_main_dep, gmock_dep],
+)
+test('adbc-driver-common', exc)

--- a/c/driver/flightsql/meson.build
+++ b/c/driver/flightsql/meson.build
@@ -55,14 +55,12 @@ pkg.generate(
     filebase: 'adbc-driver-flightsql',
 )
 
-if get_option('tests').enabled()
-    exc = executable(
-        'adbc-driver-flightsql-test',
-        'dremio_flightsql_test.cc',
-        'sqlite_flightsql_test.cc',
-        include_directories: [include_dir, c_dir, driver_dir],
-        link_with: [adbc_common_lib, adbc_driver_flightsql_lib],
-        dependencies: [adbc_validation_dep],
-    )
-    test('adbc-driver-flightsql', exc)
-endif
+exc = executable(
+    'adbc-driver-flightsql-test',
+    'dremio_flightsql_test.cc',
+    'sqlite_flightsql_test.cc',
+    include_directories: [include_dir, c_dir, driver_dir],
+    link_with: [adbc_common_lib, adbc_driver_flightsql_lib],
+    dependencies: [adbc_validation_dep],
+)
+test('adbc-driver-flightsql', exc)

--- a/c/driver/postgresql/meson.build
+++ b/c/driver/postgresql/meson.build
@@ -41,29 +41,27 @@ pkg.generate(
     filebase: 'adbc-driver-postgresql',
 )
 
-if get_option('tests').enabled()
-    postgres_tests = {
-        'driver-postgresql': {
-            'src_name': 'driver_postgresql',
-            'sources': ['postgres_type_test.cc', 'postgresql_test.cc'],
-        },
-        'driver-postgresql-copy': {
-            'src_name': 'driver_postgresql_copy',
-            'sources': [
-                'copy/postgres_copy_reader_test.cc',
-                'copy/postgres_copy_writer_test.cc',
-            ],
-        },
-    }
+postgres_tests = {
+    'driver-postgresql': {
+        'src_name': 'driver_postgresql',
+        'sources': ['postgres_type_test.cc', 'postgresql_test.cc'],
+    },
+    'driver-postgresql-copy': {
+        'src_name': 'driver_postgresql_copy',
+        'sources': [
+            'copy/postgres_copy_reader_test.cc',
+            'copy/postgres_copy_writer_test.cc',
+        ],
+    },
+}
 
-    foreach name, conf : postgres_tests
-        exc = executable(
-            'adbc-' + name + '-test',
-            sources: conf['sources'],
-            include_directories: [include_dir, driver_dir, c_dir],
-            link_with: [adbc_common_lib, adbc_postgres_driver_lib],
-            dependencies: [libpq_dep, adbc_validation_dep],
-        )
-        test('adbc-' + name, exc)
-    endforeach
-endif
+foreach name, conf : postgres_tests
+    exc = executable(
+        'adbc-' + name + '-test',
+        sources: conf['sources'],
+        include_directories: [include_dir, driver_dir, c_dir],
+        link_with: [adbc_common_lib, adbc_postgres_driver_lib],
+        dependencies: [libpq_dep, adbc_validation_dep],
+    )
+    test('adbc-' + name, exc)
+endforeach

--- a/c/driver/snowflake/meson.build
+++ b/c/driver/snowflake/meson.build
@@ -55,13 +55,11 @@ pkg.generate(
     filebase: 'adbc-driver-snowflake',
 )
 
-if get_option('tests').enabled()
-    exc = executable(
-        'adbc-driver-snowflake-test',
-        'snowflake_test.cc',
-        include_directories: [include_dir, c_dir, driver_dir],
-        link_with: [adbc_common_lib, adbc_driver_snowflake_lib],
-        dependencies: [adbc_validation_dep],
-    )
-    test('adbc-driver-snowflake', exc)
-endif
+exc = executable(
+    'adbc-driver-snowflake-test',
+    'snowflake_test.cc',
+    include_directories: [include_dir, c_dir, driver_dir],
+    link_with: [adbc_common_lib, adbc_driver_snowflake_lib],
+    dependencies: [adbc_validation_dep],
+)
+test('adbc-driver-snowflake', exc)

--- a/c/driver/sqlite/meson.build
+++ b/c/driver/sqlite/meson.build
@@ -39,13 +39,11 @@ pkg.generate(
     filebase: 'adbc-driver-sqlite',
 )
 
-if get_option('tests').enabled()
-    exc = executable(
-        'adbc-driver-sqlite-test',
-        sources: ['sqlite_test.cc'],
-        include_directories: [include_dir, c_dir, driver_dir],
-        link_with: [adbc_common_lib, adbc_sqlite3_driver_lib],
-        dependencies: [sqlite3_dep, adbc_validation_dep],
-    )
-    test('adbc-driver-sqlite', exc)
-endif
+exc = executable(
+    'adbc-driver-sqlite-test',
+    sources: ['sqlite_test.cc'],
+    include_directories: [include_dir, c_dir, driver_dir],
+    link_with: [adbc_common_lib, adbc_sqlite3_driver_lib],
+    dependencies: [sqlite3_dep, adbc_validation_dep],
+)
+test('adbc-driver-sqlite', exc)


### PR DESCRIPTION
The gtest_main_dep and gmock_dep dependencies are set to `disabler()` when the test option is not enabled in the top level configuration. Therefore, all of these subsequent `if get_option('tests')` checks are redundant; if not set, the disabler() will naturally take care of disabling the dependent target for you