### PR TITLE
feat(csharp/src/Drivers/Databricks): Allow configurable auth scope for client-credentials flow

### DIFF
--- a/csharp/src/Drivers/Databricks/Auth/OAuthClientCredentialsProvider.cs
+++ b/csharp/src/Drivers/Databricks/Auth/OAuthClientCredentialsProvider.cs
@@ -215,5 +215,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
             _httpClient.Dispose();
         }
 
+
+        public string GetCachedTokenScope()
+        {
+            return _cachedToken?.Scope;
+        }
+
     }
 }

--- a/csharp/src/Drivers/Databricks/Auth/OAuthClientCredentialsProvider.cs
+++ b/csharp/src/Drivers/Databricks/Auth/OAuthClientCredentialsProvider.cs
@@ -229,11 +229,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
             _httpClient.Dispose();
         }
 
-
         public string? GetCachedTokenScope()
         {
             return _cachedToken?.Scope;
         }
-
     }
 }

--- a/csharp/src/Drivers/Databricks/Auth/OAuthClientCredentialsProvider.cs
+++ b/csharp/src/Drivers/Databricks/Auth/OAuthClientCredentialsProvider.cs
@@ -37,6 +37,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
         private readonly string _tokenEndpoint;
         private readonly int _timeoutMinutes;
         private readonly int _refreshBufferMinutes;
+        private readonly string _scope;
         private readonly SemaphoreSlim _tokenLock = new SemaphoreSlim(1, 1);
         private TokenInfo? _cachedToken;
 
@@ -60,13 +61,15 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
         /// </summary>
         /// <param name="clientId">The OAuth client ID.</param>
         /// <param name="clientSecret">The OAuth client secret.</param>
-        /// <param name="baseUri">The base URI of the Databricks workspace.</param>
+        /// <param name="host">The base host of the Databricks workspace.</param>
+        /// <param name="scope">The scope for the OAuth token.</param>
         /// <param name="timeoutMinutes">The timeout in minutes for HTTP requests.</param>
         /// <param name="refreshBufferMinutes">The number of minutes before token expiration to refresh the token.</param>
         public OAuthClientCredentialsProvider(
             string clientId,
             string clientSecret,
             string host,
+            string scope = "sql",
             int timeoutMinutes = 1,
             int refreshBufferMinutes = 5)
         {
@@ -75,6 +78,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
             _host = host ?? throw new ArgumentNullException(nameof(host));
             _timeoutMinutes = timeoutMinutes;
             _refreshBufferMinutes = refreshBufferMinutes;
+            _scope = scope ?? throw new ArgumentNullException(nameof(scope));
             _tokenEndpoint = DetermineTokenEndpoint();
 
             _httpClient = new HttpClient();
@@ -128,7 +132,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
             var requestContent = new FormUrlEncodedContent(new[]
             {
                 new KeyValuePair<string, string>("grant_type", "client_credentials"),
-                new KeyValuePair<string, string>("scope", "sql")
+                new KeyValuePair<string, string>("scope", _scope)
             });
 
             var request = new HttpRequestMessage(HttpMethod.Post, _tokenEndpoint)

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -194,11 +194,13 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 
                 Properties.TryGetValue(DatabricksParameters.OAuthClientId, out string? clientId);
                 Properties.TryGetValue(DatabricksParameters.OAuthClientSecret, out string? clientSecret);
+                Properties.TryGetValue(DatabricksParameters.OAuthScope, out string? scope);
 
                 var tokenProvider = new OAuthClientCredentialsProvider(
                     clientId!,
                     clientSecret!,
                     host!,
+                    scope: scope ?? "sql",
                     timeoutMinutes: 1
                 );
 

--- a/csharp/src/Drivers/Databricks/DatabricksParameters.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksParameters.cs
@@ -141,6 +141,13 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// This is the client secret you obtained when registering your application with Databricks.
         /// </summary>
         public const string OAuthClientSecret = "adbc.databricks.oauth.client_secret";
+
+        /// <summary>
+        /// The OAuth scope for client credentials flow.
+        /// Optional when grant_type is "client_credentials".
+        /// Default value is "sql" if not specified.
+        /// </summary>
+        public const string OAuthScope = "adbc.databricks.oauth.scope";
     }
 
     /// <summary>

--- a/csharp/src/Drivers/Databricks/readme.md
+++ b/csharp/src/Drivers/Databricks/readme.md
@@ -33,6 +33,7 @@ The Databricks ADBC driver supports the following authentication methods:
    - Set `adbc.databricks.oauth.grant_type` to `client_credentials`
    - Set `adbc.databricks.oauth.client_id` to your OAuth client ID
    - Set `adbc.databricks.oauth.client_secret` to your OAuth client secret
+   - Set `adbc.databricks.oauth.scope` to your auth scope (defaults to `"sql"`)
    - The driver will automatically handle token acquisition, renewal, and authentication with the Databricks service
 
 Basic (username and password) authentication is not supported at this time.

--- a/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
+++ b/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
@@ -126,13 +126,15 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
         public async Task GetAccessToken_WithCustomScope_ReturnsToken()
         {
             Skip.IfNot(!string.IsNullOrEmpty(TestConfiguration.OAuthClientId), "OAuth credentials not configured");
+            
+            String scope = "all-apis";
 
-            var service = CreateService(scope: TestConfiguration.OAuthScope ?? "sql");
+            var service = CreateService(scope: scope);
             var token = await service.GetAccessTokenAsync();
 
             Assert.NotNull(token);
             Assert.NotEmpty(token);
-            Assert.Equal(TestConfiguration.OAuthScope, service.GetCachedTokenScope());
+            Assert.Equal(scope, service.GetCachedTokenScope());
         }  
     }
 }

--- a/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
+++ b/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
@@ -126,15 +126,13 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
         public async Task GetAccessToken_WithCustomScope_ReturnsToken()
         {
             Skip.IfNot(!string.IsNullOrEmpty(TestConfiguration.OAuthClientId), "OAuth credentials not configured");
-            
             String scope = "all-apis";
-
             var service = CreateService(scope: scope);
             var token = await service.GetAccessTokenAsync();
 
             Assert.NotNull(token);
             Assert.NotEmpty(token);
             Assert.Equal(scope, service.GetCachedTokenScope());
-        }  
+        }
     }
 }

--- a/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
+++ b/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
@@ -32,7 +32,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
         {
         }
 
-        private OAuthClientCredentialsProvider CreateService(int refreshBufferMinutes = 5)
+        private OAuthClientCredentialsProvider CreateService(int refreshBufferMinutes = 5, string scope = "sql")
         {
             string host;
             if (!string.IsNullOrEmpty(TestConfiguration.HostName))
@@ -60,7 +60,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
                 TestConfiguration.OAuthClientSecret,
                 host,
                 timeoutMinutes: 1,
-                refreshBufferMinutes: refreshBufferMinutes);
+                refreshBufferMinutes: refreshBufferMinutes,
+                scope: scope);
         }
 
         [SkippableFact]
@@ -119,6 +120,18 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
 
             // Tokens should be different since we're forcing a refresh
             Assert.NotEqual(token1, token2);
+        }
+
+        [SkippableFact]
+        public async Task GetAccessToken_WithCustomScope_ReturnsToken()
+        {
+            Skip.IfNot(!string.IsNullOrEmpty(TestConfiguration.OAuthClientId), "OAuth credentials not configured");
+
+            var service = CreateService(scope: "custom_scope");
+            var token = await service.GetAccessTokenAsync();
+
+            Assert.NotNull(token);
+            Assert.NotEmpty(token);
         }
     }
 }

--- a/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
+++ b/csharp/test/Drivers/Databricks/Auth/OAuthClientCredentialsProviderTests.cs
@@ -127,11 +127,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
         {
             Skip.IfNot(!string.IsNullOrEmpty(TestConfiguration.OAuthClientId), "OAuth credentials not configured");
 
-            var service = CreateService(scope: "custom_scope");
+            var service = CreateService(scope: TestConfiguration.OAuthScope ?? "sql");
             var token = await service.GetAccessTokenAsync();
 
             Assert.NotNull(token);
             Assert.NotEmpty(token);
-        }
+            Assert.Equal(TestConfiguration.OAuthScope, service.GetCachedTokenScope());
+        }  
     }
 }

--- a/csharp/test/Drivers/Databricks/DatabricksTestConfiguration.cs
+++ b/csharp/test/Drivers/Databricks/DatabricksTestConfiguration.cs
@@ -30,5 +30,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
 
         [JsonPropertyName("client_secret"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string OAuthClientSecret { get; set; } = string.Empty;
+
+        [JsonPropertyName("scope"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string OAuthScope { get; set; } = string.Empty;
     }
 }

--- a/csharp/test/Drivers/Databricks/DatabricksTestEnvironment.cs
+++ b/csharp/test/Drivers/Databricks/DatabricksTestEnvironment.cs
@@ -105,6 +105,10 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             {
                 parameters.Add(DatabricksParameters.OAuthClientSecret, testConfiguration.OAuthClientSecret!);
             }
+            if (!string.IsNullOrEmpty(testConfiguration.OAuthScope))
+            {
+                parameters.Add(DatabricksParameters.OAuthScope, testConfiguration.OAuthScope!);
+            }
             if (!string.IsNullOrEmpty(testConfiguration.Type))
             {
                 parameters.Add(SparkParameters.Type, testConfiguration.Type!);


### PR DESCRIPTION
Makes auth-scope configurable for client-credentials.

Added a test; verified that it works.