### PR TITLE
docs: rework "What exactly is ADBC?" in FAQ

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -22,16 +22,14 @@ Frequently Asked Questions (FAQ)
 What exactly is ADBC?
 =====================
 
-ADBC is:
+At a high level, you can think of ADBC as a standard for Arrow-native access to
+databases. At a lower level, ADBC is two separate things:
 
-- A set of abstract APIs in different languages (C/C++, Go, and Java,
-  with more on the way) for working with databases and Arrow data.
+1. An abstract API, with definitions in different languages (currently C, Go,
+   Java, and Rust), for working with databases and Arrow data.
 
-  For example, result sets of queries in ADBC are all returned as
-  streams of Arrow data, not row-by-row.
-- A set of implementations of that API in different languages (C/C++,
-  C#/.NET, Go, Java, Python, and Ruby) that target different databases
-  (e.g. PostgreSQL, SQLite, any database supporting Flight SQL).
+2. A set of concrete implementations of that API in different languages and
+   drivers for different databases (see :doc:`driver/status`).
 
 Why not just use JDBC/ODBC?
 ===========================

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -22,14 +22,13 @@ Frequently Asked Questions (FAQ)
 What exactly is ADBC?
 =====================
 
-At a high level, you can think of ADBC as a standard for Arrow-native access to
-databases. At a lower level, ADBC is two separate things:
+At a high level, ADBC is the standard for Arrow-native access to databases. At a
+lower level, ADBC is two separate but related things:
 
-1. An abstract API, with definitions in different languages (currently C, Go,
-   Java, and Rust), for working with databases and Arrow data.
+1. An abstract API for working with databases and Arrow data.
 
-2. A set of concrete implementations of that API in different languages and
-   drivers for different databases (see :doc:`driver/status`).
+2. A set of concrete implementations of that abstract API in different languages
+   and drivers for different databases (see :doc:`driver/status`).
 
 Why not just use JDBC/ODBC?
 ===========================


### PR DESCRIPTION
This PR is a bit of a check on my understanding. There are a few changes here:

1. Changed first sentence to help draw the reader in a bit better.
2. Changes the language "a set of abstract APIs" around. Is it more accurate to say there's one abstract API and that there are interface definitions in a few languages, most recently including Rust?
3. Remove the "For example..." as it felt out of place and slows the reader down from getting to bullet point 2.
4. Instead of referencing an easily out of date list of implementations, just link to the driver status page.