### PR TITLE
fix(c): Add libdl as dependency of driver manager in Meson

### DIFF
--- a/c/driver_manager/meson.build
+++ b/c/driver_manager/meson.build
@@ -15,12 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+dl_dep = dependency('dl')
 
 adbc_driver_manager_lib = library(
     'adbc_driver_manager',
     'adbc_driver_manager.cc',
     include_directories: [include_dir],
     install: true,
+    dependencies: [dl_dep],
 )
 
 pkg.generate(


### PR DESCRIPTION
Not sure how this was working before, but on main I get the following issues without this:

```
adbc_driver_manager.cc:(.text.AdbcLoadDriver+0xbe): undefined reference to `dlopen'
/home/willayd/miniforge3/envs/pandas-dev/bin/../lib/gcc/x86_64-conda-linux-gnu/13.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: adbc_driver_manager.cc:(.text.AdbcLoadDriver+0xf8): undefined reference to `dlsym'
/home/willayd/miniforge3/envs/pandas-dev/bin/../lib/gcc/x86_64-conda-linux-gnu/13.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: adbc_driver_manager.cc:(.text.AdbcLoadDriver+0x33e): undefined reference to `dlsym'
/home/willayd/miniforge3/envs/pandas-dev/bin/../lib/gcc/x86_64-conda-linux-gnu/13.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: adbc_driver_manager.cc:(.text.AdbcLoadDriver+0x43b): undefined reference to `dlerror'
/home/willayd/miniforge3/envs/pandas-dev/bin/../lib/gcc/x86_64-conda-linux-gnu/13.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: adbc_driver_manager.cc:(.text.AdbcLoadDriver+0x6b0): undefined reference to `dlopen'
/home/willayd/miniforge3/envs/pandas-dev/bin/../lib/gcc/x86_64-conda-linux-gnu/13.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: adbc_driver_manager.cc:(.text.AdbcLoadDriver+0xab6): undefined reference to `dlerror'
/home/willayd/miniforge3/envs/pandas-dev/bin/../lib/gcc/x86_64-conda-linux-gnu/13.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: adbc_driver_manager.cc:(.text.AdbcLoadDriver+0xd34): undefined reference to `dlerror'
/home/willayd/miniforge3/envs/pandas-dev/bin/../lib/gcc/x86_64-conda-linux-gnu/13.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: adbc_driver_manager.cc:(.text.AdbcLoadDriver+0xfbe): undefined reference to `dlerror'
/home/willayd/miniforge3/envs/pandas-dev/bin/../lib/gcc/x86_64-conda-linux-gnu/13.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: adbc_driver_manager.cc:(.text.AdbcLoadDriver+0x108f): undefined reference to `dlsym'
/home/willayd/miniforge3/envs/pandas-dev/bin/../lib/gcc/x86_64-conda-linux-gnu/13.3.0/../../../../x86_64-conda-linux-gnu/bin/ld: adbc_driver_manager.cc:(.text.AdbcLoadDriver+0x1148): undefined reference to `dlerror'
collect2: error: ld returned 1 exit status
```