### PR TITLE
feat(csharp/src/Drivers/Databricks): Status poller improvements

### DIFF
--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloadManager.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloadManager.cs
@@ -273,7 +273,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
             _cancellationTokenSource?.Cancel();
 
             // Stop the operation status poller
-            DisposeOperationStatusPoller();
+            _operationStatusPoller?.Stop();
 
             // Stop the downloader
             await _downloader.StopAsync().ConfigureAwait(false);

--- a/csharp/src/Drivers/Databricks/DatabricksOperationStatusPoller.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksOperationStatusPoller.cs
@@ -87,6 +87,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             }
         }
 
+        public void Stop()
+        {
+            _internalCts?.Cancel();
+        }
+
         public void Dispose()
         {
             if (_internalCts != null)

--- a/csharp/src/Drivers/Databricks/DatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksReader.cs
@@ -53,16 +53,13 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 }
             }
             _operationStatusPoller = new DatabricksOperationStatusPoller(statement);
+            _operationStatusPoller.Start();
         }
 
         public Schema Schema { get { return schema; } }
 
         public async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
         {
-            if (_operationStatusPoller != null && !_operationStatusPoller.IsStarted)
-            {
-                _operationStatusPoller.Start(cancellationToken);
-            }
             while (true)
             {
                 if (this.reader != null)
@@ -98,7 +95,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 if (!response.HasMoreRows)
                 {
                     this.statement = null;
-                    DisposeOperationStatusPoller();
+                    _operationStatusPoller?.Stop();
                 }
             }
         }


### PR DESCRIPTION
This PR shifts polling start Upon DatabricksReader initialization. There is some risk that upon query execution completion, `readNextBatchAsync` is not called until much later. This increases the polling time span.