### PR TITLE
fix(dev/release): use packages.apache.org instead of apache.jfrog.io

### DIFF
--- a/dev/release/.env.example
+++ b/dev/release/.env.example
@@ -30,6 +30,7 @@
 #
 # You must set this.
 #
-# This can be obtained by logging in to https://apache.jfrog.io with
-# your ASF credentials and generating an API key from your user profile.
+# This can be obtained by logging in to
+# https://packages.apache.org/ui/login with your ASF credentials and
+# generating an API key from your user profile.
 #ARTIFACTORY_API_KEY=secret

--- a/dev/release/06-binary-verify.sh
+++ b/dev/release/06-binary-verify.sh
@@ -102,9 +102,9 @@ Note: to verify APT/YUM packages on macOS/AArch64, you must \`export DOCKER_DEFA
 [1]: https://github.com/apache/arrow-adbc/issues?q=is%3Aissue+milestone%3A%22ADBC+Libraries+${RELEASE}%22+is%3Aclosed
 [2]: https://github.com/apache/arrow-adbc/commit/${commit}
 [3]: https://dist.apache.org/repos/dist/dev/arrow/${tag}/
-[4]: https://apache.jfrog.io/artifactory/arrow/almalinux-rc/
-[5]: https://apache.jfrog.io/artifactory/arrow/debian-rc/
-[6]: https://apache.jfrog.io/artifactory/arrow/ubuntu-rc/
+[4]: https://packages.apache.org/artifactory/arrow/almalinux-rc/
+[5]: https://packages.apache.org/artifactory/arrow/debian-rc/
+[6]: https://packages.apache.org/artifactory/arrow/ubuntu-rc/
 [7]: https://repository.apache.org/content/repositories/staging/org/apache/arrow/adbc/
 [8]: https://github.com/apache/arrow-adbc/releases/tag/${tag}
 [9]: https://github.com/apache/arrow-adbc/blob/${tag}/CHANGELOG.md

--- a/dev/release/post-09-announce.sh
+++ b/dev/release/post-09-announce.sh
@@ -68,7 +68,7 @@ The Apache Arrow Community
 
 [1]: https://github.com/apache/arrow-adbc/issues?q=is%3Aissue+milestone%3A%22ADBC+Libraries+${RELEASE}%22+is%3Aclosed
 [2]: https://arrow.apache.org/adbc/current/driver/installation.html
-[3]: https://apache.jfrog.io/ui/native/arrow
+[3]: https://packages.apache.org/ui/native/arrow
 [4]: https://arrow.apache.org/blog/2023/01/05/introducing-arrow-adbc/
 [5]: https://lists.apache.org/list.html?user@arrow.apache.org
 [6]: https://lists.apache.org/list.html?dev@arrow.apache.org

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -67,7 +67,7 @@ ${APT_INSTALL} \
 
 code_name="$(lsb_release --codename --short)"
 distribution="$(lsb_release --id --short | tr 'A-Z' 'a-z')"
-artifactory_base_url="https://apache.jfrog.io/artifactory/arrow/${distribution}"
+artifactory_base_url="https://packages.apache.org/artifactory/arrow/${distribution}"
 case "${TYPE}" in
   rc|staging-rc|staging-release)
     suffix=${TYPE%-release}
@@ -94,7 +94,7 @@ curl \
     --fail \
     --location \
     --remote-name \
-     https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+     https://packages.apache.org/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 ${APT_INSTALL} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 
 if [ "${TYPE}" = "local" ]; then

--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -39,7 +39,7 @@ TYPE="$2"
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 local_prefix="${SOURCE_DIR}/../../ci/linux-packages"
 
-artifactory_base_url="https://apache.jfrog.io/artifactory/arrow"
+artifactory_base_url="https://packages.apache.org/artifactory/arrow"
 
 distribution=$(. /etc/os-release && echo "${ID}")
 distribution_version=$(. /etc/os-release && echo "${VERSION_ID}" | grep -o "^[0-9]*")
@@ -94,7 +94,7 @@ fi
 if [ "${TYPE}" = "local" ]; then
   sed \
     -e "s,^\\[apache-arrow-,\\[apache-adbc-,g" \
-    -e "s,baseurl=https://apache\.jfrog\.io/artifactory/arrow/,baseurl=file://${local_prefix}/yum/repositories/,g" \
+    -e "s,baseurl=https://packages\.apache\.org/artifactory/arrow/,baseurl=file://${local_prefix}/yum/repositories/,g" \
     -e "s,RPM-GPG-KEY-Apache-Arrow,RPM-GPG-KEY-Apache-ADBC,g" \
     /etc/yum.repos.d/Apache-Arrow.repo > \
     /etc/yum.repos.d/Apache-ADBC.repo


### PR DESCRIPTION
arrow-apt-source and arrow-release changed to use packages.apache.org from apache.jfrog.io in https://github.com/apache/arrow/pull/46108 . (Note that packages.apache.org is an alias of apache.jfrog.io.)

We need to do the same change to pass CI.

Fixes #2757.