### PR TITLE
fix(docs): update go install command in flight sql recipe

### DIFF
--- a/docs/source/python/recipe/flight_sql.rst
+++ b/docs/source/python/recipe/flight_sql.rst
@@ -24,7 +24,7 @@ SQLite.  You can run it yourself as follows:
 
 .. code-block:: shell
 
-   $ go install github.com/apache/arrow/go/v${ARROW_MAJOR_VERSION}/arrow/flight/flightsql/example/cmd/sqlite_flightsql_server@latest
+   $ go install github.com/apache/arrow-go/v${ARROW_MAJOR_VERSION}/arrow/flight/flightsql/example/cmd/sqlite_flightsql_server@latest
    $ sqlite_flightsql_server -host 0.0.0.0 -port 8080
 
 Other recipes work using the OSS version of Dremio_:


### PR DESCRIPTION
The Go Arrow implementation moved out of the mono repo to apache/arrow-go and this command should be updated to match. The current command technically still works because `arrow/go` wasn't pulled from gopkgs but I think using the new `arrow-go` repo is better. I've tested the go install command still works.