### PR TITLE
feat(csharp/src/Drivers/Databricks): Implement CloudFetchUrlManager to handle presigned URL expiration in CloudFetch

### DIFF
--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloadManager.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloadManager.cs
@@ -22,9 +22,8 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow.Adbc.Drivers.Apache.Hive2;
-using Apache.Arrow.Adbc.Drivers.Databricks;
 
-namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
+namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
 {
     /// <summary>
     /// Manages the CloudFetch download pipeline.
@@ -38,6 +37,8 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
         private const bool DefaultPrefetchEnabled = true;
         private const int DefaultFetchBatchSize = 2000000;
         private const int DefaultTimeoutMinutes = 5;
+        private const int DefaultMaxUrlRefreshAttempts = 3;
+        private const int DefaultUrlExpirationBufferSeconds = 60;
 
         private readonly DatabricksStatement _statement;
         private readonly Schema _schema;
@@ -45,6 +46,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
         private readonly ICloudFetchMemoryBufferManager _memoryManager;
         private readonly BlockingCollection<IDownloadResult> _downloadQueue;
         private readonly BlockingCollection<IDownloadResult> _resultQueue;
+        private readonly CloudFetchUrlManager _urlManager;
         private readonly ICloudFetchResultFetcher _resultFetcher;
         private readonly ICloudFetchDownloader _downloader;
         private readonly HttpClient _httpClient;
@@ -151,6 +153,34 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
                 }
             }
 
+            // Parse URL expiration buffer seconds
+            int urlExpirationBufferSeconds = DefaultUrlExpirationBufferSeconds;
+            if (connectionProps.TryGetValue(DatabricksParameters.CloudFetchUrlExpirationBufferSeconds, out string? urlExpirationBufferStr))
+            {
+                if (int.TryParse(urlExpirationBufferStr, out int parsedUrlExpirationBuffer) && parsedUrlExpirationBuffer > 0)
+                {
+                    urlExpirationBufferSeconds = parsedUrlExpirationBuffer;
+                }
+                else
+                {
+                    throw new ArgumentException($"Invalid value for {DatabricksParameters.CloudFetchUrlExpirationBufferSeconds}: {urlExpirationBufferStr}. Expected a positive integer.");
+                }
+            }
+
+            // Parse max URL refresh attempts
+            int maxUrlRefreshAttempts = DefaultMaxUrlRefreshAttempts;
+            if (connectionProps.TryGetValue(DatabricksParameters.CloudFetchMaxUrlRefreshAttempts, out string? maxUrlRefreshAttemptsStr))
+            {
+                if (int.TryParse(maxUrlRefreshAttemptsStr, out int parsedMaxUrlRefreshAttempts) && parsedMaxUrlRefreshAttempts > 0)
+                {
+                    maxUrlRefreshAttempts = parsedMaxUrlRefreshAttempts;
+                }
+                else
+                {
+                    throw new ArgumentException($"Invalid value for {DatabricksParameters.CloudFetchMaxUrlRefreshAttempts}: {maxUrlRefreshAttemptsStr}. Expected a positive integer.");
+                }
+            }
+
             // Initialize the memory manager
             _memoryManager = new CloudFetchMemoryBufferManager(memoryBufferSizeMB);
 
@@ -160,6 +190,9 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
 
             _httpClient = httpClient;
             _httpClient.Timeout = TimeSpan.FromMinutes(timeoutMinutes);
+
+            // Initialize the URL manager
+            _urlManager = new CloudFetchUrlManager(_statement, urlExpirationBufferSeconds);
 
             // Initialize the result fetcher
             _resultFetcher = new CloudFetchResultFetcher(
@@ -174,10 +207,13 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
                 _resultQueue,
                 _memoryManager,
                 _httpClient,
+                _urlManager,
                 parallelDownloads,
                 _isLz4Compressed,
                 maxRetries,
-                retryDelayMs);
+                retryDelayMs,
+                maxUrlRefreshAttempts,
+                urlExpirationBufferSeconds);
         }
 
         /// <summary>
@@ -206,6 +242,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
             _memoryManager = new CloudFetchMemoryBufferManager(DefaultMemoryBufferSizeMB);
             _downloadQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), 10);
             _resultQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), 10);
+            _urlManager = new CloudFetchUrlManager(_statement);
             _httpClient = new HttpClient();
         }
 

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloader.cs
@@ -24,7 +24,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using K4os.Compression.LZ4.Streams;
 
-namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
+namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
 {
     /// <summary>
     /// Downloads files from URLs.
@@ -35,10 +35,13 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
         private readonly BlockingCollection<IDownloadResult> _resultQueue;
         private readonly ICloudFetchMemoryBufferManager _memoryManager;
         private readonly HttpClient _httpClient;
+        private readonly CloudFetchUrlManager _urlManager;
         private readonly int _maxParallelDownloads;
         private readonly bool _isLz4Compressed;
         private readonly int _maxRetries;
         private readonly int _retryDelayMs;
+        private readonly int _maxUrlRefreshAttempts;
+        private readonly int _urlExpirationBufferSeconds;
         private readonly SemaphoreSlim _downloadSemaphore;
         private Task? _downloadTask;
         private CancellationTokenSource? _cancellationTokenSource;
@@ -53,29 +56,37 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
         /// <param name="resultQueue">The queue to add completed downloads to.</param>
         /// <param name="memoryManager">The memory buffer manager.</param>
         /// <param name="httpClient">The HTTP client to use for downloads.</param>
+        /// <param name="urlManager">The URL manager for handling URL expiration.</param>
         /// <param name="maxParallelDownloads">The maximum number of parallel downloads.</param>
         /// <param name="isLz4Compressed">Whether the results are LZ4 compressed.</param>
-        /// <param name="logger">The logger instance.</param>
         /// <param name="maxRetries">The maximum number of retry attempts.</param>
         /// <param name="retryDelayMs">The delay between retry attempts in milliseconds.</param>
+        /// <param name="maxUrlRefreshAttempts">The maximum number of URL refresh attempts.</param>
+        /// <param name="urlExpirationBufferSeconds">Buffer time in seconds before URL expiration to trigger refresh.</param>
         public CloudFetchDownloader(
             BlockingCollection<IDownloadResult> downloadQueue,
             BlockingCollection<IDownloadResult> resultQueue,
             ICloudFetchMemoryBufferManager memoryManager,
             HttpClient httpClient,
+            CloudFetchUrlManager urlManager,
             int maxParallelDownloads,
             bool isLz4Compressed,
             int maxRetries = 3,
-            int retryDelayMs = 500)
+            int retryDelayMs = 500,
+            int maxUrlRefreshAttempts = 3,
+            int urlExpirationBufferSeconds = 60)
         {
             _downloadQueue = downloadQueue ?? throw new ArgumentNullException(nameof(downloadQueue));
             _resultQueue = resultQueue ?? throw new ArgumentNullException(nameof(resultQueue));
             _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager));
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _urlManager = urlManager ?? throw new ArgumentNullException(nameof(urlManager));
             _maxParallelDownloads = maxParallelDownloads > 0 ? maxParallelDownloads : throw new ArgumentOutOfRangeException(nameof(maxParallelDownloads));
             _isLz4Compressed = isLz4Compressed;
             _maxRetries = maxRetries > 0 ? maxRetries : throw new ArgumentOutOfRangeException(nameof(maxRetries));
             _retryDelayMs = retryDelayMs > 0 ? retryDelayMs : throw new ArgumentOutOfRangeException(nameof(retryDelayMs));
+            _maxUrlRefreshAttempts = maxUrlRefreshAttempts > 0 ? maxUrlRefreshAttempts : throw new ArgumentOutOfRangeException(nameof(maxUrlRefreshAttempts));
+            _urlExpirationBufferSeconds = urlExpirationBufferSeconds > 0 ? urlExpirationBufferSeconds : throw new ArgumentOutOfRangeException(nameof(urlExpirationBufferSeconds));
             _downloadSemaphore = new SemaphoreSlim(_maxParallelDownloads, _maxParallelDownloads);
             _isCompleted = false;
         }
@@ -237,6 +248,25 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
                         break;
                     }
 
+                    // Check if there are any expired URLs that need refreshing
+                    if (_urlManager.HasExpiredOrExpiringSoonUrls())
+                    {
+                        await _urlManager.RefreshExpiredUrlsAsync(cancellationToken);
+                    }
+
+                    // Check if the URL is expired or about to expire
+                    if (downloadResult.IsExpiredOrExpiringSoon(_urlExpirationBufferSeconds))
+                    {
+                        // Get a refreshed URL before starting the download
+                        var refreshedLink = await _urlManager.GetUrlAsync(downloadResult.Link.StartRowOffset, cancellationToken);
+                        if (refreshedLink != null)
+                        {
+                            // Update the download result with the refreshed link
+                            downloadResult.UpdateWithRefreshedLink(refreshedLink);
+                            Trace.TraceInformation($"Updated URL for file at offset {refreshedLink.StartRowOffset} before download");
+                        }
+                    }
+
                     // Acquire a download slot
                     await _downloadSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
@@ -340,6 +370,40 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
                         url,
                         HttpCompletionOption.ResponseHeadersRead,
                         cancellationToken).ConfigureAwait(false);
+
+                    // Check if the response indicates an expired URL (typically 403 or 401)
+                    if (response.StatusCode == System.Net.HttpStatusCode.Forbidden ||
+                        response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                    {
+                        // If we've already tried refreshing too many times, fail
+                        if (downloadResult.RefreshAttempts >= _maxUrlRefreshAttempts)
+                        {
+                            throw new InvalidOperationException($"Failed to download file after {downloadResult.RefreshAttempts} URL refresh attempts.");
+                        }
+
+                        // Try to refresh the URL
+                        var refreshedLink = await _urlManager.GetUrlAsync(downloadResult.Link.StartRowOffset, cancellationToken);
+                        if (refreshedLink != null)
+                        {
+                            // Update the download result with the refreshed link
+                            downloadResult.UpdateWithRefreshedLink(refreshedLink);
+                            url = refreshedLink.FileLink;
+                            sanitizedUrl = SanitizeUrl(url);
+
+                            Trace.TraceInformation($"URL for file at offset {refreshedLink.StartRowOffset} was refreshed after expired URL response");
+
+                            // Also refresh other potentially expired URLs
+                            await _urlManager.RefreshExpiredUrlsAsync(cancellationToken);
+
+                            // Continue to the next retry attempt with the refreshed URL
+                            continue;
+                        }
+                        else
+                        {
+                            // If refresh failed, throw an exception
+                            throw new InvalidOperationException("Failed to refresh expired URL.");
+                        }
+                    }
 
                     response.EnsureSuccessStatusCode();
 

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchMemoryBufferManager.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchMemoryBufferManager.cs
@@ -19,7 +19,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
+namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
 {
     /// <summary>
     /// Manages memory allocation for prefetched files.

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchReader.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchReader.cs
@@ -21,8 +21,6 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch;
-using Apache.Arrow.Adbc.Drivers.Databricks;
 using Apache.Arrow.Ipc;
 using Apache.Hive.Service.Rpc.Thrift;
 

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchResultFetcher.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchResultFetcher.cs
@@ -23,7 +23,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Apache.Hive.Service.Rpc.Thrift;
 
-namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
+namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
 {
     /// <summary>
     /// Fetches result chunks from the Thrift server.
@@ -155,7 +155,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
                         Debug.WriteLine($"Error fetching results: {ex.Message}");
                         _error = ex;
                         _hasMoreResults = false;
-                        break;
+                        throw;
                     }
                 }
 

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchUrlManager.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchUrlManager.cs
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Hive.Service.Rpc.Thrift;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
+{
+    /// <summary>
+    /// Abstraction for time operations to enable testing with controlled time.
+    /// </summary>
+    public interface IClock
+    {
+        /// <summary>
+        /// Gets the current UTC time.
+        /// </summary>
+        DateTime UtcNow { get; }
+    }
+
+    /// <summary>
+    /// Default implementation that uses system time.
+    /// </summary>
+    internal class SystemClock : IClock
+    {
+        public DateTime UtcNow => DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Test implementation that allows controlling time for testing scenarios.
+    /// </summary>
+    public class ControllableClock : IClock
+    {
+        private DateTime _currentTime;
+
+        public ControllableClock(DateTime? initialTime = null)
+        {
+            _currentTime = initialTime ?? DateTime.UtcNow;
+        }
+
+        public DateTime UtcNow => _currentTime;
+
+        /// <summary>
+        /// Advances the clock by the specified time span.
+        /// </summary>
+        /// <param name="timeSpan">The amount of time to advance.</param>
+        public void AdvanceTime(TimeSpan timeSpan)
+        {
+            _currentTime = _currentTime.Add(timeSpan);
+        }
+
+        /// <summary>
+        /// Sets the clock to a specific time.
+        /// </summary>
+        /// <param name="time">The time to set.</param>
+        public void SetTime(DateTime time)
+        {
+            _currentTime = time;
+        }
+
+        /// <summary>
+        /// Resets the clock to the current system time.
+        /// </summary>
+        public void Reset()
+        {
+            _currentTime = DateTime.UtcNow;
+        }
+    }
+
+    /// <summary>
+    /// Manages CloudFetch URLs, handling both initial fetching and refreshing of expired URLs.
+    /// </summary>
+    internal class CloudFetchUrlManager
+    {
+        private readonly IHiveServer2Statement _statement;
+        private readonly SemaphoreSlim _fetchLock = new SemaphoreSlim(1, 1);
+        private readonly ConcurrentDictionary<long, TSparkArrowResultLink> _urlsByOffset = new ConcurrentDictionary<long, TSparkArrowResultLink>();
+        private readonly int _expirationBufferSeconds;
+        private readonly IClock _clock;
+        private long _lastFetchedOffset = 0;
+        private bool _hasMoreResults = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CloudFetchUrlManager"/> class.
+        /// </summary>
+        /// <param name="statement">The HiveServer2 statement to use for fetching URLs.</param>
+        /// <param name="expirationBufferSeconds">Buffer time in seconds before URL expiration to trigger refresh.</param>
+        /// <param name="clock">Clock implementation for time operations. If null, uses system clock.</param>
+        public CloudFetchUrlManager(IHiveServer2Statement statement, int expirationBufferSeconds = 60, IClock? clock = null)
+        {
+            _statement = statement ?? throw new ArgumentNullException(nameof(statement));
+            _expirationBufferSeconds = expirationBufferSeconds;
+            _clock = clock ?? new SystemClock();
+        }
+
+        /// <summary>
+        /// Gets a URL for the specified offset, fetching or refreshing as needed.
+        /// </summary>
+        /// <param name="offset">The row offset for which to get a URL.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The URL link for the specified offset, or null if not available.</returns>
+        public async Task<TSparkArrowResultLink?> GetUrlAsync(long offset, CancellationToken cancellationToken)
+        {
+            // Check if we already have a valid URL for this offset
+            if (_urlsByOffset.TryGetValue(offset, out var link) && !IsUrlExpiredOrExpiringSoon(link))
+            {
+                return link;
+            }
+
+            // Need to fetch or refresh the URL
+            await _fetchLock.WaitAsync(cancellationToken);
+            try
+            {
+                // Check again in case another thread already fetched/refreshed while we were waiting
+                if (_urlsByOffset.TryGetValue(offset, out link) && !IsUrlExpiredOrExpiringSoon(link))
+                {
+                    return link;
+                }
+
+                // Determine if we need to fetch new URLs or refresh existing ones
+                if (!_urlsByOffset.ContainsKey(offset) && _hasMoreResults)
+                {
+                    // This is a new offset we haven't seen before - fetch new URLs
+                    return await FetchNewUrlsAsync(offset, cancellationToken);
+                }
+                else
+                {
+                    // We have the URL but it's expired - refresh it
+                    return await RefreshUrlAsync(offset, cancellationToken);
+                }
+            }
+            finally
+            {
+                _fetchLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Gets URLs for a range of offsets, fetching or refreshing as needed.
+        /// </summary>
+        /// <param name="startOffset">The starting row offset.</param>
+        /// <param name="count">The number of URLs to get.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A dictionary mapping offsets to their URL links.</returns>
+        public async Task<Dictionary<long, TSparkArrowResultLink>> GetUrlRangeAsync(
+            long startOffset, int count, CancellationToken cancellationToken)
+        {
+            var result = new Dictionary<long, TSparkArrowResultLink>();
+
+            // First check which URLs we already have that are valid
+            var offsetsToFetch = new List<long>();
+            for (long i = startOffset; i < startOffset + count; i++)
+            {
+                if (_urlsByOffset.TryGetValue(i, out var link) && !IsUrlExpiredOrExpiringSoon(link))
+                {
+                    result[i] = link;
+                }
+                else
+                {
+                    offsetsToFetch.Add(i);
+                }
+            }
+
+            // If we have all URLs and they're valid, return early
+            if (offsetsToFetch.Count == 0)
+            {
+                return result;
+            }
+
+            // Need to fetch or refresh some URLs
+            await _fetchLock.WaitAsync(cancellationToken);
+            try
+            {
+                // Determine if we need to fetch new URLs or refresh existing ones
+                bool allOffsetsAreNew = offsetsToFetch.All(offset => !_urlsByOffset.ContainsKey(offset));
+
+                if (offsetsToFetch.Count > 0 && allOffsetsAreNew && _hasMoreResults)
+                {
+                    // Fetch new URLs
+                    var newLinks = await FetchUrlBatchAsync(offsetsToFetch[0], count, cancellationToken);
+                    foreach (var link in newLinks)
+                    {
+                        result[link.StartRowOffset] = link;
+                    }
+                }
+                else
+                {
+                    // Refresh existing URLs
+                    foreach (var offset in offsetsToFetch)
+                    {
+                        var refreshedLink = await RefreshUrlAsync(offset, cancellationToken);
+                        if (refreshedLink != null)
+                        {
+                            result[offset] = refreshedLink;
+                        }
+                    }
+                }
+
+                // Fill in any remaining URLs we already have
+                for (long i = startOffset; i < startOffset + count; i++)
+                {
+                    if (!result.ContainsKey(i) && _urlsByOffset.TryGetValue(i, out var link))
+                    {
+                        result[i] = link;
+                    }
+                }
+
+                return result;
+            }
+            finally
+            {
+                _fetchLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Proactively refreshes URLs that are expired or about to expire.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public async Task RefreshExpiredUrlsAsync(CancellationToken cancellationToken)
+        {
+            // Find the earliest offset that needs refreshing
+            long? earliestExpiredOffset = null;
+
+            foreach (var entry in _urlsByOffset)
+            {
+                if (IsUrlExpiredOrExpiringSoon(entry.Value))
+                {
+                    if (!earliestExpiredOffset.HasValue || entry.Key < earliestExpiredOffset.Value)
+                    {
+                        earliestExpiredOffset = entry.Key;
+                    }
+                }
+            }
+
+            if (earliestExpiredOffset.HasValue)
+            {
+                await _fetchLock.WaitAsync(cancellationToken);
+                try
+                {
+                    Trace.TraceInformation($"Proactively refreshing URLs starting from offset {earliestExpiredOffset.Value}");
+                    await FetchUrlBatchAsync(earliestExpiredOffset.Value, 100, cancellationToken);
+                }
+                finally
+                {
+                    _fetchLock.Release();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks if any URLs are expired or about to expire.
+        /// </summary>
+        /// <returns>True if any URLs are expired or about to expire, false otherwise.</returns>
+        public bool HasExpiredOrExpiringSoonUrls()
+        {
+            return _urlsByOffset.Values.Any(IsUrlExpiredOrExpiringSoon);
+        }
+
+        /// <summary>
+        /// Gets all currently cached URLs.
+        /// </summary>
+        /// <returns>A dictionary mapping offsets to their URL links.</returns>
+        public Dictionary<long, TSparkArrowResultLink> GetAllCachedUrls()
+        {
+            return new Dictionary<long, TSparkArrowResultLink>(_urlsByOffset);
+        }
+
+        /// <summary>
+        /// Clears all cached URLs.
+        /// </summary>
+        public void ClearCache()
+        {
+            _urlsByOffset.Clear();
+            _lastFetchedOffset = 0;
+            _hasMoreResults = true;
+        }
+
+        /// <summary>
+        /// Fetches new URLs starting from the specified offset.
+        /// </summary>
+        private async Task<TSparkArrowResultLink?> FetchNewUrlsAsync(long offset, CancellationToken cancellationToken)
+        {
+            var links = await FetchUrlBatchAsync(offset, 100, cancellationToken);
+            return links.FirstOrDefault(l => l.StartRowOffset == offset);
+        }
+
+        /// <summary>
+        /// Fetches a batch of URLs starting from the specified offset.
+        /// </summary>
+        private async Task<List<TSparkArrowResultLink>> FetchUrlBatchAsync(
+            long startOffset, int batchSize, CancellationToken cancellationToken)
+        {
+            try
+            {
+                Trace.TraceInformation($"Fetching URL batch starting at offset {startOffset}");
+
+                // Create fetch request
+                TFetchResultsReq request = new TFetchResultsReq(
+                    _statement.OperationHandle!,
+                    TFetchOrientation.FETCH_NEXT,
+                    batchSize);
+
+                request.StartRowOffset = startOffset;
+
+                // Fetch results
+                TFetchResultsResp response = await _statement.Client.FetchResults(request, cancellationToken);
+
+                // Process the results
+                if (response.Status.StatusCode == TStatusCode.SUCCESS_STATUS &&
+                    response.Results.__isset.resultLinks &&
+                    response.Results.ResultLinks != null &&
+                    response.Results.ResultLinks.Count > 0)
+                {
+                    Trace.TraceInformation($"Received {response.Results.ResultLinks.Count} URLs in batch");
+
+                    // Update our cached URLs
+                    foreach (var link in response.Results.ResultLinks)
+                    {
+                        _urlsByOffset[link.StartRowOffset] = link;
+
+                        // Update the last fetched offset
+                        _lastFetchedOffset = Math.Max(_lastFetchedOffset, link.StartRowOffset + link.RowCount);
+                    }
+
+                    // Update whether we have more results
+                    _hasMoreResults = response.HasMoreRows;
+
+                    return response.Results.ResultLinks;
+                }
+                else
+                {
+                    Trace.TraceWarning("No URLs received in batch");
+                    _hasMoreResults = false;
+                    return new List<TSparkArrowResultLink>();
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError($"Error fetching URL batch: {ex.Message}");
+                return new List<TSparkArrowResultLink>();
+            }
+        }
+
+        /// <summary>
+        /// Refreshes a specific URL.
+        /// </summary>
+        private async Task<TSparkArrowResultLink?> RefreshUrlAsync(long offset, CancellationToken cancellationToken)
+        {
+            try
+            {
+                Trace.TraceInformation($"Refreshing URL for offset {offset}");
+
+                // Create fetch request for the specific offset
+                TFetchResultsReq request = new TFetchResultsReq(
+                    _statement.OperationHandle!,
+                    TFetchOrientation.FETCH_NEXT,
+                    1);
+
+                request.StartRowOffset = offset;
+
+                // Fetch results
+                TFetchResultsResp response = await _statement.Client.FetchResults(request, cancellationToken);
+
+                // Process the results
+                if (response.Status.StatusCode == TStatusCode.SUCCESS_STATUS &&
+                    response.Results.__isset.resultLinks &&
+                    response.Results.ResultLinks != null &&
+                    response.Results.ResultLinks.Count > 0)
+                {
+                    var refreshedLink = response.Results.ResultLinks.FirstOrDefault(l => l.StartRowOffset == offset);
+                    if (refreshedLink != null)
+                    {
+                        Trace.TraceInformation($"Successfully refreshed URL for offset {offset}");
+                        _urlsByOffset[offset] = refreshedLink;
+                        return refreshedLink;
+                    }
+                }
+
+                Trace.TraceWarning($"Failed to refresh URL for offset {offset}");
+                return null;
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError($"Error refreshing URL: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Checks if a URL is expired or will expire soon.
+        /// </summary>
+        private bool IsUrlExpiredOrExpiringSoon(TSparkArrowResultLink link)
+        {
+            // Convert expiry time to DateTime
+            var expiryTime = DateTimeOffset.FromUnixTimeMilliseconds(link.ExpiryTime).UtcDateTime;
+
+            // Check if the URL is already expired or will expire soon
+            return _clock.UtcNow.AddSeconds(_expirationBufferSeconds) >= expiryTime;
+        }
+    }
+}

--- a/csharp/src/Drivers/Databricks/CloudFetch/EndOfResultsGuard.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/EndOfResultsGuard.cs
@@ -20,7 +20,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Apache.Hive.Service.Rpc.Thrift;
 
-namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
+namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
 {
     /// <summary>
     /// Special marker class that indicates the end of results in the download queue.
@@ -55,10 +55,19 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
         public bool IsCompleted => true;
 
         /// <inheritdoc />
+        public int RefreshAttempts => 0;
+
+        /// <inheritdoc />
         public void SetCompleted(Stream dataStream, long size) => throw new NotSupportedException("EndOfResultsGuard cannot be completed.");
 
         /// <inheritdoc />
         public void SetFailed(Exception exception) => throw new NotSupportedException("EndOfResultsGuard cannot fail.");
+
+        /// <inheritdoc />
+        public void UpdateWithRefreshedLink(TSparkArrowResultLink refreshedLink) => throw new NotSupportedException("EndOfResultsGuard cannot be updated with a refreshed link.");
+
+        /// <inheritdoc />
+        public bool IsExpiredOrExpiringSoon(int expirationBufferSeconds = 60) => false;
 
         /// <inheritdoc />
         public void Dispose()

--- a/csharp/src/Drivers/Databricks/CloudFetch/ICloudFetchInterfaces.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/ICloudFetchInterfaces.cs
@@ -22,7 +22,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Apache.Hive.Service.Rpc.Thrift;
 
-namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
+namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
 {
     /// <summary>
     /// Represents a downloaded result file with its associated metadata.
@@ -55,6 +55,11 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
         bool IsCompleted { get; }
 
         /// <summary>
+        /// Gets the number of URL refresh attempts for this download.
+        /// </summary>
+        int RefreshAttempts { get; }
+
+        /// <summary>
         /// Sets the download as completed with the provided data stream.
         /// </summary>
         /// <param name="dataStream">The stream containing the downloaded data.</param>
@@ -66,6 +71,19 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
         /// </summary>
         /// <param name="exception">The exception that caused the failure.</param>
         void SetFailed(Exception exception);
+
+        /// <summary>
+        /// Updates this download result with a refreshed link.
+        /// </summary>
+        /// <param name="refreshedLink">The refreshed link information.</param>
+        void UpdateWithRefreshedLink(TSparkArrowResultLink refreshedLink);
+
+        /// <summary>
+        /// Checks if the URL is expired or about to expire.
+        /// </summary>
+        /// <param name="expirationBufferSeconds">Buffer time in seconds before expiration to consider a URL as expiring soon.</param>
+        /// <returns>True if the URL is expired or about to expire, false otherwise.</returns>
+        bool IsExpiredOrExpiringSoon(int expirationBufferSeconds = 60);
     }
 
     /// <summary>

--- a/csharp/src/Drivers/Databricks/CloudFetch/IHiveServer2Statement.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/IHiveServer2Statement.cs
@@ -17,7 +17,7 @@
 
 using Apache.Hive.Service.Rpc.Thrift;
 
-namespace Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch
+namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
 {
     /// <summary>
     /// Interface for accessing HiveServer2Statement properties needed by CloudFetchResultFetcher.

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -30,6 +30,9 @@ using Apache.Arrow.Adbc.Drivers.Databricks.Auth;
 using Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch;
 using Apache.Arrow.Ipc;
 using Apache.Hive.Service.Rpc.Thrift;
+using Thrift.Protocol;
+using Thrift.Transport;
+using Thrift.Transport.Client;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks
 {
@@ -466,6 +469,27 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 }
             }
             return base.GetAuthenticationHeaderValue(authType);
+        }
+
+        /// <summary>
+        /// Gets a fresh Thrift client for fetching results.
+        /// This helps avoid "stream already consumed" errors when a Thrift transport has already been used.
+        /// </summary>
+        /// <returns>A fresh Thrift client instance.</returns>
+        internal TCLIService.IAsync GetFreshClient()
+        {
+            // Create a new transport and protocol
+            TTransport transport = CreateTransport();
+            TProtocol protocol = new TBinaryProtocol(transport);
+
+            // Open the transport synchronously to make it available immediately
+            if (!transport.IsOpen)
+            {
+                transport.OpenAsync().GetAwaiter().GetResult();
+            }
+
+            // Return a new client that uses the fresh transport
+            return new TCLIService.Client(protocol);
         }
 
         protected override void ValidateOAuthParameters()

--- a/csharp/src/Drivers/Databricks/DatabricksOperationStatusPoller.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksOperationStatusPoller.cs
@@ -18,7 +18,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch;
+using Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch;
 using Apache.Hive.Service.Rpc.Thrift;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks

--- a/csharp/src/Drivers/Databricks/DatabricksParameters.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksParameters.cs
@@ -63,6 +63,18 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         public const string CloudFetchTimeoutMinutes = "adbc.databricks.cloudfetch.timeout_minutes";
 
         /// <summary>
+        /// Buffer time in seconds before URL expiration to trigger refresh.
+        /// Default value is 60 seconds if not specified.
+        /// </summary>
+        public const string CloudFetchUrlExpirationBufferSeconds = "adbc.databricks.cloudfetch.url_expiration_buffer_seconds";
+
+        /// <summary>
+        /// Maximum number of URL refresh attempts for CloudFetch downloads.
+        /// Default value is 3 if not specified.
+        /// </summary>
+        public const string CloudFetchMaxUrlRefreshAttempts = "adbc.databricks.cloudfetch.max_url_refresh_attempts";
+
+        /// <summary>
         /// Whether to enable the use of direct results when executing queries.
         /// Default value is true if not specified.
         /// </summary>

--- a/csharp/src/Drivers/Databricks/DatabricksStatement.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksStatement.cs
@@ -18,7 +18,7 @@
 using System;
 using Apache.Arrow.Adbc.Drivers.Apache;
 using Apache.Arrow.Adbc.Drivers.Apache.Spark;
-using Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch;
+using Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch;
 using Apache.Hive.Service.Rpc.Thrift;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks

--- a/csharp/test/Drivers/Databricks/CloudFetch/CloudFetchDownloaderTest.cs
+++ b/csharp/test/Drivers/Databricks/CloudFetch/CloudFetchDownloaderTest.cs
@@ -24,25 +24,29 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch;
+using Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch;
 using Apache.Hive.Service.Rpc.Thrift;
 using Moq;
 using Moq.Protected;
 using Xunit;
 
-namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
 {
     public class CloudFetchDownloaderTest
     {
         private readonly BlockingCollection<IDownloadResult> _downloadQueue;
         private readonly BlockingCollection<IDownloadResult> _resultQueue;
         private readonly Mock<ICloudFetchMemoryBufferManager> _mockMemoryManager;
+        private readonly Mock<IHiveServer2Statement> _mockStatement;
+        private readonly CloudFetchUrlManager _urlManager;
 
         public CloudFetchDownloaderTest()
         {
             _downloadQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), 10);
             _resultQueue = new BlockingCollection<IDownloadResult>(new ConcurrentQueue<IDownloadResult>(), 10);
             _mockMemoryManager = new Mock<ICloudFetchMemoryBufferManager>();
+            _mockStatement = new Mock<IHiveServer2Statement>();
+            _urlManager = new CloudFetchUrlManager(_mockStatement.Object);
 
             // Set up memory manager defaults
             _mockMemoryManager.Setup(m => m.TryAcquireMemory(It.IsAny<long>())).Returns(true);
@@ -77,6 +81,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
                 _resultQueue,
                 _mockMemoryManager.Object,
                 httpClient,
+                _urlManager,
                 3, // maxParallelDownloads
                 false); // isLz4Compressed
 
@@ -108,9 +113,14 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
 
             // Create a test download result
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink { FileLink = "http://test.com/file1" };
+            var resultLink = new TSparkArrowResultLink {
+                FileLink = "http://test.com/file1",
+                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds() // Set expiry 30 minutes in the future
+            };
             mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
             mockDownloadResult.Setup(r => r.Size).Returns(testContentBytes.Length);
+            mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
+            mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
 
             // Capture the stream and size passed to SetCompleted
             Stream? capturedStream = null;
@@ -128,6 +138,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
                 _resultQueue,
                 _mockMemoryManager.Object,
                 httpClient,
+                _urlManager,
                 1, // maxParallelDownloads
                 false, // isLz4Compressed
                 1, // maxRetries
@@ -189,9 +200,14 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
 
             // Create a test download result
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink { FileLink = "http://test.com/file1" };
+            var resultLink = new TSparkArrowResultLink {
+                FileLink = "http://test.com/file1",
+                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds() // Set expiry 30 minutes in the future
+            };
             mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
             mockDownloadResult.Setup(r => r.Size).Returns(1000); // Some arbitrary size
+            mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
+            mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
 
             // Capture when SetFailed is called
             Exception? capturedException = null;
@@ -204,6 +220,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
                 _resultQueue,
                 _mockMemoryManager.Object,
                 httpClient,
+                _urlManager,
                 1, // maxParallelDownloads
                 false, // isLz4Compressed
                 1, // maxRetries
@@ -256,9 +273,14 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
 
             // Create test download results
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink { FileLink = "http://test.com/file1" };
+            var resultLink = new TSparkArrowResultLink {
+                FileLink = "http://test.com/file1",
+                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds() // Set expiry 30 minutes in the future
+            };
             mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
             mockDownloadResult.Setup(r => r.Size).Returns(100);
+            mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
+            mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
 
             // Capture when SetFailed is called
             Exception? capturedException = null;
@@ -271,6 +293,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
                 _resultQueue,
                 _mockMemoryManager.Object,
                 httpClient,
+                _urlManager,
                 1, // maxParallelDownloads
                 false, // isLz4Compressed
                 1, // maxRetries
@@ -345,9 +368,14 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
 
             // Create a test download result
             var mockDownloadResult = new Mock<IDownloadResult>();
-            var resultLink = new TSparkArrowResultLink { FileLink = "http://test.com/file1" };
+            var resultLink = new TSparkArrowResultLink {
+                FileLink = "http://test.com/file1",
+                ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds() // Set expiry 30 minutes in the future
+            };
             mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
             mockDownloadResult.Setup(r => r.Size).Returns(100);
+            mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
+            mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
 
             // Create the downloader and add the download to the queue
             var downloader = new CloudFetchDownloader(
@@ -355,6 +383,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
                 _resultQueue,
                 _mockMemoryManager.Object,
                 httpClient,
+                _urlManager,
                 1, // maxParallelDownloads
                 false); // isLz4Compressed
 
@@ -429,9 +458,14 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
             for (int i = 0; i < totalDownloads; i++)
             {
                 var mockDownloadResult = new Mock<IDownloadResult>();
-                var resultLink = new TSparkArrowResultLink { FileLink = $"http://test.com/file{i}" };
+                var resultLink = new TSparkArrowResultLink {
+                    FileLink = $"http://test.com/file{i}",
+                    ExpiryTime = DateTimeOffset.UtcNow.AddMinutes(30).ToUnixTimeSeconds() // Set expiry 30 minutes in the future
+                };
                 mockDownloadResult.Setup(r => r.Link).Returns(resultLink);
                 mockDownloadResult.Setup(r => r.Size).Returns(100);
+                mockDownloadResult.Setup(r => r.RefreshAttempts).Returns(0);
+                mockDownloadResult.Setup(r => r.IsExpiredOrExpiringSoon(It.IsAny<int>())).Returns(false);
                 mockDownloadResult.Setup(r => r.SetCompleted(It.IsAny<Stream>(), It.IsAny<long>()))
                     .Callback<Stream, long>((_, _) => { });
                 downloadResults[i] = mockDownloadResult.Object;
@@ -443,6 +477,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
                 _resultQueue,
                 _mockMemoryManager.Object,
                 httpClient,
+                _urlManager,
                 maxParallelDownloads,
                 false); // isLz4Compressed
 

--- a/csharp/test/Drivers/Databricks/CloudFetch/CloudFetchResultFetcherTest.cs
+++ b/csharp/test/Drivers/Databricks/CloudFetch/CloudFetchResultFetcherTest.cs
@@ -20,12 +20,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch;
+using Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch;
 using Apache.Hive.Service.Rpc.Thrift;
 using Moq;
 using Xunit;
 
-namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Databricks.CloudFetch
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
 {
     /// <summary>
     /// Tests for CloudFetchResultFetcher

--- a/csharp/test/Drivers/Databricks/CloudFetch/CloudFetchUrlManagerTest.cs
+++ b/csharp/test/Drivers/Databricks/CloudFetch/CloudFetchUrlManagerTest.cs
@@ -1,0 +1,450 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch;
+using Apache.Hive.Service.Rpc.Thrift;
+using Moq;
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
+{
+    public class CloudFetchUrlManagerTest
+    {
+        private readonly Mock<IHiveServer2Statement> _mockStatement;
+        private readonly Mock<TCLIService.IAsync> _mockClient;
+        private readonly TOperationHandle _operationHandle;
+        private readonly MockClock _mockClock;
+        private readonly CloudFetchUrlManagerWithMockClock _urlManager;
+
+        public CloudFetchUrlManagerTest()
+        {
+            _mockClient = new Mock<TCLIService.IAsync>();
+            _mockStatement = new Mock<IHiveServer2Statement>();
+            _operationHandle = new TOperationHandle
+            {
+                OperationId = new THandleIdentifier { Guid = new byte[] { 1, 2, 3, 4 } },
+                OperationType = TOperationType.EXECUTE_STATEMENT
+            };
+
+            _mockStatement.Setup(s => s.Client).Returns(_mockClient.Object);
+            _mockStatement.Setup(s => s.OperationHandle).Returns(_operationHandle);
+
+            _mockClock = new MockClock();
+            _urlManager = new CloudFetchUrlManagerWithMockClock(_mockStatement.Object, _mockClock, 60);
+        }
+
+        [Fact]
+        public async Task GetUrlAsync_FetchesNewUrl_WhenNotCached()
+        {
+            // Arrange
+            long offset = 0;
+            var resultLink = CreateTestResultLink(offset, 100, "http://test.com/file1", 3600);
+            SetupMockClientFetchResults(new List<TSparkArrowResultLink> { resultLink }, true);
+
+            // Act
+            var result = await _urlManager.GetUrlAsync(offset, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(offset, result.StartRowOffset);
+            Assert.Equal("http://test.com/file1", result.FileLink);
+            _mockClient.Verify(c => c.FetchResults(It.IsAny<TFetchResultsReq>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetUrlAsync_ReturnsCachedUrl_WhenNotExpired()
+        {
+            // Arrange
+            long offset = 0;
+            var resultLink = CreateTestResultLink(offset, 100, "http://test.com/file1", 3600);
+            SetupMockClientFetchResults(new List<TSparkArrowResultLink> { resultLink }, true);
+
+            // First call to cache the URL
+            var initialResult = await _urlManager.GetUrlAsync(offset, CancellationToken.None);
+
+            // Verify we have the expected URL from the first call
+            Assert.NotNull(initialResult);
+
+            // Setup a new mock client for the second call to verify no further calls
+            var secondMock = new Mock<TCLIService.IAsync>(MockBehavior.Strict);
+            var originalClient = _mockStatement.Object.Client;
+            _mockStatement.Setup(s => s.Client).Returns(secondMock.Object);
+
+            // Act
+            var result = await _urlManager.GetUrlAsync(offset, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(offset, result.StartRowOffset);
+            Assert.Equal("http://test.com/file1", result.FileLink);
+
+            // Restore the original client for other tests
+            _mockStatement.Setup(s => s.Client).Returns(originalClient);
+        }
+
+        [Fact]
+        public async Task GetUrlAsync_RefreshesUrl_WhenExpired()
+        {
+            // Arrange
+            long offset = 0;
+
+            // Create a URL that expires in 30 seconds
+            var initialLink = CreateTestResultLink(offset, 100, "http://test.com/file1", 30);
+            SetupMockClientFetchResults(new List<TSparkArrowResultLink> { initialLink }, true);
+
+            // First call to cache the URL
+            await _urlManager.GetUrlAsync(offset, CancellationToken.None);
+
+            // Advance time past expiration (30 seconds + buffer of 60 seconds)
+            _mockClock.AdvanceTime(TimeSpan.FromSeconds(100));
+
+            // Reset the mock and setup for the refresh call with a new URL
+            _mockClient.Invocations.Clear();
+            var refreshedLink = CreateTestResultLink(offset, 100, "http://test.com/file1-refreshed", 3600);
+            SetupMockClientFetchResults(new List<TSparkArrowResultLink> { refreshedLink }, true);
+
+            // Act
+            var result = await _urlManager.GetUrlAsync(offset, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(offset, result.StartRowOffset);
+            Assert.Equal("http://test.com/file1-refreshed", result.FileLink);
+            _mockClient.Verify(c => c.FetchResults(It.IsAny<TFetchResultsReq>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetUrlRangeAsync_FetchesMultipleUrls()
+        {
+            // Arrange
+            var resultLinks = new List<TSparkArrowResultLink>
+            {
+                CreateTestResultLink(0, 100, "http://test.com/file1", 3600),
+                CreateTestResultLink(100, 100, "http://test.com/file2", 3600),
+                CreateTestResultLink(200, 100, "http://test.com/file3", 3600)
+            };
+
+            SetupMockClientFetchResults(resultLinks, true);
+
+            // Act
+            var results = await _urlManager.GetUrlRangeAsync(0, 300, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(3, results.Count);
+            Assert.Equal("http://test.com/file1", results[0].FileLink);
+            Assert.Equal("http://test.com/file2", results[100].FileLink);
+            Assert.Equal("http://test.com/file3", results[200].FileLink);
+            _mockClient.Verify(c => c.FetchResults(It.IsAny<TFetchResultsReq>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetUrlRangeAsync_ReturnsCachedUrls_WhenNotExpired()
+        {
+            // Arrange
+            var resultLinks = new List<TSparkArrowResultLink>
+            {
+                CreateTestResultLink(0, 100, "http://test.com/file1", 3600),
+                CreateTestResultLink(100, 100, "http://test.com/file2", 3600),
+                CreateTestResultLink(200, 100, "http://test.com/file3", 3600)
+            };
+
+            SetupMockClientFetchResults(resultLinks, true);
+
+            // First call to cache the URLs
+            var initialResults = await _urlManager.GetUrlRangeAsync(0, 300, CancellationToken.None);
+
+            // Verify we have the expected URLs from the first call
+            Assert.Equal(3, initialResults.Count);
+
+            // Setup a new mock client for the second call to verify no further calls
+            var secondMock = new Mock<TCLIService.IAsync>(MockBehavior.Strict);
+            var originalClient = _mockStatement.Object.Client;
+            _mockStatement.Setup(s => s.Client).Returns(secondMock.Object);
+
+            // Act
+            var results = await _urlManager.GetUrlRangeAsync(0, 300, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(3, results.Count);
+            Assert.Equal("http://test.com/file1", results[0].FileLink);
+            Assert.Equal("http://test.com/file2", results[100].FileLink);
+            Assert.Equal("http://test.com/file3", results[200].FileLink);
+
+            // Restore the original client for other tests
+            _mockStatement.Setup(s => s.Client).Returns(originalClient);
+        }
+
+        [Fact]
+        public async Task GetUrlRangeAsync_RefreshesExpiredUrls()
+        {
+            // Arrange
+            var resultLinks = new List<TSparkArrowResultLink>
+            {
+                CreateTestResultLink(0, 100, "http://test.com/file1", 30),  // Short expiry
+                CreateTestResultLink(100, 100, "http://test.com/file2", 3600),
+                CreateTestResultLink(200, 100, "http://test.com/file3", 3600)
+            };
+
+            // Setup the initial mock client
+            SetupMockClientFetchResults(resultLinks, true);
+
+            // First call to cache the URLs
+            await _urlManager.GetUrlRangeAsync(0, 300, CancellationToken.None);
+
+            // Advance time past expiration of the first URL
+            _mockClock.AdvanceTime(TimeSpan.FromSeconds(100));
+
+            // Setup the refreshed URL response
+            var refreshedLink = CreateTestResultLink(0, 100, "http://test.com/file1-refreshed", 3600);
+
+            // Update the mock client to return the refreshed link for offset 0
+            _mockClient.Setup(c => c.FetchResults(
+                It.Is<TFetchResultsReq>(req => req.StartRowOffset == 0 && req.MaxRows == 1),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TFetchResultsResp
+                {
+                    Status = new TStatus { StatusCode = TStatusCode.SUCCESS_STATUS },
+                    HasMoreRows = true,
+                    Results = new TRowSet
+                    {
+                        __isset = { resultLinks = true },
+                        ResultLinks = new List<TSparkArrowResultLink> { refreshedLink }
+                    },
+                    __isset = { results = true, hasMoreRows = true }
+                });
+
+            // Act
+            var results = await _urlManager.GetUrlRangeAsync(0, 300, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(3, results.Count);
+            Assert.Equal("http://test.com/file1-refreshed", results[0].FileLink);
+            Assert.Equal("http://test.com/file2", results[100].FileLink);
+            Assert.Equal("http://test.com/file3", results[200].FileLink);
+
+            // Verify the mock client was called for refresh
+            _mockClient.Verify(c => c.FetchResults(
+                It.Is<TFetchResultsReq>(req => req.StartRowOffset == 0 && req.MaxRows == 1),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task RefreshExpiredUrlsAsync_RefreshesOnlyExpiredUrls()
+        {
+            // Arrange
+            var resultLinks = new List<TSparkArrowResultLink>
+            {
+                CreateTestResultLink(0, 100, "http://test.com/file1", 30),  // Short expiry
+                CreateTestResultLink(100, 100, "http://test.com/file2", 3600),
+                CreateTestResultLink(200, 100, "http://test.com/file3", 3600)
+            };
+
+            SetupMockClientFetchResults(resultLinks, true);
+
+            // First call to cache the URLs
+            await _urlManager.GetUrlRangeAsync(0, 300, CancellationToken.None);
+
+            // Advance time past expiration of the first URL
+            _mockClock.AdvanceTime(TimeSpan.FromSeconds(100));
+
+            // Setup mock for the refresh call with a new URL for offset 0
+            var refreshedLinks = new List<TSparkArrowResultLink>
+            {
+                CreateTestResultLink(0, 100, "http://test.com/file1-refreshed", 3600)
+            };
+            SetupMockClientFetchResults(refreshedLinks, true);
+
+            // Reset the mock to track new calls
+            _mockClient.Invocations.Clear();
+
+            // Act
+            await _urlManager.RefreshExpiredUrlsAsync(CancellationToken.None);
+
+            // Assert
+            var allUrls = _urlManager.GetAllCachedUrls();
+            Assert.Equal("http://test.com/file1-refreshed", allUrls[0].FileLink);
+            Assert.Equal("http://test.com/file2", allUrls[100].FileLink);
+            Assert.Equal("http://test.com/file3", allUrls[200].FileLink);
+            _mockClient.Verify(c => c.FetchResults(It.IsAny<TFetchResultsReq>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task HasExpiredOrExpiringSoonUrls_ReturnsTrueWhenUrlsAreExpiring()
+        {
+            // Arrange
+            var resultLinks = new List<TSparkArrowResultLink>
+            {
+                CreateTestResultLink(0, 100, "http://test.com/file1", 30),  // Short expiry
+                CreateTestResultLink(100, 100, "http://test.com/file2", 3600)
+            };
+
+            SetupMockClientFetchResults(resultLinks, true);
+
+            // Cache the URLs
+            await _urlManager.GetUrlRangeAsync(0, 200, CancellationToken.None);
+
+            // Advance time close to expiration (within buffer)
+            _mockClock.AdvanceTime(TimeSpan.FromSeconds(10));  // URL will expire in 20 seconds, buffer is 60
+
+            // Act
+            bool hasExpiring = _urlManager.HasExpiredOrExpiringSoonUrls();
+
+            // Assert
+            Assert.True(hasExpiring);
+        }
+
+        [Fact]
+        public async Task HasExpiredOrExpiringSoonUrls_ReturnsFalseWhenNoUrlsAreExpiring()
+        {
+            // Arrange
+            var resultLinks = new List<TSparkArrowResultLink>
+            {
+                CreateTestResultLink(0, 100, "http://test.com/file1", 3600),
+                CreateTestResultLink(100, 100, "http://test.com/file2", 3600)
+            };
+
+            SetupMockClientFetchResults(resultLinks, true);
+
+            // Cache the URLs
+            await _urlManager.GetUrlRangeAsync(0, 200, CancellationToken.None);
+
+            // Act - we're using 3600 seconds expiry and 60 second buffer, so this should not be expiring
+            bool hasExpiring = _urlManager.HasExpiredOrExpiringSoonUrls();
+
+            // Assert
+            Assert.False(hasExpiring);
+        }
+
+        [Fact]
+        public async Task ClearCache_RemovesAllCachedUrls()
+        {
+            // Arrange
+            var resultLinks = new List<TSparkArrowResultLink>
+            {
+                CreateTestResultLink(0, 100, "http://test.com/file1", 3600),
+                CreateTestResultLink(100, 100, "http://test.com/file2", 3600)
+            };
+
+            SetupMockClientFetchResults(resultLinks, true);
+
+            // Cache the URLs
+            await _urlManager.GetUrlRangeAsync(0, 200, CancellationToken.None);
+
+            // Act
+            _urlManager.ClearCache();
+            var cachedUrls = _urlManager.GetAllCachedUrls();
+
+            // Assert
+            Assert.Empty(cachedUrls);
+        }
+
+        private TSparkArrowResultLink CreateTestResultLink(long startRowOffset, int rowCount, string fileLink, int expirySeconds)
+        {
+            return new TSparkArrowResultLink
+            {
+                StartRowOffset = startRowOffset,
+                RowCount = rowCount,
+                FileLink = fileLink,
+                ExpiryTime = _mockClock.UtcNow.AddSeconds(expirySeconds).ToUnixTimeMilliseconds()
+            };
+        }
+
+        private void SetupMockClientFetchResults(List<TSparkArrowResultLink> resultLinks, bool hasMoreRows)
+        {
+            var results = new TRowSet { __isset = { resultLinks = true } };
+            results.ResultLinks = resultLinks;
+
+            var response = new TFetchResultsResp
+            {
+                Status = new TStatus { StatusCode = TStatusCode.SUCCESS_STATUS },
+                HasMoreRows = hasMoreRows,
+                Results = results,
+                __isset = { results = true, hasMoreRows = true }
+            };
+
+            // Clear any previous setups
+            _mockClient.Reset();
+
+            // Setup for any fetch request
+            _mockClient.Setup(c => c.FetchResults(It.IsAny<TFetchResultsReq>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(response);
+        }
+    }
+
+    /// <summary>
+    /// Mock clock implementation for testing time-dependent behavior.
+    /// </summary>
+    public class MockClock
+    {
+        private DateTimeOffset _now;
+
+        public MockClock()
+        {
+            _now = DateTimeOffset.UtcNow;
+        }
+
+        public DateTimeOffset UtcNow => _now;
+
+        public void AdvanceTime(TimeSpan timeSpan)
+        {
+            _now = _now.Add(timeSpan);
+        }
+
+        public void SetTime(DateTimeOffset time)
+        {
+            _now = time;
+        }
+    }
+
+    /// <summary>
+    /// Extension of CloudFetchUrlManager that uses a mock clock for testing.
+    /// </summary>
+    internal class CloudFetchUrlManagerWithMockClock : CloudFetchUrlManager
+    {
+        private readonly MockClock _mockClock;
+
+        public CloudFetchUrlManagerWithMockClock(
+            IHiveServer2Statement statement,
+            MockClock mockClock,
+            int expirationBufferSeconds = 60)
+            : base(statement, expirationBufferSeconds, new MockClockAdapter(mockClock))
+        {
+            _mockClock = mockClock;
+        }
+    }
+
+    /// <summary>
+    /// Adapter to convert MockClock to IClock interface.
+    /// </summary>
+    internal class MockClockAdapter : IClock
+    {
+        private readonly MockClock _mockClock;
+
+        public MockClockAdapter(MockClock mockClock)
+        {
+            _mockClock = mockClock;
+        }
+
+        public DateTime UtcNow => _mockClock.UtcNow.UtcDateTime;
+    }
+}

--- a/csharp/test/Drivers/Databricks/CloudFetchE2ETest.cs
+++ b/csharp/test/Drivers/Databricks/CloudFetchE2ETest.cs
@@ -53,6 +53,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             yield return new object[] { largeQuery, 1000000, false, false };
         }
 
+        [Fact]
+        public async Task SingleTest()
+        {
+            await TestRealDatabricksCloudFetch("SELECT * FROM main.tpcds_sf10_delta.catalog_sales LIMIT 1000000", 1000000, true, true);
+        }
+
         /// <summary>
         /// Integration test for running queries against a real Databricks cluster with different CloudFetch settings.
         /// </summary>
@@ -65,7 +71,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
                 [DatabricksParameters.UseCloudFetch] = useCloudFetch.ToString(),
                 [DatabricksParameters.EnableDirectResults] = enableDirectResults.ToString(),
                 [DatabricksParameters.CanDecompressLz4] = "true",
-                [DatabricksParameters.MaxBytesPerFile] = "10485760" // 10MB
+                [DatabricksParameters.MaxBytesPerFile] = "10485760", // 10MB
+                [DatabricksParameters.CloudFetchUrlExpirationBufferSeconds] = (15 * 60 - 2).ToString(),
             });
 
             // Execute a query that generates a large result set using range function

--- a/csharp/test/Drivers/Databricks/DatabricksOperationStatusPollerTests.cs
+++ b/csharp/test/Drivers/Databricks/DatabricksOperationStatusPollerTests.cs
@@ -18,7 +18,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch;
+using Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch;
 using Apache.Arrow.Adbc.Drivers.Databricks;
 using Apache.Hive.Service.Rpc.Thrift;
 using Moq;


### PR DESCRIPTION
### Problem
The Databricks driver's CloudFetch functionality was not properly handling expired cloud file URLs, which could lead to failed downloads and errors during query execution. The system needed a way to track, cache, and refresh presigned URLs before they expire.

### Solution
- Implemented a new `CloudFetchUrlManager` class that:
  - Manages a cache of cloud file URLs with their expiration times
  - Proactively refreshes URLs that are about to expire
  - Efficiently fetches and caches URLs in batches
  - Provides thread-safe access to URL information
- Added an `IClock` interface and implementations to facilitate testing with controlled time
- Extended the `IDownloadResult` interface to support URL refreshing and expiration checking
- Updated namespace from `Apache.Arrow.Adbc.Drivers.Apache.Databricks.CloudFetch` to `Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch` for better organization

### Testing
- Created comprehensive unit tests in `CloudFetchUrlManagerTest.cs` that verify:
  - URL caching behavior
  - Proper handling of URL expiration
  - Batch fetching of URLs
  - Refreshing of expired URLs
  - Thread safety of the implementation

This change improves the reliability of the CloudFetch functionality by ensuring that cloud file URLs are refreshed before they expire, preventing download failures during query execution