### PR TITLE
fix(go/adbc/driver/snowflake): Boolean columns return as string types in an empty recordset schema

### DIFF
--- a/go/adbc/driver/snowflake/driver_test.go
+++ b/go/adbc/driver/snowflake/driver_test.go
@@ -1680,6 +1680,23 @@ func (suite *SnowflakeTests) TestTimestampSnow() {
 	}
 }
 
+func (suite *SnowflakeTests) TestBooleanType() {
+	suite.Require().NoError(suite.stmt.SetSqlQuery("select * from (SELECT CAST(TRUE  as BOOLEAN) as BOOLEANTYPE) as \"_\" where 0 = 1"))
+	rdr, _, err := suite.stmt.ExecuteQuery(suite.ctx)
+	suite.Require().NoError(err)
+	defer rdr.Release()
+
+	for _, f := range rdr.Schema().Fields() {
+		st, ok := f.Metadata.GetValue("SNOWFLAKE_TYPE")
+		if !ok {
+			continue
+		}
+		if st == "boolean" {
+			suite.Require().IsType(&arrow.BooleanType{}, f.Type)
+		}
+	}
+}
+
 func (suite *SnowflakeTests) TestUseHighPrecision() {
 	suite.Require().NoError(suite.Quirks.DropTable(suite.cnxn, "NUMBERTYPETEST"))
 

--- a/go/adbc/driver/snowflake/record_reader.go
+++ b/go/adbc/driver/snowflake/record_reader.go
@@ -343,6 +343,8 @@ func rowTypesToArrowSchema(_ context.Context, ld gosnowflake.ArrowStreamLoader, 
 			fields[i].Type = &arrow.TimestampType{Unit: arrow.Nanosecond, TimeZone: loc.String()}
 		case "binary":
 			fields[i].Type = arrow.BinaryTypes.Binary
+		case "boolean":
+			fields[i].Type = arrow.FixedWidthTypes.Boolean
 		default:
 			fields[i].Type = arrow.BinaryTypes.String
 		}


### PR DESCRIPTION
When the user runs a query that does not return a record set, ie:

```
select * from (SELECT CAST(TRUE as BOOLEAN) as BOOLEANTYPE) as \"_\" where 0 = 1
```

the boolean column was being identified as a string column.

One example of this public issue:
https://www.reddit.com/r/PowerBI/comments/1kqhywe/comment/mttjia5/?context=3&share_id=Wr1PAx4F7KemsyQrCVnDK&utm_content=1&utm_medium=ios_app&utm_name=ioscss&utm_source=share&utm_term=1