### PR TITLE
fix(glib): use -fPIE explicitly for g-ir-scanner

### DIFF
--- a/glib/adbc-arrow-glib/meson.build
+++ b/glib/adbc-arrow-glib/meson.build
@@ -81,7 +81,7 @@ adbc_arrow_glib_gir = \
     libadbc_arrow_glib,
     dependencies: [declare_dependency(sources: adbc_glib_gir), arrow_glib],
     export_packages: 'adbc-arrow-glib',
-    extra_args: ['--warn-all'],
+    extra_args: gir_scanner_extra_args,
     fatal_warnings: gi_fatal_warnings,
     header: 'adbc-arrow-glib/adbc-arrow-glib.h',
     identifier_prefix: 'GADBCArrow',

--- a/glib/adbc-glib/meson.build
+++ b/glib/adbc-glib/meson.build
@@ -91,7 +91,7 @@ pkgconfig.generate(
 adbc_glib_gir = gnome.generate_gir(
     libadbc_glib,
     export_packages: 'adbc-glib',
-    extra_args: ['--warn-all'],
+    extra_args: gir_scanner_extra_args,
     fatal_warnings: gi_fatal_warnings,
     header: 'adbc-glib/adbc-glib.h',
     identifier_prefix: 'GADBC',

--- a/glib/meson.build
+++ b/glib/meson.build
@@ -57,10 +57,10 @@ if adbc_build_dir != ''
     adbc_build_dir = meson.source_root() / adbc_build_dir
 endif
 
+c_compiler = meson.get_compiler('c')
 if adbc_build_dir == ''
     adbc_driver_manager = dependency('adbc-driver-manager')
 else
-    c_compiler = meson.get_compiler('c')
     adbc_driver_manager = c_compiler.find_library(
         'adbc_driver_manager',
         dirs: [adbc_build_dir],
@@ -74,6 +74,18 @@ generate_vapi = get_option('vapi')
 if generate_vapi
     pkgconfig_variables += ['vapidir=@0@'.format(vapi_dir)]
     add_languages('vala')
+endif
+
+# Specify -fPIE explicitly for g-ir-scanner because PIE is disabled by
+# default on AlmaLinux 9 RPM build by
+# LDFLAGS="-specs=/usr/lib/rpm/redhat/redhat-hardened-ld".
+gir_scanner_cflags = c_compiler.get_supported_arguments('-fPIE')
+if gir_scanner_cflags.length() == 0
+    gir_scanner_extra_args = []
+else
+    gir_scanner_extra_args = ['--cflags-begin'] + gir_scanner_cflags + [
+        '--cflags-end',
+    ]
 endif
 
 subdir('adbc-glib')


### PR DESCRIPTION
AlmaLinux 9 RPM build environment disables PIE by default by `LDFLAGS="-specs=/usr/lib/rpm/redhat/redhat-hardened-ld"`. If PIE is disabled, `g-ir-scanner` is failed:

    /usr/bin/ld:
    /build/rpmbuild/BUILD/apache-arrow-adbc-18/glib/build/tmp-introspect4ug84fdq/ADBC-1.0.o:
    relocation R_X86_64_32 against `.rodata' can not be used when
    making a PIE object; recompile with -fPIE

Fixes #2574.