### PR TITLE
fix(go/adbc/driver/snowflake): fix copy concurrency 0

### DIFF
--- a/docs/source/driver/snowflake.rst
+++ b/docs/source/driver/snowflake.rst
@@ -298,7 +298,7 @@ and resource usage may be tuned with the following options on the :c:struct:`Adb
     Maximum number of COPY operations to run concurrently. Bulk ingestion performance is optimized by executing COPY
     queries as files are still being uploaded. Snowflake COPY speed scales with warehouse size, so smaller warehouses
     may benefit from setting this value higher to ensure long-running COPY queries do not block newly uploaded files
-    from being loaded. Default is 4. If set to 0, there will be no limitation and instead a new COPY INTO query will 
+    from being loaded. Default is 4. If set to 0, there will be no limitation and instead a new COPY INTO query will
     be executed for each file that is uploaded. Cannot be negative.
 
 ``adbc.snowflake.statement.ingest_target_file_size``

--- a/docs/source/driver/snowflake.rst
+++ b/docs/source/driver/snowflake.rst
@@ -298,8 +298,8 @@ and resource usage may be tuned with the following options on the :c:struct:`Adb
     Maximum number of COPY operations to run concurrently. Bulk ingestion performance is optimized by executing COPY
     queries as files are still being uploaded. Snowflake COPY speed scales with warehouse size, so smaller warehouses
     may benefit from setting this value higher to ensure long-running COPY queries do not block newly uploaded files
-    from being loaded. Default is 4. If set to 0, only a single COPY query will be executed as part of ingestion,
-    once all files have finished uploading. Cannot be negative.
+    from being loaded. Default is 4. If set to 0, there will be no limitation and instead a new COPY INTO query will 
+    be executed for each file that is uploaded. Cannot be negative.
 
 ``adbc.snowflake.statement.ingest_target_file_size``
     Approximate size of Parquet files written during ingestion. Actual size will be slightly larger, depending on

--- a/go/adbc/driver/snowflake/bulk_ingestion.go
+++ b/go/adbc/driver/snowflake/bulk_ingestion.go
@@ -546,6 +546,9 @@ func runCopyTasks(ctx context.Context, cn snowflakeConn, tableName string, concu
 
 	ctx, cancel := context.WithCancel(ctx)
 	g, ctx := errgroup.WithContext(ctx)
+	if concurrency == 0 {
+		concurrency = -1 // if concurrency is 0, then treat it as unlimited
+	}
 	g.SetLimit(concurrency)
 
 	done := make(chan struct{})


### PR DESCRIPTION
fixes #2793 by checking for a concurrency of 0 and setting it to unlimited.