### PR TITLE
fix(csharp/src/Drivers/Apache): Fix setting foreign schema/table in GetCrossReference

### DIFF
--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2Connection.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2Connection.cs
@@ -1139,11 +1139,11 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
             {
                 req.ForeignCatalogName = foreignCatalogName!;
             }
-            if (schemaName != null)
+            if (foreignSchemaName != null)
             {
                 req.ForeignSchemaName = foreignSchemaName!;
             }
-            if (tableName != null)
+            if (foreignTableName != null)
             {
                 req.ForeignTableName = foreignTableName!;
             }


### PR DESCRIPTION
Currently, calling GetCrossReference with just ForeignCatalogName, ForeignSchemaName, and ForeignTableName parameters fails because these parameters aren't properly set on the Thrift request. 

This PR fixes the typo

Tested E2E locally and it works
```
          statement.SqlQuery = "getcrossreference";
          statement.SetOption(ApacheParameters.IsMetadataCommand, "true");
          statement.SetOption(ApacheParameters.ForeignCatalogName, "powerbi");
          statement.SetOption(ApacheParameters.ForeignSchemaName, "default");
          statement.SetOption(ApacheParameters.ForeignTableName, "nyc_taxi_tripdata");
```