### PR TITLE
feat(csharp/src/Drivers/Databricks): Integrate ProxyConfigurations with Drivers

### DIFF
--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2HttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2HttpConnection.cs
@@ -36,8 +36,13 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
     {
         private const string BasicAuthenticationScheme = "Basic";
 
+        private readonly HiveServer2ProxyConfigurator _proxyConfigurator;
+
         public HiveServer2HttpConnection(IReadOnlyDictionary<string, string> properties) : base(properties)
         {
+            ValidateProperties();
+            _proxyConfigurator = HiveServer2ProxyConfigurator.FromProperties(properties);
+            _productVersion = new Lazy<string>(() => GetProductVersion(), LazyThreadSafetyMode.PublicationOnly);
         }
 
         protected override void ValidateAuthentication()
@@ -138,7 +143,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
             Uri baseAddress = GetBaseAddress(uri, hostName, path, port, HiveServer2Parameters.HostName, TlsOptions.IsTlsEnabled);
             AuthenticationHeaderValue? authenticationHeaderValue = GetAuthenticationHeaderValue(authTypeValue, username, password);
 
-            HttpClientHandler httpClientHandler = HiveServer2TlsImpl.NewHttpClientHandler(TlsOptions);
+            HttpClientHandler httpClientHandler = HiveServer2TlsImpl.NewHttpClientHandler(TlsOptions, _proxyConfigurator);
             httpClientHandler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
             HttpClient httpClient = new(httpClientHandler);
             httpClient.BaseAddress = baseAddress;

--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2HttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2HttpConnection.cs
@@ -40,9 +40,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
 
         public HiveServer2HttpConnection(IReadOnlyDictionary<string, string> properties) : base(properties)
         {
-            ValidateProperties();
             _proxyConfigurator = HiveServer2ProxyConfigurator.FromProperties(properties);
-            _productVersion = new Lazy<string>(() => GetProductVersion(), LazyThreadSafetyMode.PublicationOnly);
         }
 
         protected override void ValidateAuthentication()

--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2ProxyConfigurator.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2ProxyConfigurator.cs
@@ -63,7 +63,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
                     throw new ArgumentNullException(nameof(proxyPort));
             }
 
-            if (proxyAuth)
+            if (useProxy && proxyAuth)
             {
                 if (proxyUid == null)
                     throw new ArgumentNullException(nameof(proxyUid));
@@ -78,7 +78,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
             _proxyUid = proxyUid;
             _proxyPwd = proxyPwd;
 
-            if (!string.IsNullOrEmpty(proxyIgnoreList))
+            if (useProxy && !string.IsNullOrEmpty(proxyIgnoreList))
             {
                 _proxyBypassList = ParseProxyIgnoreList(proxyIgnoreList);
             }

--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2TlsImpl.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2TlsImpl.cs
@@ -72,7 +72,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
             return tlsProperties;
         }
 
-        static internal HttpClientHandler NewHttpClientHandler(TlsProperties tlsProperties, HiveServer2ProxyConfigurator? proxyConfigurator)
+        static internal HttpClientHandler NewHttpClientHandler(TlsProperties tlsProperties, HiveServer2ProxyConfigurator proxyConfigurator)
         {
             HttpClientHandler httpClientHandler = new();
             if (tlsProperties.IsTlsEnabled)
@@ -99,10 +99,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
                     return chain2.Build(certificate);
                 };
             }
-            if (proxyConfigurator != null)
-            {
-                proxyConfigurator.ConfigureProxy(httpClientHandler);
-            }
+            proxyConfigurator.ConfigureProxy(httpClientHandler);
             return httpClientHandler;
         }
 

--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2TlsImpl.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2TlsImpl.cs
@@ -72,7 +72,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
             return tlsProperties;
         }
 
-        static internal HttpClientHandler NewHttpClientHandler(TlsProperties tlsProperties)
+        static internal HttpClientHandler NewHttpClientHandler(TlsProperties tlsProperties, HiveServer2ProxyConfigurator? proxyConfigurator)
         {
             HttpClientHandler httpClientHandler = new();
             if (tlsProperties.IsTlsEnabled)
@@ -98,6 +98,10 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
                     // Build the chain and verify
                     return chain2.Build(certificate);
                 };
+            }
+            if (proxyConfigurator != null)
+            {
+                proxyConfigurator.ConfigureProxy(httpClientHandler);
             }
             return httpClientHandler;
         }

--- a/csharp/src/Drivers/Apache/Hive2/README.md
+++ b/csharp/src/Drivers/Apache/Hive2/README.md
@@ -53,13 +53,13 @@ but can also be passed in the call to `AdbcDatabase.Connect`.
 | `adbc.http_options.tls.allow_self_signed` | If self signed tls/ssl certificate needs to be allowed or not. One of `True`, `False` | `False` |
 | `adbc.http_options.tls.allow_hostname_mismatch` | If hostname mismatch is allowed for ssl. One of `True`, `False` | `False` |
 | `adbc.http_options.tls.trusted_certificate_path` | The full path of the tls/ssl certificate .pem file containing custom CA certificates for verifying the server when connecting over TLS | `` |
-| `adbc.proxy_options.use_proxy` | Whether to use a proxy for HTTP connections. One of `True`, `False` | `False` |
-| `adbc.proxy_options.proxy_host` | Hostname or IP address of the proxy server. Required when use_proxy is True | |
-| `adbc.proxy_options.proxy_port` | Port number of the proxy server. Required when use_proxy is True | |
-| `adbc.proxy_options.proxy_ignore_list` | Comma-separated list of hosts or domains that should bypass the proxy. For example: "localhost,127.0.0.1,.internal.domain.com". Supports wildcard patterns like "*.internal.domain.com" | |
-| `adbc.proxy_options.proxy_auth` | Whether to enable proxy authentication. One of `True`, `False` | `False` |
-| `adbc.proxy_options.proxy_uid` | Username for proxy authentication. Required when proxy_auth is True | |
-| `adbc.proxy_options.proxy_pwd` | Password for proxy authentication. Required when proxy_auth is True | |
+| `adbc.proxy_options.use_proxy` | Currently only supported by spark drivers. Whether to use a proxy for HTTP connections. One of `True`, `False` | `False` |
+| `adbc.proxy_options.proxy_host` | Currently only supported by spark drivers. Hostname or IP address of the proxy server. Required when use_proxy is True | |
+| `adbc.proxy_options.proxy_port` | Currently only supported by spark drivers. Port number of the proxy server. Required when use_proxy is True | |
+| `adbc.proxy_options.proxy_ignore_list` | Currently only supported by spark drivers. Comma-separated list of hosts or domains that should bypass the proxy. For example: "localhost,127.0.0.1,.internal.domain.com". Supports wildcard patterns like "*.internal.domain.com" | |
+| `adbc.proxy_options.proxy_auth` | Currently only supported by spark drivers. Whether to enable proxy authentication. One of `True`, `False` | `False` |
+| `adbc.proxy_options.proxy_uid` | Currently only supported by spark drivers. Username for proxy authentication. Required when proxy_auth is True | |
+| `adbc.proxy_options.proxy_pwd` | Currently only supported by spark drivers. Password for proxy authentication. Required when proxy_auth is True | |
 
 ## Timeout Configuration
 

--- a/csharp/src/Drivers/Apache/Hive2/README.md
+++ b/csharp/src/Drivers/Apache/Hive2/README.md
@@ -53,13 +53,13 @@ but can also be passed in the call to `AdbcDatabase.Connect`.
 | `adbc.http_options.tls.allow_self_signed` | If self signed tls/ssl certificate needs to be allowed or not. One of `True`, `False` | `False` |
 | `adbc.http_options.tls.allow_hostname_mismatch` | If hostname mismatch is allowed for ssl. One of `True`, `False` | `False` |
 | `adbc.http_options.tls.trusted_certificate_path` | The full path of the tls/ssl certificate .pem file containing custom CA certificates for verifying the server when connecting over TLS | `` |
-| `adbc.proxy_options.use_proxy` | Currently only supported by spark drivers. Whether to use a proxy for HTTP connections. One of `True`, `False` | `False` |
-| `adbc.proxy_options.proxy_host` | Currently only supported by spark drivers. Hostname or IP address of the proxy server. Required when use_proxy is True | |
-| `adbc.proxy_options.proxy_port` | Currently only supported by spark drivers. Port number of the proxy server. Required when use_proxy is True | |
-| `adbc.proxy_options.proxy_ignore_list` | Currently only supported by spark drivers. Comma-separated list of hosts or domains that should bypass the proxy. For example: "localhost,127.0.0.1,.internal.domain.com". Supports wildcard patterns like "*.internal.domain.com" | |
-| `adbc.proxy_options.proxy_auth` | Currently only supported by spark drivers. Whether to enable proxy authentication. One of `True`, `False` | `False` |
-| `adbc.proxy_options.proxy_uid` | Currently only supported by spark drivers. Username for proxy authentication. Required when proxy_auth is True | |
-| `adbc.proxy_options.proxy_pwd` | Currently only supported by spark drivers. Password for proxy authentication. Required when proxy_auth is True | |
+| `adbc.proxy_options.use_proxy` | Whether to use a proxy for HTTP connections. Only feature-complete in Spark driver. One of `True`, `False` | `False` |
+| `adbc.proxy_options.proxy_host` | Hostname or IP address of the proxy server. Only feature-complete in Spark driver. Required when use_proxy is True | |
+| `adbc.proxy_options.proxy_port` | Port number of the proxy server. Only feature-complete in Spark driver. Required when use_proxy is True | |
+| `adbc.proxy_options.proxy_ignore_list` | Comma-separated list of hosts or domains that should bypass the proxy. Only feature-complete in Spark driver. For example: "localhost,127.0.0.1,.internal.domain.com". Supports wildcard patterns like "*.internal.domain.com" | |
+| `adbc.proxy_options.proxy_auth` | Whether to enable proxy authentication. Only feature-complete in Spark driver. One of `True`, `False` | `False` |
+| `adbc.proxy_options.proxy_uid` | Username for proxy authentication. Only feature-complete in Spark driver. Required when proxy_auth is True | |
+| `adbc.proxy_options.proxy_pwd` | Password for proxy authentication. Only feature-complete in Spark driver. Required when proxy_auth is True | |
 
 ## Timeout Configuration
 

--- a/csharp/src/Drivers/Apache/Hive2/README.md
+++ b/csharp/src/Drivers/Apache/Hive2/README.md
@@ -53,6 +53,13 @@ but can also be passed in the call to `AdbcDatabase.Connect`.
 | `adbc.http_options.tls.allow_self_signed` | If self signed tls/ssl certificate needs to be allowed or not. One of `True`, `False` | `False` |
 | `adbc.http_options.tls.allow_hostname_mismatch` | If hostname mismatch is allowed for ssl. One of `True`, `False` | `False` |
 | `adbc.http_options.tls.trusted_certificate_path` | The full path of the tls/ssl certificate .pem file containing custom CA certificates for verifying the server when connecting over TLS | `` |
+| `adbc.proxy_options.use_proxy` | Whether to use a proxy for HTTP connections. One of `True`, `False` | `False` |
+| `adbc.proxy_options.proxy_host` | Hostname or IP address of the proxy server. Required when use_proxy is True | |
+| `adbc.proxy_options.proxy_port` | Port number of the proxy server. Required when use_proxy is True | |
+| `adbc.proxy_options.proxy_ignore_list` | Comma-separated list of hosts or domains that should bypass the proxy. For example: "localhost,127.0.0.1,.internal.domain.com". Supports wildcard patterns like "*.internal.domain.com" | |
+| `adbc.proxy_options.proxy_auth` | Whether to enable proxy authentication. One of `True`, `False` | `False` |
+| `adbc.proxy_options.proxy_uid` | Username for proxy authentication. Required when proxy_auth is True | |
+| `adbc.proxy_options.proxy_pwd` | Password for proxy authentication. Required when proxy_auth is True | |
 
 ## Timeout Configuration
 

--- a/csharp/src/Drivers/Apache/Impala/ImpalaHttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Impala/ImpalaHttpConnection.cs
@@ -38,8 +38,11 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Impala
     {
         private const string BasicAuthenticationScheme = "Basic";
 
+        private readonly HiveServer2ProxyConfigurator _proxyConfigurator;
+
         public ImpalaHttpConnection(IReadOnlyDictionary<string, string> properties) : base(properties)
         {
+            _proxyConfigurator = HiveServer2ProxyConfigurator.FromProperties(properties);
         }
 
         protected override void ValidateAuthentication()
@@ -142,7 +145,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Impala
             Uri baseAddress = GetBaseAddress(uri, hostName, path, port, ImpalaParameters.HostName, TlsOptions.IsTlsEnabled);
             AuthenticationHeaderValue? authenticationHeaderValue = GetAuthenticationHeaderValue(authTypeValue, username, password);
 
-            HttpClientHandler httpClientHandler = HiveServer2TlsImpl.NewHttpClientHandler(TlsOptions);
+            HttpClientHandler httpClientHandler = HiveServer2TlsImpl.NewHttpClientHandler(TlsOptions, _proxyConfigurator);
             HttpClient httpClient = new(httpClientHandler);
             httpClient.BaseAddress = baseAddress;
             httpClient.DefaultRequestHeaders.Authorization = authenticationHeaderValue;

--- a/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkHttpConnection.cs
@@ -39,8 +39,11 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
         private const string BasicAuthenticationScheme = "Basic";
         private const string BearerAuthenticationScheme = "Bearer";
 
+        protected readonly HiveServer2ProxyConfigurator _proxyConfigurator;
+
         public SparkHttpConnection(IReadOnlyDictionary<string, string> properties) : base(properties)
         {
+            _proxyConfigurator = HiveServer2ProxyConfigurator.FromProperties(properties);
         }
 
         protected override void ValidateAuthentication()
@@ -148,7 +151,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
 
         protected virtual HttpMessageHandler CreateHttpHandler()
         {
-            return HiveServer2TlsImpl.NewHttpClientHandler(TlsOptions);
+            return HiveServer2TlsImpl.NewHttpClientHandler(TlsOptions, _proxyConfigurator);
         }
 
         protected override TTransport CreateTransport()

--- a/csharp/src/Drivers/Databricks/Auth/OAuthClientCredentialsProvider.cs
+++ b/csharp/src/Drivers/Databricks/Auth/OAuthClientCredentialsProvider.cs
@@ -72,6 +72,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
             string clientSecret,
             string host,
             string scope = "sql",
+            HttpClient httpClient,
             int timeoutMinutes = 1,
             int refreshBufferMinutes = 5)
         {
@@ -83,7 +84,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
             _scope = scope ?? throw new ArgumentNullException(nameof(scope));
             _tokenEndpoint = DetermineTokenEndpoint();
 
-            _httpClient = new HttpClient();
+            _httpClient = httpClient;
             _httpClient.Timeout = TimeSpan.FromMinutes(_timeoutMinutes);
         }
 

--- a/csharp/src/Drivers/Databricks/Auth/OAuthClientCredentialsProvider.cs
+++ b/csharp/src/Drivers/Databricks/Auth/OAuthClientCredentialsProvider.cs
@@ -61,6 +61,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
         /// <summary>
         /// Initializes a new instance of the <see cref="OAuthClientCredentialsService"/> class.
         /// </summary>
+        /// <param name="httpClient">The HTTP client to use for requests.</param>
         /// <param name="clientId">The OAuth client ID.</param>
         /// <param name="clientSecret">The OAuth client secret.</param>
         /// <param name="host">The base host of the Databricks workspace.</param>
@@ -68,11 +69,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
         /// <param name="timeoutMinutes">The timeout in minutes for HTTP requests.</param>
         /// <param name="refreshBufferMinutes">The number of minutes before token expiration to refresh the token.</param>
         public OAuthClientCredentialsProvider(
+            HttpClient httpClient,
             string clientId,
             string clientSecret,
             string host,
             string scope = "sql",
-            HttpClient httpClient,
             int timeoutMinutes = 1,
             int refreshBufferMinutes = 5)
         {

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloadManager.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloadManager.cs
@@ -157,8 +157,8 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
             _downloadQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), prefetchCount * 2);
             _resultQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), prefetchCount * 2);
 
-            // Initialize the HTTP client
             _httpClient = httpClient;
+            _httpClient.Timeout = TimeSpan.FromMinutes(timeoutMinutes);
 
             // Initialize the result fetcher
             _resultFetcher = new CloudFetchResultFetcher(

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloadManager.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloadManager.cs
@@ -57,7 +57,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
         /// <param name="statement">The HiveServer2 statement.</param>
         /// <param name="schema">The Arrow schema.</param>
         /// <param name="isLz4Compressed">Whether the results are LZ4 compressed.</param>
-        public CloudFetchDownloadManager(DatabricksStatement statement, Schema schema, bool isLz4Compressed)
+        public CloudFetchDownloadManager(DatabricksStatement statement, Schema schema, bool isLz4Compressed, HttpClient httpClient)
         {
             _statement = statement ?? throw new ArgumentNullException(nameof(statement));
             _schema = schema ?? throw new ArgumentNullException(nameof(schema));
@@ -158,10 +158,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
             _resultQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), prefetchCount * 2);
 
             // Initialize the HTTP client
-            _httpClient = new HttpClient
-            {
-                Timeout = TimeSpan.FromMinutes(timeoutMinutes)
-            };
+            _httpClient = httpClient;
 
             // Initialize the result fetcher
             _resultFetcher = new CloudFetchResultFetcher(

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchReader.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchReader.cs
@@ -48,7 +48,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
         /// <param name="statement">The Databricks statement.</param>
         /// <param name="schema">The Arrow schema.</param>
         /// <param name="isLz4Compressed">Whether the results are LZ4 compressed.</param>
-        public CloudFetchReader(DatabricksStatement statement, Schema schema, bool isLz4Compressed)
+        public CloudFetchReader(DatabricksStatement statement, Schema schema, bool isLz4Compressed, HttpClient httpClient)
         {
             this.schema = schema;
             this.isLz4Compressed = isLz4Compressed;
@@ -71,14 +71,14 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
             // Initialize the download manager
             if (isPrefetchEnabled)
             {
-                downloadManager = new CloudFetchDownloadManager(statement, schema, isLz4Compressed);
+                downloadManager = new CloudFetchDownloadManager(statement, schema, isLz4Compressed, httpClient);
                 downloadManager.StartAsync().Wait();
             }
             else
             {
                 // For now, we only support the prefetch implementation
                 // This flag is reserved for future use if we need to support a non-prefetch mode
-                downloadManager = new CloudFetchDownloadManager(statement, schema, isLz4Compressed);
+                downloadManager = new CloudFetchDownloadManager(statement, schema, isLz4Compressed, httpClient);
                 downloadManager.StartAsync().Wait();
             }
         }

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -196,15 +196,15 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 Properties.TryGetValue(DatabricksParameters.OAuthClientId, out string? clientId);
                 Properties.TryGetValue(DatabricksParameters.OAuthClientSecret, out string? clientSecret);
                 Properties.TryGetValue(DatabricksParameters.OAuthScope, out string? scope);
-                
+
                 HttpClient OauthHttpClient = new HttpClient(HiveServer2TlsImpl.NewHttpClientHandler(TlsOptions, _proxyConfigurator));
 
                 var tokenProvider = new OAuthClientCredentialsProvider(
+                    OauthHttpClient,
                     clientId!,
                     clientSecret!,
                     host!,
                     scope: scope ?? "sql",
-                    OauthHttpClient,
                     timeoutMinutes: 1
                 );
 

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -24,6 +24,7 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow.Adbc.Drivers.Apache;
+using Apache.Arrow.Adbc.Drivers.Apache.Hive2;
 using Apache.Arrow.Adbc.Drivers.Apache.Spark;
 using Apache.Arrow.Adbc.Drivers.Databricks.Auth;
 using Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch;
@@ -195,12 +196,15 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 Properties.TryGetValue(DatabricksParameters.OAuthClientId, out string? clientId);
                 Properties.TryGetValue(DatabricksParameters.OAuthClientSecret, out string? clientSecret);
                 Properties.TryGetValue(DatabricksParameters.OAuthScope, out string? scope);
+                
+                HttpClient OauthHttpClient = new HttpClient(HiveServer2TlsImpl.NewHttpClientHandler(TlsOptions, _proxyConfigurator));
 
                 var tokenProvider = new OAuthClientCredentialsProvider(
                     clientId!,
                     clientSecret!,
                     host!,
                     scope: scope ?? "sql",
+                    OauthHttpClient,
                     timeoutMinutes: 1
                 );
 
@@ -255,7 +259,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             // Choose the appropriate reader based on the result format
             if (resultFormat == TSparkRowSetType.URL_BASED_SET)
             {
-                return new CloudFetchReader(databricksStatement, schema, isLz4Compressed);
+                HttpClient cloudFetchHttpClient = new HttpClient(HiveServer2TlsImpl.NewHttpClientHandler(TlsOptions, _proxyConfigurator));
+                return new CloudFetchReader(databricksStatement, schema, isLz4Compressed, cloudFetchHttpClient);
             }
             else
             {

--- a/csharp/test/Drivers/Apache/ApacheTestConfiguration.cs
+++ b/csharp/test/Drivers/Apache/ApacheTestConfiguration.cs
@@ -68,31 +68,31 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache
     {
         [JsonPropertyName("tls"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public TlsTestConfiguration? Tls { get; set; }
-        
+
         [JsonPropertyName("proxy"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public ProxyTestConfiguration? Proxy { get; set; }
     }
-    
+
     public class ProxyTestConfiguration
     {
         [JsonPropertyName("use_proxy"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public bool? UseProxy { get; set; }
-        
+        public string? UseProxy { get; set; }
+
         [JsonPropertyName("proxy_host"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? ProxyHost { get; set; }
-        
+
         [JsonPropertyName("proxy_port"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public int? ProxyPort { get; set; }
-        
+
         [JsonPropertyName("proxy_auth"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-        public bool? ProxyAuth { get; set; }
-        
+        public string? ProxyAuth { get; set; }
+
         [JsonPropertyName("proxy_uid"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? ProxyUid { get; set; }
-        
+
         [JsonPropertyName("proxy_pwd"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? ProxyPwd { get; set; }
-        
+
         [JsonPropertyName("proxy_ignore_list"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? ProxyIgnoreList { get; set; }
     }

--- a/csharp/test/Drivers/Apache/ApacheTestConfiguration.cs
+++ b/csharp/test/Drivers/Apache/ApacheTestConfiguration.cs
@@ -68,6 +68,33 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache
     {
         [JsonPropertyName("tls"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public TlsTestConfiguration? Tls { get; set; }
+        
+        [JsonPropertyName("proxy"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public ProxyTestConfiguration? Proxy { get; set; }
+    }
+    
+    public class ProxyTestConfiguration
+    {
+        [JsonPropertyName("use_proxy"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool? UseProxy { get; set; }
+        
+        [JsonPropertyName("proxy_host"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? ProxyHost { get; set; }
+        
+        [JsonPropertyName("proxy_port"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int? ProxyPort { get; set; }
+        
+        [JsonPropertyName("proxy_auth"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool? ProxyAuth { get; set; }
+        
+        [JsonPropertyName("proxy_uid"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? ProxyUid { get; set; }
+        
+        [JsonPropertyName("proxy_pwd"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? ProxyPwd { get; set; }
+        
+        [JsonPropertyName("proxy_ignore_list"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string? ProxyIgnoreList { get; set; }
     }
 
     public class TlsTestConfiguration

--- a/csharp/test/Drivers/Apache/Hive2/HiveServer2TestEnvironment.cs
+++ b/csharp/test/Drivers/Apache/Hive2/HiveServer2TestEnvironment.cs
@@ -132,6 +132,40 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Hive2
                         parameters.Add(HttpTlsOptions.TrustedCertificatePath, tlsOptions.TrustedCertificatePath!);
                     }
                 }
+                
+                // Add proxy configuration if provided
+                if (testConfiguration.HttpOptions.Proxy != null)
+                {
+                    ProxyTestConfiguration proxyOptions = testConfiguration.HttpOptions.Proxy;
+                    if (proxyOptions.UseProxy.HasValue)
+                    {
+                        parameters.Add(HttpProxyOptions.UseProxy, proxyOptions.UseProxy.Value ? "1" : "0");
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyHost))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyHost, proxyOptions.ProxyHost!);
+                    }
+                    if (proxyOptions.ProxyPort.HasValue)
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyPort, proxyOptions.ProxyPort.Value.ToString());
+                    }
+                    if (proxyOptions.ProxyAuth.HasValue)
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyAuth, proxyOptions.ProxyAuth.Value ? "1" : "0");
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyUid))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyUID, proxyOptions.ProxyUid!);
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyPwd))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyPWD, proxyOptions.ProxyPwd!);
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyIgnoreList))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyIgnoreList, proxyOptions.ProxyIgnoreList!);
+                    }
+                }
             }
 
             return parameters;

--- a/csharp/test/Drivers/Apache/Hive2/HiveServer2TestEnvironment.cs
+++ b/csharp/test/Drivers/Apache/Hive2/HiveServer2TestEnvironment.cs
@@ -132,14 +132,14 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Hive2
                         parameters.Add(HttpTlsOptions.TrustedCertificatePath, tlsOptions.TrustedCertificatePath!);
                     }
                 }
-                
+
                 // Add proxy configuration if provided
                 if (testConfiguration.HttpOptions.Proxy != null)
                 {
                     ProxyTestConfiguration proxyOptions = testConfiguration.HttpOptions.Proxy;
-                    if (proxyOptions.UseProxy.HasValue)
+                    if (!string.IsNullOrEmpty(proxyOptions.UseProxy))
                     {
-                        parameters.Add(HttpProxyOptions.UseProxy, proxyOptions.UseProxy.Value ? "1" : "0");
+                        parameters.Add(HttpProxyOptions.UseProxy, proxyOptions.UseProxy!);
                     }
                     if (!string.IsNullOrEmpty(proxyOptions.ProxyHost))
                     {
@@ -149,9 +149,9 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Hive2
                     {
                         parameters.Add(HttpProxyOptions.ProxyPort, proxyOptions.ProxyPort.Value.ToString());
                     }
-                    if (proxyOptions.ProxyAuth.HasValue)
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyAuth))
                     {
-                        parameters.Add(HttpProxyOptions.ProxyAuth, proxyOptions.ProxyAuth.Value ? "1" : "0");
+                        parameters.Add(HttpProxyOptions.ProxyAuth, proxyOptions.ProxyAuth!);
                     }
                     if (!string.IsNullOrEmpty(proxyOptions.ProxyUid))
                     {

--- a/csharp/test/Drivers/Apache/Spark/SparkTestEnvironment.cs
+++ b/csharp/test/Drivers/Apache/Spark/SparkTestEnvironment.cs
@@ -141,6 +141,40 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Spark
                         parameters.Add(HttpTlsOptions.TrustedCertificatePath, tlsOptions.TrustedCertificatePath!);
                     }
                 }
+
+                // Add proxy configuration if provided
+                if (testConfiguration.HttpOptions.Proxy != null)
+                {
+                    ProxyTestConfiguration proxyOptions = testConfiguration.HttpOptions.Proxy;
+                    if (!string.IsNullOrEmpty(proxyOptions.UseProxy))
+                    {
+                        parameters.Add(HttpProxyOptions.UseProxy, proxyOptions.UseProxy!);
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyHost))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyHost, proxyOptions.ProxyHost!);
+                    }
+                    if (proxyOptions.ProxyPort.HasValue)
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyPort, proxyOptions.ProxyPort.Value.ToString());
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyAuth))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyAuth, proxyOptions.ProxyAuth!);
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyUid))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyUID, proxyOptions.ProxyUid!);
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyPwd))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyPWD, proxyOptions.ProxyPwd!);
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyIgnoreList))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyIgnoreList, proxyOptions.ProxyIgnoreList!);
+                    }
+                }
             }
 
             return parameters;

--- a/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
+++ b/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
@@ -22,6 +22,7 @@ using Apache.Arrow.Adbc.Drivers.Databricks.Auth;
 using Xunit;
 using Xunit.Abstractions;
 using Apache.Arrow.Adbc.Tests.Drivers.Databricks;
+using System.Net.Http;
 
 namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
 {
@@ -56,6 +57,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
             }
 
             return new OAuthClientCredentialsProvider(
+                new HttpClient(),
                 TestConfiguration.OAuthClientId,
                 TestConfiguration.OAuthClientSecret,
                 host,

--- a/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
+++ b/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
@@ -14,15 +14,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
+using Apache.Arrow.Adbc.Drivers.Databricks.Auth;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Apache.Arrow.Adbc.Drivers.Databricks.Auth;
+using System.Net.Http;
 using Xunit;
 using Xunit.Abstractions;
-using Apache.Arrow.Adbc.Tests.Drivers.Databricks;
-using System.Net.Http;
 
 namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
 {
@@ -61,9 +59,9 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
                 TestConfiguration.OAuthClientId,
                 TestConfiguration.OAuthClientSecret,
                 host,
+                scope,
                 timeoutMinutes: 1,
-                refreshBufferMinutes: refreshBufferMinutes,
-                scope: scope);
+                refreshBufferMinutes: refreshBufferMinutes);
         }
 
         [SkippableFact]

--- a/csharp/test/Drivers/Databricks/DatabricksTestEnvironment.cs
+++ b/csharp/test/Drivers/Databricks/DatabricksTestEnvironment.cs
@@ -159,6 +159,40 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
                         parameters.Add(HttpTlsOptions.TrustedCertificatePath, tlsOptions.TrustedCertificatePath!);
                     }
                 }
+
+                // Add proxy configuration if provided
+                if (testConfiguration.HttpOptions.Proxy != null)
+                {
+                    ProxyTestConfiguration proxyOptions = testConfiguration.HttpOptions.Proxy;
+                    if (!string.IsNullOrEmpty(proxyOptions.UseProxy))
+                    {
+                        parameters.Add(HttpProxyOptions.UseProxy, proxyOptions.UseProxy!);
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyHost))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyHost, proxyOptions.ProxyHost!);
+                    }
+                    if (proxyOptions.ProxyPort.HasValue)
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyPort, proxyOptions.ProxyPort.Value.ToString());
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyAuth))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyAuth, proxyOptions.ProxyAuth!);
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyUid))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyUID, proxyOptions.ProxyUid!);
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyPwd))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyPWD, proxyOptions.ProxyPwd!);
+                    }
+                    if (!string.IsNullOrEmpty(proxyOptions.ProxyIgnoreList))
+                    {
+                        parameters.Add(HttpProxyOptions.ProxyIgnoreList, proxyOptions.ProxyIgnoreList!);
+                    }
+                }
             }
 
             return parameters;


### PR DESCRIPTION
Integrates proxy logic with the rest of the Spark-Driver. Also applies to Cloud-fetch and OAuth2 fetch.

Other drivers, like Impala driver, should be compatible with the change. However, it is not tested - so I marked in the README that it's not fully complete

To test, add the following to `DATABRICKS_TEST_CONFIG_FILE` environment variable:
```
  "http_options": {
    "proxy": {
      "use_proxy": "true",
      "proxy_host": "...",
      "proxy_port":..,
      "proxy_auth": "...", // if using basic auth
      "proxy_uid": "...",
      "proxy_pwd": "..."
    },
    "tls": { // you may need to enable depending on your proxy, or you need to trust the cert
      "enabled": ,
      "allow_self_signed": 
    }
  }
```

And inspect proxy traffic. Verified that it works in driver testing and Powerbi testing