### PR TITLE
feat(csharp/src/Drivers/Databricks): BaseDatabricksReader

### DIFF
--- a/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
@@ -1,0 +1,93 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow;
+using Apache.Arrow.Ipc;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks
+{
+    /// <summary>
+    /// Base class for Databricks readers that handles common functionality. Handles the operation status poller.
+    /// </summary>
+    internal abstract class BaseDatabricksReader : IArrowArrayStream
+    {
+        protected DatabricksStatement? statement;
+        protected readonly Schema schema;
+        protected readonly bool isLz4Compressed;
+        protected DatabricksOperationStatusPoller? operationStatusPoller;
+        private bool isDisposed;
+
+        protected BaseDatabricksReader(DatabricksStatement statement, Schema schema, bool isLz4Compressed)
+        {
+            this.schema = schema;
+            this.isLz4Compressed = isLz4Compressed;
+            this.statement = statement;
+            if (statement.DirectResults != null && !statement.DirectResults.ResultSet.HasMoreRows) {
+                return;
+            }
+            operationStatusPoller = new DatabricksOperationStatusPoller(statement);
+            operationStatusPoller.Start();
+        }
+
+        public Schema Schema { get { return schema; } }
+
+        protected void StopOperationStatusPoller()
+        {
+            operationStatusPoller?.Stop();
+        }
+
+        public void Dispose()
+        {
+            if (isDisposed)
+            {
+                return;
+            }
+
+            DisposeOperationStatusPoller();
+            DisposeResources();
+            isDisposed = true;
+        }
+
+
+        protected virtual void DisposeResources()
+        {
+        }
+
+        protected void DisposeOperationStatusPoller()
+        {
+            if (operationStatusPoller != null)
+            {
+                operationStatusPoller.Stop();
+                operationStatusPoller.Dispose();
+                operationStatusPoller = null;
+            }
+        }
+
+        protected void ThrowIfDisposed()
+        {
+            if (isDisposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+        }
+
+        public abstract ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
@@ -39,7 +39,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             this.schema = schema;
             this.isLz4Compressed = isLz4Compressed;
             this.statement = statement;
-            if (statement.DirectResults != null && !statement.DirectResults.ResultSet.HasMoreRows) {
+            if (statement.DirectResults != null && !statement.DirectResults.ResultSet.HasMoreRows)
+            {
                 return;
             }
             operationStatusPoller = new DatabricksOperationStatusPoller(statement);
@@ -64,7 +65,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             DisposeResources();
             isDisposed = true;
         }
-
 
         protected virtual void DisposeResources()
         {

--- a/csharp/src/Drivers/Databricks/DatabricksOperationStatusPoller.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksOperationStatusPoller.cs
@@ -87,6 +87,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             }
         }
 
+        public void Stop()
+        {
+            _internalCts?.Cancel();
+        }
+
         public void Dispose()
         {
             if (_internalCts != null)

--- a/csharp/src/Drivers/Databricks/DatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksReader.cs
@@ -25,22 +25,14 @@ using Apache.Hive.Service.Rpc.Thrift;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks
 {
-    internal sealed class DatabricksReader : IArrowArrayStream
+    internal sealed class DatabricksReader : BaseDatabricksReader
     {
-        DatabricksStatement? statement;
-        Schema schema;
         List<TSparkArrowBatch>? batches;
         int index;
         IArrowReader? reader;
-        bool isLz4Compressed;
-        private DatabricksOperationStatusPoller? _operationStatusPoller;
 
-        public DatabricksReader(DatabricksStatement statement, Schema schema, bool isLz4Compressed)
+        public DatabricksReader(DatabricksStatement statement, Schema schema, bool isLz4Compressed) : base(statement, schema, isLz4Compressed)
         {
-            this.statement = statement;
-            this.schema = schema;
-            this.isLz4Compressed = isLz4Compressed;
-
             // If we have direct results, initialize the batches from them
             if (statement.HasDirectResults)
             {
@@ -52,17 +44,12 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                     return;
                 }
             }
-            _operationStatusPoller = new DatabricksOperationStatusPoller(statement);
         }
 
-        public Schema Schema { get { return schema; } }
-
-        public async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
+        public override async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
         {
-            if (_operationStatusPoller != null && !_operationStatusPoller.IsStarted)
-            {
-                _operationStatusPoller.Start(cancellationToken);
-            }
+            ThrowIfDisposed();
+
             while (true)
             {
                 if (this.reader != null)
@@ -98,7 +85,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 if (!response.HasMoreRows)
                 {
                     this.statement = null;
-                    DisposeOperationStatusPoller();
+                    StopOperationStatusPoller();
                 }
             }
         }
@@ -138,20 +125,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 throw new AdbcException(errorMessage, ex);
             }
             this.index++;
-        }
-
-        public void Dispose()
-        {
-            DisposeOperationStatusPoller();
-        }
-
-        private void DisposeOperationStatusPoller()
-        {
-            if (_operationStatusPoller != null)
-            {
-                _operationStatusPoller.Dispose();
-                _operationStatusPoller = null;
-            }
         }
     }
 }

--- a/csharp/src/Drivers/Databricks/DatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksReader.cs
@@ -73,6 +73,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 
                 if (this.statement == null)
                 {
+                    StopOperationStatusPoller();
                     return null;
                 }
 
@@ -85,7 +86,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 if (!response.HasMoreRows)
                 {
                     this.statement = null;
-                    StopOperationStatusPoller();
                 }
             }
         }

--- a/csharp/test/Drivers/Databricks/StatementTests.cs
+++ b/csharp/test/Drivers/Databricks/StatementTests.cs
@@ -451,7 +451,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             using var statement = connection.CreateStatement();
 
             // Execute a query that should return data - using a larger dataset to ensure multiple batches
-            statement.SqlQuery = "SELECT id, CAST(id AS STRING) as id_string, id * 2 as id_doubled FROM RANGE(3000000)";
+            statement.SqlQuery = "SELECT id, CAST(id AS STRING) as id_string, id * 2 as id_doubled FROM RANGE(30000000)";
             QueryResult result = statement.ExecuteQuery();
 
             Assert.NotNull(result.Stream);
@@ -482,7 +482,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             }
 
             // Verify we got all rows
-            Assert.Equal(3000000, totalRows);
+            Assert.Equal(30000000, totalRows);
             Assert.True(batchCount > 1, "Should have read multiple batches");
             OutputHelper?.WriteLine($"Successfully read {totalRows} rows in {batchCount} batches after 30 minute delay with {configName}");
         }

--- a/csharp/test/Drivers/Databricks/StatementTests.cs
+++ b/csharp/test/Drivers/Databricks/StatementTests.cs
@@ -436,13 +436,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
 
         // NOTE: this is a thirty minute test. As of writing, databricks commands have 20 minutes of idle time (and checked every 5 mintues)
         [SkippableTheory]
-        [InlineData(true, "CloudFetch enabled")]
-        [InlineData(false, "CloudFetch disabled")]
+        [InlineData(false, "CloudFetch disabled")] // TODO: test cloudfetch enabled
         public async Task StatusPollerKeepsQueryAlive(bool useCloudFetch, string configName)
         {
             OutputHelper?.WriteLine($"Testing status poller with long delay between reads ({configName})");
 
-            // Create a connection using the test configuration with a small batch size
+            // Create a connection using the test configuration
             var connectionParams = new Dictionary<string, string>
             {
                 [DatabricksParameters.UseCloudFetch] = useCloudFetch.ToString().ToLower()
@@ -451,24 +450,18 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             using var statement = connection.CreateStatement();
 
             // Execute a query that should return data - using a larger dataset to ensure multiple batches
-            statement.SqlQuery = "SELECT id, CAST(id AS STRING) as id_string, id * 2 as id_doubled FROM RANGE(30000000)";
+            statement.SqlQuery = "SELECT id, CAST(id AS STRING) as id_string, id * 2 as id_doubled FROM RANGE(3000000)";
             QueryResult result = statement.ExecuteQuery();
 
             Assert.NotNull(result.Stream);
-
-            // Read first batch
-            using var firstBatch = await result.Stream.ReadNextRecordBatchAsync();
-            Assert.NotNull(firstBatch);
-            int firstBatchRows = firstBatch.Length;
-            OutputHelper?.WriteLine($"First batch: Read {firstBatchRows} rows");
 
             // Simulate a long delay (30 minutes)
             OutputHelper?.WriteLine("Simulating 30 minute delay...");
             await Task.Delay(TimeSpan.FromMinutes(30));
 
             // Read remaining batches
-            int totalRows = firstBatchRows;
-            int batchCount = 1;
+            int totalRows = 0;
+            int batchCount = 0;
 
             while (result.Stream != null)
             {
@@ -482,7 +475,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             }
 
             // Verify we got all rows
-            Assert.Equal(30000000, totalRows);
+            Assert.Equal(3000000, totalRows);
             Assert.True(batchCount > 1, "Should have read multiple batches");
             OutputHelper?.WriteLine($"Successfully read {totalRows} rows in {batchCount} batches after 30 minute delay with {configName}");
         }


### PR DESCRIPTION
Handles shared reading logic (Status Polling logic) for DatabricksReader and CloudFetchReader. Also modifies polling lifecycle to begin during Reader initialization instead of first time `ReadNextRecordBatchAsync` is called

There is still a slight gap when we are not polling for results immediately after query execution completes ([here](https://github.com/apache/arrow-adbc/blob/main/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs#L121)); can be addressed in a later PR