### PR TITLE
fix(r/adbcsnowflake): Fix configuration of adbcsnowflake when configure is run from a git shell

### DIFF
--- a/r/adbcsnowflake/configure
+++ b/r/adbcsnowflake/configure
@@ -144,7 +144,7 @@ fi
 # On OSX we need -framework Security because of some dependency somewhere
 if [ `uname` = "Darwin" ]; then
   PKG_LIBS="-framework Security -lresolv $PKG_LIBS"
-elif uname | grep -e "MSYS" >/dev/null ; then
+elif uname | grep -e "MSYS" -e "MINGW" >/dev/null; then
   # Windows
   PKG_LIBS="$PKG_LIBS"
 else


### PR DESCRIPTION
Closes #2767 

It seems like the RTools shell identifies itself as `MSYS_NT...` whereas the git shell identifies itself as `MINGW64_NT...`. It looks like r-universe configures using the git shell? We can support both!