### PR TITLE
feat(csharp/src/Drivers/Databricks): Add configurable multiple catalog support

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -37,7 +37,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
     {
         private bool _applySSPWithQueries = false;
         private bool _enableDirectResults = true;
-        private bool _canUseMultipleCatalogs = true;
+        private bool _enableMultipleCatalogSupport = true;
 
         internal static TSparkGetDirectResults defaultGetDirectResults = new()
         {
@@ -64,24 +64,24 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 
         private void ValidateProperties()
         {
-            if (Properties.TryGetValue(DatabricksParameters.CanUseMultipleCatalogs, out string? canUseMultipleCatalogsStr))
+            if (Properties.TryGetValue(DatabricksParameters.EnableMultipleCatalogSupport, out string? enableMultipleCatalogSupportStr))
             {
-                if (bool.TryParse(canUseMultipleCatalogsStr, out bool canUseMultipleCatalogsValue))
+                if (bool.TryParse(enableMultipleCatalogSupportStr, out bool enableMultipleCatalogSupportValue))
                 {
-                    _canUseMultipleCatalogs = canUseMultipleCatalogsValue;
+                    _enableMultipleCatalogSupport = enableMultipleCatalogSupportValue;
                 }
                 // PowerBI will pass in "1" and "0" as strings, so we need to handle that
-                else if (canUseMultipleCatalogsStr == "1")
+                else if (enableMultipleCatalogSupportStr == "1")
                 {
-                    _canUseMultipleCatalogs = true;
+                    _enableMultipleCatalogSupport = true;
                 }
-                else if (canUseMultipleCatalogsStr == "0")
+                else if (enableMultipleCatalogSupportStr == "0")
                 {
-                    _canUseMultipleCatalogs = false;
+                    _enableMultipleCatalogSupport = false;
                 }
                 else
                 {
-                    throw new ArgumentException($"Parameter '{DatabricksParameters.CanUseMultipleCatalogs}' value '{canUseMultipleCatalogsStr}' could not be parsed. Valid values are 'true', 'false', '1', or '0'.");
+                    throw new ArgumentException($"Parameter '{DatabricksParameters.EnableMultipleCatalogSupport}' value '{enableMultipleCatalogSupportStr}' could not be parsed. Valid values are 'true', 'false', '1', or '0'.");
                 }
             }
 
@@ -331,7 +331,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             {
                 Client_protocol = TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V7,
                 Client_protocol_i64 = (long)TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V7,
-                CanUseMultipleCatalogs = _canUseMultipleCatalogs,
+                CanUseMultipleCatalogs = _enableMultipleCatalogSupport,
             };
 
             // Set default namespace if available

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -70,18 +70,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 {
                     _enableMultipleCatalogSupport = enableMultipleCatalogSupportValue;
                 }
-                // PowerBI will pass in "1" and "0" as strings, so we need to handle that
-                else if (enableMultipleCatalogSupportStr == "1")
-                {
-                    _enableMultipleCatalogSupport = true;
-                }
-                else if (enableMultipleCatalogSupportStr == "0")
-                {
-                    _enableMultipleCatalogSupport = false;
-                }
                 else
                 {
-                    throw new ArgumentException($"Parameter '{DatabricksParameters.EnableMultipleCatalogSupport}' value '{enableMultipleCatalogSupportStr}' could not be parsed. Valid values are 'true', 'false', '1', or '0'.");
+                    throw new ArgumentException($"Parameter '{DatabricksParameters.EnableMultipleCatalogSupport}' value '{enableMultipleCatalogSupportStr}' could not be parsed. Valid values are 'true', 'false'.");
                 }
             }
 

--- a/csharp/src/Drivers/Databricks/DatabricksParameters.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksParameters.cs
@@ -153,7 +153,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// Whether to use multiple catalogs.
         /// Default value is true if not specified.
         /// </summary>
-        public const string CanUseMultipleCatalogs = "adbc.databricks.enable_multiple_catalog_support";
+        public const string EnableMultipleCatalogSupport = "adbc.databricks.enable_multiple_catalog_support";
     }
 
     /// <summary>

--- a/csharp/src/Drivers/Databricks/DatabricksParameters.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksParameters.cs
@@ -92,7 +92,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// Maximum total time in seconds to retry 503 responses before failing.
         /// Default value is 900 seconds (15 minutes). Set to 0 to retry indefinitely.
         /// </summary>
-        public const string TemporarilyUnavailableRetryTimeout = "adbc.spark.temporarily_unavailable_retry_timeout";
+        public const string TemporarilyUnavailableRetryTimeout = "adbc.databricks.temporarily.unavailable.retry.timeout";
 
         /// <summary>
         /// Maximum number of parallel downloads for CloudFetch operations.
@@ -148,6 +148,12 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// Default value is "sql" if not specified.
         /// </summary>
         public const string OAuthScope = "adbc.databricks.oauth.scope";
+
+        /// <summary>
+        /// Whether to use multiple catalogs.
+        /// Default value is true if not specified.
+        /// </summary>
+        public const string CanUseMultipleCatalogs = "adbc.databricks.enable_multiple_catalog_support";
     }
 
     /// <summary>

--- a/csharp/src/Drivers/Databricks/DatabricksParameters.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksParameters.cs
@@ -92,7 +92,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// Maximum total time in seconds to retry 503 responses before failing.
         /// Default value is 900 seconds (15 minutes). Set to 0 to retry indefinitely.
         /// </summary>
-        public const string TemporarilyUnavailableRetryTimeout = "adbc.databricks.temporarily.unavailable.retry.timeout";
+        public const string TemporarilyUnavailableRetryTimeout = "adbc.spark.temporarily.unavailable.retry.timeout";
 
         /// <summary>
         /// Maximum number of parallel downloads for CloudFetch operations.

--- a/csharp/src/Drivers/Databricks/DatabricksParameters.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksParameters.cs
@@ -92,7 +92,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// Maximum total time in seconds to retry 503 responses before failing.
         /// Default value is 900 seconds (15 minutes). Set to 0 to retry indefinitely.
         /// </summary>
-        public const string TemporarilyUnavailableRetryTimeout = "adbc.spark.temporarily.unavailable.retry.timeout";
+        public const string TemporarilyUnavailableRetryTimeout = "adbc.spark.temporarily_unavailable_retry_timeout";
 
         /// <summary>
         /// Maximum number of parallel downloads for CloudFetch operations.

--- a/csharp/test/Drivers/Databricks/DatabricksConnectionTest.cs
+++ b/csharp/test/Drivers/Databricks/DatabricksConnectionTest.cs
@@ -318,8 +318,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [DatabricksParameters.TemporarilyUnavailableRetryTimeout] = "invalid" }, typeof(ArgumentOutOfRangeException)));
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [DatabricksParameters.TemporarilyUnavailableRetryTimeout] = "-1" }, typeof(ArgumentOutOfRangeException)));
 
-                // Tests for CanUseMultipleCatalogs parameter
-                Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [DatabricksParameters.CanUseMultipleCatalogs] = "notabool" }, typeof(ArgumentException)));
+                // Tests for EnableMultipleCatalogSupport parameter
+                Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [DatabricksParameters.EnableMultipleCatalogSupport] = "notabool" }, typeof(ArgumentException)));
             }
         }
 

--- a/csharp/test/Drivers/Databricks/DatabricksConnectionTest.cs
+++ b/csharp/test/Drivers/Databricks/DatabricksConnectionTest.cs
@@ -317,6 +317,9 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [DatabricksParameters.TemporarilyUnavailableRetry] = "invalid" }, typeof(ArgumentOutOfRangeException)));
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [DatabricksParameters.TemporarilyUnavailableRetryTimeout] = "invalid" }, typeof(ArgumentOutOfRangeException)));
                 Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [DatabricksParameters.TemporarilyUnavailableRetryTimeout] = "-1" }, typeof(ArgumentOutOfRangeException)));
+
+                // Tests for CanUseMultipleCatalogs parameter
+                Add(new(new() { [SparkParameters.Type] = SparkServerTypeConstants.Http, [SparkParameters.HostName] = "valid.server.com", [AdbcOptions.Username] = "user", [AdbcOptions.Password] = "myPassword", [DatabricksParameters.CanUseMultipleCatalogs] = "notabool" }, typeof(ArgumentException)));
             }
         }
 

--- a/csharp/test/Drivers/Databricks/DatabricksTestConfiguration.cs
+++ b/csharp/test/Drivers/Databricks/DatabricksTestConfiguration.cs
@@ -34,7 +34,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
         [JsonPropertyName("scope"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string OAuthScope { get; set; } = string.Empty;
 
-        [JsonPropertyName("canUseMultipleCatalogs")]
-        public string CanUseMultipleCatalogs { get; set; } = string.Empty;
+        [JsonPropertyName("enableMultipleCatalogSupport")]
+        public string EnableMultipleCatalogSupport { get; set; } = string.Empty;
     }
 }

--- a/csharp/test/Drivers/Databricks/DatabricksTestConfiguration.cs
+++ b/csharp/test/Drivers/Databricks/DatabricksTestConfiguration.cs
@@ -33,5 +33,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
 
         [JsonPropertyName("scope"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string OAuthScope { get; set; } = string.Empty;
+
+        [JsonPropertyName("canUseMultipleCatalogs")]
+        public string CanUseMultipleCatalogs { get; set; } = string.Empty;
     }
 }

--- a/csharp/test/Drivers/Databricks/DatabricksTestEnvironment.cs
+++ b/csharp/test/Drivers/Databricks/DatabricksTestEnvironment.cs
@@ -141,6 +141,10 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             {
                 parameters.Add(ApacheParameters.QueryTimeoutSeconds, testConfiguration.QueryTimeoutSeconds!);
             }
+            if (!string.IsNullOrEmpty(testConfiguration.CanUseMultipleCatalogs))
+            {
+                parameters.Add(DatabricksParameters.CanUseMultipleCatalogs, testConfiguration.CanUseMultipleCatalogs!);
+            }
             if (testConfiguration.HttpOptions != null)
             {
                 if (testConfiguration.HttpOptions.Tls != null)

--- a/csharp/test/Drivers/Databricks/DatabricksTestEnvironment.cs
+++ b/csharp/test/Drivers/Databricks/DatabricksTestEnvironment.cs
@@ -141,9 +141,9 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             {
                 parameters.Add(ApacheParameters.QueryTimeoutSeconds, testConfiguration.QueryTimeoutSeconds!);
             }
-            if (!string.IsNullOrEmpty(testConfiguration.CanUseMultipleCatalogs))
+            if (!string.IsNullOrEmpty(testConfiguration.EnableMultipleCatalogSupport))
             {
-                parameters.Add(DatabricksParameters.CanUseMultipleCatalogs, testConfiguration.CanUseMultipleCatalogs!);
+                parameters.Add(DatabricksParameters.EnableMultipleCatalogSupport, testConfiguration.EnableMultipleCatalogSupport!);
             }
             if (testConfiguration.HttpOptions != null)
             {

--- a/csharp/test/Drivers/Databricks/StatementTests.cs
+++ b/csharp/test/Drivers/Databricks/StatementTests.cs
@@ -479,5 +479,88 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             Assert.True(batchCount > 1, "Should have read multiple batches");
             OutputHelper?.WriteLine($"Successfully read {totalRows} rows in {batchCount} batches after 30 minute delay with {configName}");
         }
+
+        [SkippableTheory]
+        [InlineData("1", true)]  // Should allow multiple catalogs
+        [InlineData("0", false)] // Should only use default catalog
+        public async Task CanUseMultipleCatalogsAffectsMetadataQueries(string canUseMultipleCatalogs, bool shouldAllowMultipleCatalogs)
+        {
+            // Create a connection with the specified CanUseMultipleCatalogs setting
+            var testConfig = (DatabricksTestConfiguration)TestConfiguration.Clone();
+            testConfig.CanUseMultipleCatalogs = canUseMultipleCatalogs;
+            using var connection = NewConnection(testConfig);
+
+            // Test each metadata query type
+            await TestMetadataQuery(connection, "GetSchemas", shouldAllowMultipleCatalogs);
+            await TestMetadataQuery(connection, "GetTables", shouldAllowMultipleCatalogs);
+        }
+
+        private async Task TestMetadataQuery(AdbcConnection connection, string queryType, bool shouldAllowMultipleCatalogs)
+        {
+            OutputHelper?.WriteLine($"Testing {queryType} with CanUseMultipleCatalogs={shouldAllowMultipleCatalogs}");
+
+            var statement = connection.CreateStatement();
+            statement.SetOption(ApacheParameters.IsMetadataCommand, "true");
+
+            // Do not pass in catalog so it is set to null
+            // Use default as schema name, it is the default schema name
+            statement.SetOption(ApacheParameters.SchemaName, "default");
+            statement.SqlQuery = queryType;
+
+            QueryResult queryResult = await statement.ExecuteQueryAsync();
+            Assert.NotNull(queryResult.Stream);
+
+            int rowCount = 0;
+            HashSet<string> foundCatalogs = new HashSet<string>();
+            string? defaultCatalog = null;
+
+            while (queryResult.Stream != null)
+            {
+                RecordBatch? batch = await queryResult.Stream.ReadNextRecordBatchAsync();
+                if (batch == null) break;
+
+                rowCount += batch.Length;
+
+                // Check catalog values in each row
+                for (int i = 0; i < batch.Length; i++)
+                {
+                    for (int j = 0; j < batch.ColumnCount; j++)
+                    {
+                        if (queryResult.Stream.Schema.FieldsList[j].Name.Equals("TABLE_CATALOG", StringComparison.OrdinalIgnoreCase) ||
+                            queryResult.Stream.Schema.FieldsList[j].Name.Equals("TABLE_CAT", StringComparison.OrdinalIgnoreCase))
+                        {
+                            string? catalog = GetStringValue(batch.Column(j), i);
+                            if (!string.IsNullOrEmpty(catalog))
+                            {
+                                foundCatalogs.Add(catalog);
+                                // Store the first catalog we find as the default catalog
+                                defaultCatalog ??= catalog;
+                            }
+                        }
+                    }
+                }
+            }
+
+            OutputHelper?.WriteLine($"{queryType} returned {rowCount} rows, found {foundCatalogs.Count} different catalogs: {string.Join(", ", foundCatalogs)}");
+
+            // Verify behavior based on CanUseMultipleCatalogs setting
+            if (!shouldAllowMultipleCatalogs)
+            {
+                // When CanUseMultipleCatalogs is false, all results should be from the default catalog (hive_metastore)
+                Assert.True(foundCatalogs.Count == 1,
+                    $"{queryType} should only return results from the default catalog when CanUseMultipleCatalogs is false");
+                OutputHelper?.WriteLine($"All results are from default catalog: {defaultCatalog}");
+            }
+            else
+            {
+                // When CanUseMultipleCatalogs is true, we may have results from multiple catalogs
+                Assert.True(foundCatalogs.Count > 1,
+                    $"{queryType} should return results from at least one catalog when CanUseMultipleCatalogs is true");
+                if (foundCatalogs.Count > 1)
+                {
+                    OutputHelper?.WriteLine($"Found results from multiple catalogs: {string.Join(", ", foundCatalogs)}");
+                }
+            }
+        }
     }
 }

--- a/csharp/test/Drivers/Databricks/StatementTests.cs
+++ b/csharp/test/Drivers/Databricks/StatementTests.cs
@@ -483,11 +483,11 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
         [SkippableTheory]
         [InlineData("1", true)]  // Should allow multiple catalogs
         [InlineData("0", false)] // Should only use default catalog
-        public async Task CanUseMultipleCatalogsAffectsMetadataQueries(string canUseMultipleCatalogs, bool shouldAllowMultipleCatalogs)
+        public async Task EnableMultipleCatalogSupportAffectsMetadataQueries(string enableMultipleCatalogSupport, bool shouldAllowMultipleCatalogs)
         {
-            // Create a connection with the specified CanUseMultipleCatalogs setting
+            // Create a connection with the specified EnableMultipleCatalogSupport setting
             var testConfig = (DatabricksTestConfiguration)TestConfiguration.Clone();
-            testConfig.CanUseMultipleCatalogs = canUseMultipleCatalogs;
+            testConfig.EnableMultipleCatalogSupport = enableMultipleCatalogSupport;
             using var connection = NewConnection(testConfig);
 
             // Test each metadata query type
@@ -497,7 +497,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
 
         private async Task TestMetadataQuery(AdbcConnection connection, string queryType, bool shouldAllowMultipleCatalogs)
         {
-            OutputHelper?.WriteLine($"Testing {queryType} with CanUseMultipleCatalogs={shouldAllowMultipleCatalogs}");
+            OutputHelper?.WriteLine($"Testing {queryType} with EnableMultipleCatalogSupport={shouldAllowMultipleCatalogs}");
 
             var statement = connection.CreateStatement();
             statement.SetOption(ApacheParameters.IsMetadataCommand, "true");
@@ -543,19 +543,19 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
 
             OutputHelper?.WriteLine($"{queryType} returned {rowCount} rows, found {foundCatalogs.Count} different catalogs: {string.Join(", ", foundCatalogs)}");
 
-            // Verify behavior based on CanUseMultipleCatalogs setting
+            // Verify behavior based on EnableMultipleCatalogSupport setting
             if (!shouldAllowMultipleCatalogs)
             {
-                // When CanUseMultipleCatalogs is false, all results should be from the default catalog (hive_metastore)
+                // When EnableMultipleCatalogSupport is false, all results should be from the default catalog, so count should be one
                 Assert.True(foundCatalogs.Count == 1,
-                    $"{queryType} should only return results from the default catalog when CanUseMultipleCatalogs is false");
+                    $"{queryType} should only return results from the default catalog when EnableMultipleCatalogSupport is false");
                 OutputHelper?.WriteLine($"All results are from default catalog: {defaultCatalog}");
             }
             else
             {
-                // When CanUseMultipleCatalogs is true, we may have results from multiple catalogs
+                // When EnableMultipleCatalogSupport is true, we may have results from multiple catalogs
                 Assert.True(foundCatalogs.Count > 1,
-                    $"{queryType} should return results from at least one catalog when CanUseMultipleCatalogs is true");
+                    $"{queryType} should return results from at least one catalog when EnableMultipleCatalogSupport is true");
                 if (foundCatalogs.Count > 1)
                 {
                     OutputHelper?.WriteLine($"Found results from multiple catalogs: {string.Join(", ", foundCatalogs)}");

--- a/csharp/test/Drivers/Databricks/StatementTests.cs
+++ b/csharp/test/Drivers/Databricks/StatementTests.cs
@@ -481,8 +481,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
         }
 
         [SkippableTheory]
-        [InlineData("1", true)]  // Should allow multiple catalogs
-        [InlineData("0", false)] // Should only use default catalog
+        [InlineData("true", true)]  // Should allow multiple catalogs
+        [InlineData("false", false)] // Should only use default catalog
         public async Task EnableMultipleCatalogSupportAffectsMetadataQueries(string enableMultipleCatalogSupport, bool shouldAllowMultipleCatalogs)
         {
             // Create a connection with the specified EnableMultipleCatalogSupport setting


### PR DESCRIPTION
# Description

This PR adds support for configuring multiple catalog behavior in the C# Databricks ADBC driver. It introduces a new connection parameter `adbc.databricks.enable_multiple_catalog_support` that allows users to control whether the driver should use multiple catalogs or restrict to a default catalog.

## Proposed Changes

- Add new connection parameter `adbc.databricks.enable_multiple_catalog_support` to control multiple catalog behavior
- Implement parameter parsing with support for boolean values and string values "1"/"0" for compatibility with tools like PowerBI
- Add tests to verify the behavior of metadata queries with different parameter settings

## How is this tested?

Added unit tests that verify the behavior of metadata queries (GetSchemas, GetTables) with different settings of the `CanUseMultipleCatalogs` parameter. Tests confirm that when disabled, only the default catalog is used, and when enabled, multiple catalogs can be accessed.
```
