### PR TITLE
Generate versioned DLLs and import LIBs when building with MSVC

### DIFF
--- a/c/CMakePresets.json
+++ b/c/CMakePresets.json
@@ -24,6 +24,26 @@
             }
         },
         {
+            "name": "multi-config-windows",
+            "displayName": "Multi config for Windows without ASAN/UBSAN",
+            "generator": "Ninja Multi-Config",
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "ADBC_BUILD_TESTS": "ON",
+                "ADBC_DRIVER_FLIGHTSQL": "ON",
+                "ADBC_DRIVER_MANAGER": "ON",
+                "ADBC_DRIVER_POSTGRESQL": "ON",
+                "ADBC_DRIVER_SNOWFLAKE": "ON",
+                "ADBC_DRIVER_SQLITE": "ON",
+                "ADBC_BUILD_SHARED": "ON",
+                "ADBC_BUILD_STATIC": "OFF",
+                "ADBC_USE_ASAN": "OFF",
+                "ADBC_USE_UBSAN": "OFF",
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+            }
+        },
+        {
             "name": "debug-python",
             "displayName": "debug, all drivers, with tests, without ASan/UBSan (usable from Python)",
             "generator": "Ninja",
@@ -39,6 +59,18 @@
                 "ADBC_USE_ASAN": "OFF",
                 "ADBC_USE_UBSAN": "OFF"
             }
+        }
+    ],
+    "buildPresets": [
+        {
+          "name": "debug-windows",
+          "configurePreset": "multi-config-windows",
+          "configuration": "Debug"
+        },
+        {
+          "name": "release-windows",
+          "configurePreset": "multi-config-windows",
+          "configuration": "Release"
         }
     ],
     "testPresets": [

--- a/c/cmake_modules/AdbcDefines.cmake
+++ b/c/cmake_modules/AdbcDefines.cmake
@@ -95,7 +95,7 @@ if(MSVC)
   add_compile_options(/wd5027)
   add_compile_options(/wd5039)
   add_compile_options(/wd5045)
-  add_compile_options(/wd5246)
+  add_compile_options(/wd5246) 
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"
        OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
        OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -143,6 +143,18 @@ endmacro()
 # Common testing setup
 add_custom_target(all-tests)
 if(ADBC_BUILD_TESTS)
+  if(MSVC)
+    # MSVC emitted warnings for testing code
+    add_compile_options(/wd5204)
+    add_compile_options(/wd5026)
+    add_compile_options(/wd4266)
+    add_compile_options(/wd4265)
+    add_compile_options(/wd5262)
+    add_compile_options(/wd4146)
+    add_compile_options(/wd4244)
+    add_compile_options(/wd4307)
+  endif()
+
   find_package(GTest)
   if(NOT GTest_FOUND)
     message(STATUS "Building googletest from source")

--- a/c/cmake_modules/BuildUtils.cmake
+++ b/c/cmake_modules/BuildUtils.cmake
@@ -240,6 +240,21 @@ function(ADD_ARROW_LIB LIB_NAME)
                                      OUTPUT_NAME ${LIB_NAME}
                                      VERSION "${ADBC_FULL_SO_VERSION}"
                                      SOVERSION "${ADBC_SO_VERSION}")
+                                     
+    if(MSVC)
+        # Binaries generated on Windows need file version information, otherwise when the binary is part of a Windows installer
+        # the installer won't know to update a previously installed version.
+        set(VERSION_RC_TEMPLATE "${CMAKE_SOURCE_DIR}/cmake_modules/version.rc.in")
+        configure_file(
+            "${VERSION_RC_TEMPLATE}"
+            "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}_version.rc"
+            @ONLY
+        )
+    
+        target_sources(${LIB_NAME}_shared PRIVATE 
+            "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}_version.rc"
+        )
+    endif()
 
     # https://github.com/apache/arrow-adbc/issues/81
     target_compile_features(${LIB_NAME}_shared PRIVATE cxx_std_11)

--- a/c/cmake_modules/GoUtils.cmake
+++ b/c/cmake_modules/GoUtils.cmake
@@ -18,6 +18,13 @@
 find_program(GO_BIN "go" REQUIRED)
 message(STATUS "Detecting Go executable: Found ${GO_BIN}")
 
+# Find tools for generating import libraries on Windows
+if(MSVC)
+  # msys64 is needed for dlltool and gendef
+  find_program(DLLTOOL_BIN "dlltool")
+  find_program(GENDEF_BIN "gendef")
+endif()
+
 set(ADBC_GO_PACKAGE_INIT
     [=[
 get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
@@ -64,6 +71,19 @@ function(adbc_add_static_library target_name base_name)
   endif()
 endfunction()
 ]=])
+
+# Function to generate import library from DLL on Windows
+function(generate_import_library DLL_PATH LIB_PATH DEF_PATH)
+  add_custom_command(OUTPUT "${DEF_PATH}"
+                      COMMAND ${GENDEF_BIN} - "${DLL_PATH}" > "${DEF_PATH}"
+                      DEPENDS "${DLL_PATH}"
+                      COMMENT "Generating .def file from ${DLL_PATH}")
+        
+  add_custom_command(OUTPUT "${LIB_PATH}"
+                      COMMAND ${DLLTOOL_BIN} -d "${DEF_PATH}" -l "${LIB_PATH}" -D "${DLL_PATH}"
+                      DEPENDS "${DEF_PATH}"
+                      COMMENT "Generating import library ${LIB_PATH}")
+endfunction()
 
 function(add_go_lib GO_MOD_DIR GO_LIBNAME)
   set(options)
@@ -180,36 +200,78 @@ function(add_go_lib GO_MOD_DIR GO_LIBNAME)
       list(APPEND GO_ENV_VARS "GOARCH=arm64")
     endif()
 
-    add_custom_command(OUTPUT "${LIBOUT_SHARED}.${ADBC_FULL_SO_VERSION}"
-                       WORKING_DIRECTORY ${GO_MOD_DIR}
-                       DEPENDS ${ARG_SOURCES}
-                       COMMAND ${CMAKE_COMMAND} -E env ${GO_ENV_VARS} ${GO_BIN} build
-                               ${GO_BUILD_TAGS} "${GO_BUILD_FLAGS}" -o
-                               ${LIBOUT_SHARED}.${ADBC_FULL_SO_VERSION}
-                               -buildmode=c-shared ${GO_LDFLAGS} .
-                       COMMAND ${CMAKE_COMMAND} -E remove -f
-                               "${LIBOUT_SHARED}.${ADBC_SO_VERSION}.0.h"
-                       COMMENT "Building Go Shared lib ${GO_LIBNAME}"
-                       COMMAND_EXPAND_LISTS)
+    if(MSVC)
+      # On Windows with MSVC, generate a lib from the DLL file created by go. Binaries generated on Windows have their version
+      # as part of the DLL/file details, therefore the generated DLL file name does not need to have the version info.
+      set(LIBOUT_IMPORT_LIB "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_IMPORT_LIBRARY_PREFIX}${GO_LIBNAME}${CMAKE_IMPORT_LIBRARY_SUFFIX}")
+      set(LIBOUT_DEF_FILE "${CMAKE_CURRENT_BINARY_DIR}/${GO_LIBNAME}.def")
 
-    add_custom_command(OUTPUT "${LIBOUT_SHARED}.${ADBC_SO_VERSION}" "${LIBOUT_SHARED}"
-                       DEPENDS "${LIBOUT_SHARED}.${ADBC_FULL_SO_VERSION}"
-                       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                       COMMAND ${CMAKE_COMMAND} -E create_symlink
-                               "${LIB_NAME_SHARED}.${ADBC_FULL_SO_VERSION}"
-                               "${LIB_NAME_SHARED}.${ADBC_SO_VERSION}"
-                       COMMAND ${CMAKE_COMMAND} -E create_symlink
-                               "${LIB_NAME_SHARED}.${ADBC_SO_VERSION}"
-                               "${LIB_NAME_SHARED}")
+      add_custom_command(OUTPUT "${LIBOUT_SHARED}"
+                         WORKING_DIRECTORY ${GO_MOD_DIR}
+                         DEPENDS ${ARG_SOURCES}
+                         COMMAND ${CMAKE_COMMAND} -E env ${GO_ENV_VARS} ${GO_BIN} build
+                                 ${GO_BUILD_TAGS} "${GO_BUILD_FLAGS}" -o
+                                 ${LIBOUT_SHARED}
+                                 -buildmode=c-shared ${GO_LDFLAGS} .
+                         COMMAND ${CMAKE_COMMAND} -E remove -f
+                                 "${LIBOUT_SHARED}.h"
+                         COMMENT "Building Go Shared lib ${GO_LIBNAME}"
+                         COMMAND_EXPAND_LISTS)
 
-    add_custom_target(${GO_LIBNAME}_target ALL
-                      DEPENDS "${LIBOUT_SHARED}.${ADBC_FULL_SO_VERSION}"
-                              "${LIBOUT_SHARED}.${ADBC_SO_VERSION}" "${LIBOUT_SHARED}")
-    add_library(${GO_LIBNAME}_shared SHARED IMPORTED GLOBAL)
-    set_target_properties(${GO_LIBNAME}_shared
-                          PROPERTIES IMPORTED_LOCATION
-                                     "${LIBOUT_SHARED}.${ADBC_FULL_SO_VERSION}"
-                                     IMPORTED_SONAME "${LIB_NAME_SHARED}")
+      # Generate import library if tools are available
+      if(GENDEF_BIN AND DLLTOOL_BIN)
+        generate_import_library("${LIBOUT_SHARED}" "${LIBOUT_IMPORT_LIB}" "${LIBOUT_DEF_FILE}")
+        set(IMPORT_LIB_OUTPUTS "${LIBOUT_IMPORT_LIB}" "${LIBOUT_DEF_FILE}")
+      else()
+        set(IMPORT_LIB_OUTPUTS)
+        message(WARNING "Import library generation tools not found. You may need to link directly to the DLL or use delay-loading.")
+      endif()
+
+      add_custom_target(${GO_LIBNAME}_target ALL
+                        DEPENDS "${LIBOUT_SHARED}"
+                                ${IMPORT_LIB_OUTPUTS})
+      
+      add_library(${GO_LIBNAME}_shared SHARED IMPORTED GLOBAL)
+      set_target_properties(${GO_LIBNAME}_shared
+                            PROPERTIES IMPORTED_LOCATION "${LIBOUT_SHARED}")
+      
+      # Set import library if it was generated
+      if(IMPORT_LIB_OUTPUTS)
+        set_target_properties(${GO_LIBNAME}_shared
+                              PROPERTIES IMPORTED_IMPLIB "${LIBOUT_IMPORT_LIB}")
+      endif()
+    else()
+      add_custom_command(OUTPUT "${LIBOUT_SHARED}.${ADBC_FULL_SO_VERSION}"
+                         WORKING_DIRECTORY ${GO_MOD_DIR}
+                         DEPENDS ${ARG_SOURCES}
+                         COMMAND ${CMAKE_COMMAND} -E env ${GO_ENV_VARS} ${GO_BIN} build
+                                 ${GO_BUILD_TAGS} "${GO_BUILD_FLAGS}" -o
+                                 ${LIBOUT_SHARED}.${ADBC_FULL_SO_VERSION}
+                                 -buildmode=c-shared ${GO_LDFLAGS} .
+                         COMMAND ${CMAKE_COMMAND} -E remove -f
+                                 "${LIBOUT_SHARED}.${ADBC_SO_VERSION}.0.h"
+                         COMMENT "Building Go Shared lib ${GO_LIBNAME}"
+                         COMMAND_EXPAND_LISTS)
+
+      add_custom_command(OUTPUT "${LIBOUT_SHARED}.${ADBC_SO_VERSION}" "${LIBOUT_SHARED}"
+                         DEPENDS "${LIBOUT_SHARED}.${ADBC_FULL_SO_VERSION}"
+                         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                         COMMAND ${CMAKE_COMMAND} -E create_symlink
+                                 "${LIB_NAME_SHARED}.${ADBC_FULL_SO_VERSION}"
+                                 "${LIB_NAME_SHARED}.${ADBC_SO_VERSION}"
+                         COMMAND ${CMAKE_COMMAND} -E create_symlink
+                                 "${LIB_NAME_SHARED}.${ADBC_SO_VERSION}"
+                                 "${LIB_NAME_SHARED}")
+
+      add_custom_target(${GO_LIBNAME}_target ALL
+                        DEPENDS "${LIBOUT_SHARED}.${ADBC_FULL_SO_VERSION}"
+                                "${LIBOUT_SHARED}.${ADBC_SO_VERSION}" "${LIBOUT_SHARED}")
+      add_library(${GO_LIBNAME}_shared SHARED IMPORTED GLOBAL)
+      set_target_properties(${GO_LIBNAME}_shared
+                            PROPERTIES IMPORTED_LOCATION
+                                       "${LIBOUT_SHARED}.${ADBC_FULL_SO_VERSION}"
+                                       IMPORTED_SONAME "${LIB_NAME_SHARED}")
+    endif()
     add_dependencies(${GO_LIBNAME}_shared ${GO_LIBNAME}_target)
     if(ARG_OUTPUTS)
       list(APPEND ${ARG_OUTPUTS} ${GO_LIBNAME}_shared)
@@ -239,6 +301,9 @@ function(add_go_lib GO_MOD_DIR GO_LIBNAME)
       if(WIN32)
         install(PROGRAMS $<TARGET_FILE:${GO_LIBNAME}_shared> ${INSTALL_IS_OPTIONAL}
                 DESTINATION ${RUNTIME_INSTALL_DIR})
+        if(IMPORT_LIB_OUTPUTS)
+          install(FILES "${LIBOUT_IMPORT_LIB}" TYPE LIB)
+        endif()
       else()
         install(PROGRAMS $<TARGET_FILE:${GO_LIBNAME}_shared> ${INSTALL_IS_OPTIONAL}
                 TYPE LIB)
@@ -255,8 +320,10 @@ function(add_go_lib GO_MOD_DIR GO_LIBNAME)
               ${CMAKE_INSTALL_LIBDIR})
     endif()
     if(WIN32)
-      # This symlink doesn't get installed
-      install(FILES "${LIBOUT_SHARED}.${ADBC_SO_VERSION}" TYPE BIN)
+      install(FILES "${LIBOUT_SHARED}" TYPE BIN)
+      if(IMPORT_LIB_OUTPUTS)
+        install(FILES "${LIBOUT_IMPORT_LIB}" TYPE LIB)
+      endif()
     else()
       install(FILES "${LIBOUT_SHARED}" "${LIBOUT_SHARED}.${ADBC_SO_VERSION}" TYPE LIB)
     endif()

--- a/c/cmake_modules/version.rc.in
+++ b/c/cmake_modules/version.rc.in
@@ -1,0 +1,27 @@
+#include <windows.h>
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION @ADBC_VERSION_MAJOR@,@ADBC_VERSION_MINOR@,@ADBC_VERSION_PATCH@,0
+PRODUCTVERSION @ADBC_VERSION_MAJOR@,@ADBC_VERSION_MINOR@,@ADBC_VERSION_PATCH@,0
+FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+FILEFLAGS 0x0L
+FILEOS VOS__WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "FileDescription", "ADBC: Arrow Database Connectivity"
+            VALUE "FileVersion", "@ADBC_FULL_SO_VERSION@"
+            VALUE "ProductVersion", "@ADBC_FULL_SO_VERSION@"
+            VALUE "CompanyName", "Apache"
+            VALUE "ProductName", "@LIB_NAME@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/c/driver/flightsql/CMakeLists.txt
+++ b/c/driver/flightsql/CMakeLists.txt
@@ -63,6 +63,18 @@ if(ADBC_BUILD_TESTS)
                 adbc_driver_common
                 adbc_validation
                 ${TEST_LINK_LIBS})
+
+  if(ADBC_TEST_LINKAGE STREQUAL "shared")
+    # The go build is not copying the DLL to the test location, causing the test to fail on Windows.
+    if (MSVC)
+      add_custom_command(TARGET adbc-driver-flightsql-test POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                  "$<TARGET_FILE:adbc_driver_flightsql_shared>"
+                  "$<TARGET_FILE_DIR:adbc-driver-flightsql-test>"
+      )
+    endif()
+  endif()
+
   target_compile_features(adbc-driver-flightsql-test PRIVATE cxx_std_17)
   target_include_directories(adbc-driver-flightsql-test SYSTEM
                              PRIVATE ${REPOSITORY_ROOT}/c/ ${REPOSITORY_ROOT}/c/include/

--- a/c/driver/postgresql/copy/postgres_copy_reader_test.cc
+++ b/c/driver/postgresql/copy/postgres_copy_reader_test.cc
@@ -237,10 +237,10 @@ TEST(PostgresCopyUtilsTest, PostgresCopyReadReal) {
   ASSERT_TRUE(ArrowBitGet(validity, 3));
   ASSERT_FALSE(ArrowBitGet(validity, 4));
 
-  ASSERT_FLOAT_EQ(data_buffer[0], -123.456);
+  ASSERT_FLOAT_EQ(data_buffer[0], -123.456f);
   ASSERT_EQ(data_buffer[1], -1);
   ASSERT_EQ(data_buffer[2], 1);
-  ASSERT_FLOAT_EQ(data_buffer[3], 123.456);
+  ASSERT_FLOAT_EQ(data_buffer[3], 123.456f);
   ASSERT_EQ(data_buffer[4], 0);
 }
 

--- a/c/driver/snowflake/CMakeLists.txt
+++ b/c/driver/snowflake/CMakeLists.txt
@@ -63,6 +63,18 @@ if(ADBC_BUILD_TESTS)
                 adbc_validation
                 nanoarrow
                 ${TEST_LINK_LIBS})
+
+  if(ADBC_TEST_LINKAGE STREQUAL "shared")
+    # The go build is not copying the DLL to the test location, causing the test to fail on Windows.
+    if (MSVC)
+      add_custom_command(TARGET adbc-driver-snowflake-test POST_BUILD
+          COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                  "$<TARGET_FILE:adbc_driver_snowflake_shared>"
+                  "$<TARGET_FILE_DIR:adbc-driver-snowflake-test>"
+      )
+    endif()
+  endif()
+
   target_compile_features(adbc-driver-snowflake-test PRIVATE cxx_std_17)
   target_include_directories(adbc-driver-snowflake-test SYSTEM
                              PRIVATE ${REPOSITORY_ROOT}/c/ ${REPOSITORY_ROOT}/c/include/

--- a/c/driver/sqlite/sqlite_test.cc
+++ b/c/driver/sqlite/sqlite_test.cc
@@ -446,7 +446,7 @@ class SqliteReaderTest : public ::testing::Test {
 
   void Exec(const std::string& query) {
     SCOPED_TRACE(query);
-    int rc = sqlite3_prepare_v2(db, query.c_str(), query.size(), &stmt,
+    int rc = sqlite3_prepare_v2(db, query.c_str(), static_cast<int>(query.size()), &stmt,
                                 /*pzTail=*/nullptr);
     ASSERT_EQ(SQLITE_OK, rc) << "Failed to prepare query: " << sqlite3_errmsg(db);
     ASSERT_EQ(SQLITE_DONE, sqlite3_step(stmt));
@@ -478,7 +478,7 @@ class SqliteReaderTest : public ::testing::Test {
 
   void Exec(const std::string& query, size_t infer_rows,
             adbc_validation::StreamReader* reader) {
-    ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db, query.c_str(), query.size(), &stmt,
+    ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db, query.c_str(), static_cast<int>(query.size()), &stmt,
                                             /*pzTail=*/nullptr));
     struct AdbcSqliteBinder* binder =
         this->binder.schema.release ? &this->binder : nullptr;

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -426,8 +426,15 @@ AdbcStatusCode InternalAdbcSqliteBinderBindNext(struct AdbcSqliteBinder* binder,
         }
         case NANOARROW_TYPE_TIMESTAMP: {
           struct ArrowSchemaView bind_schema_view;
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244) // RAISE_NA returns ArrowErrorCode, but this function returns AdbcStatusCode
+#endif
           RAISE_NA(ArrowSchemaViewInit(&bind_schema_view, binder->schema.children[col],
                                        &arrow_error));
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
           enum ArrowTimeUnit unit = bind_schema_view.time_unit;
           int64_t value =
               ArrowArrayViewGetIntUnsafe(binder->batch.children[col], binder->next_row);

--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -675,7 +675,7 @@ std::string AdbcDriverManagerDefaultEntrypoint(const std::string& driver) {
     // if pos == npos this is the entire filename
     std::string token = filename.substr(prev, pos - prev);
     // capitalize first letter
-    token[0] = std::toupper(static_cast<unsigned char>(token[0]));
+    token[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(token[0])));
 
     entrypoint += token;
 

--- a/c/validation/adbc_validation.cc
+++ b/c/validation/adbc_validation.cc
@@ -51,11 +51,11 @@ AdbcStatusCode DoIngestSampleTable(struct AdbcConnection* connection,
   Handle<struct ArrowSchema> schema;
   Handle<struct ArrowArray> array;
   struct ArrowError na_error;
-  CHECK_OK(MakeSchema(&schema.value, {{"int64s", NANOARROW_TYPE_INT64},
-                                      {"strings", NANOARROW_TYPE_STRING}}));
-  CHECK_OK((MakeBatch<int64_t, std::string>(&schema.value, &array.value, &na_error,
+  CHECK_OK(static_cast<AdbcStatusCode>(MakeSchema(&schema.value, {{"int64s", NANOARROW_TYPE_INT64},
+                                      {"strings", NANOARROW_TYPE_STRING}})));
+  CHECK_OK((static_cast<AdbcStatusCode>(MakeBatch<int64_t, std::string>(&schema.value, &array.value, &na_error,
                                             {42, -42, std::nullopt},
-                                            {"foo", std::nullopt, ""})));
+                                            {"foo", std::nullopt, ""}))));
 
   Handle<struct AdbcStatement> statement;
   CHECK_OK(AdbcStatementNew(connection, &statement.value, error));

--- a/c/validation/adbc_validation_connection.cc
+++ b/c/validation/adbc_validation_connection.cc
@@ -868,7 +868,7 @@ void ConstraintTest(const AdbcGetObjectsConstraint* constraint,
                     const std::vector<std::string>& columns) {
   std::string_view constraint_type(constraint->constraint_type.data,
                                    constraint->constraint_type.size_bytes);
-  int number_of_columns = columns.size();
+  int number_of_columns = static_cast<int>(columns.size());
   ASSERT_EQ(constraint_type, key_type);
   ASSERT_EQ(constraint->n_column_names, number_of_columns)
       << "expected constraint " << key_type

--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -1358,22 +1358,22 @@ void StatementTest::TestSqlIngestTemporaryAppend() {
     ASSERT_THAT((MakeBatch<int64_t>(&schema.value, &array.value, &na_error, {0, 1, 2})),
                 IsOkErrno());
 
-    Handle<struct AdbcStatement> statement;
-    ASSERT_THAT(AdbcStatementNew(&connection, &statement.value, &error),
+    Handle<struct AdbcStatement> statement2;
+    ASSERT_THAT(AdbcStatementNew(&connection, &statement2.value, &error),
                 IsOkStatus(&error));
 
-    ASSERT_THAT(AdbcStatementSetOption(&statement.value, ADBC_INGEST_OPTION_TEMPORARY,
+    ASSERT_THAT(AdbcStatementSetOption(&statement2.value, ADBC_INGEST_OPTION_TEMPORARY,
                                        ADBC_OPTION_VALUE_ENABLED, &error),
                 IsOkStatus(&error));
-    ASSERT_THAT(AdbcStatementSetOption(&statement.value, ADBC_INGEST_OPTION_MODE,
+    ASSERT_THAT(AdbcStatementSetOption(&statement2.value, ADBC_INGEST_OPTION_MODE,
                                        ADBC_INGEST_OPTION_MODE_APPEND, &error),
                 IsOkStatus(&error));
-    ASSERT_THAT(AdbcStatementSetOption(&statement.value, ADBC_INGEST_OPTION_TARGET_TABLE,
+    ASSERT_THAT(AdbcStatementSetOption(&statement2.value, ADBC_INGEST_OPTION_TARGET_TABLE,
                                        name.c_str(), &error),
                 IsOkStatus(&error));
-    ASSERT_THAT(AdbcStatementBind(&statement.value, &array.value, &schema.value, &error),
+    ASSERT_THAT(AdbcStatementBind(&statement2.value, &array.value, &schema.value, &error),
                 IsOkStatus(&error));
-    ASSERT_THAT(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, &error),
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement2.value, nullptr, nullptr, &error),
                 IsOkStatus(&error));
   }
 
@@ -1533,22 +1533,22 @@ void StatementTest::TestSqlIngestTemporaryReplace() {
                                                  {"foo", "bar", std::nullopt})),
                 IsOkErrno());
 
-    Handle<struct AdbcStatement> statement;
-    ASSERT_THAT(AdbcStatementNew(&connection, &statement.value, &error),
+    Handle<struct AdbcStatement> statement2;
+    ASSERT_THAT(AdbcStatementNew(&connection, &statement2.value, &error),
                 IsOkStatus(&error));
 
-    ASSERT_THAT(AdbcStatementSetOption(&statement.value, ADBC_INGEST_OPTION_TEMPORARY,
+    ASSERT_THAT(AdbcStatementSetOption(&statement2.value, ADBC_INGEST_OPTION_TEMPORARY,
                                        ADBC_OPTION_VALUE_ENABLED, &error),
                 IsOkStatus(&error));
-    ASSERT_THAT(AdbcStatementSetOption(&statement.value, ADBC_INGEST_OPTION_MODE,
+    ASSERT_THAT(AdbcStatementSetOption(&statement2.value, ADBC_INGEST_OPTION_MODE,
                                        ADBC_INGEST_OPTION_MODE_APPEND, &error),
                 IsOkStatus(&error));
-    ASSERT_THAT(AdbcStatementSetOption(&statement.value, ADBC_INGEST_OPTION_TARGET_TABLE,
+    ASSERT_THAT(AdbcStatementSetOption(&statement2.value, ADBC_INGEST_OPTION_TARGET_TABLE,
                                        name.c_str(), &error),
                 IsOkStatus(&error));
-    ASSERT_THAT(AdbcStatementBind(&statement.value, &array.value, &schema.value, &error),
+    ASSERT_THAT(AdbcStatementBind(&statement2.value, &array.value, &schema.value, &error),
                 IsOkStatus(&error));
-    ASSERT_THAT(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, &error),
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement2.value, nullptr, nullptr, &error),
                 IsOkStatus(&error));
   }
 

--- a/c/validation/adbc_validation_util.h
+++ b/c/validation/adbc_validation_util.h
@@ -432,8 +432,8 @@ void CompareArray(struct ArrowArrayView* array,
       } else if constexpr (std::is_same<T, std::vector<std::byte>>::value) {
         struct ArrowBufferView view = ArrowArrayViewGetBytesUnsafe(array, i);
         ASSERT_EQ(v->size(), view.size_bytes);
-        for (int64_t i = 0; i < view.size_bytes; i++) {
-          ASSERT_EQ((*v)[i], std::byte{view.data.as_uint8[i]});
+        for (int64_t i2 = 0; i2 < view.size_bytes; i2++) {
+          ASSERT_EQ((*v)[i2], std::byte{view.data.as_uint8[i2]});
         }
       } else if constexpr (std::is_same<T, ArrowInterval*>::value) {
         ASSERT_NE(array->buffer_views[1].data.data, nullptr);


### PR DESCRIPTION
Hi.

This is to address building binaries and LIBs on Windows. The PR is mainly for consideration purposes, as it's my first PR against this repo so not necessarily a complete one. Following are the changes I needed to make:
- Disable ASAN/UBSAN builds configs as they require GCC/Clang, and on Windows we're building with MSVC.
- An environment variable to `vcpkg` root is expected so that third party packages (sqlite, postgres etc) can be installed and found via vcpkg.
- Disable some warnings for testing code that are safe to ignore for MSVC builds.
- Ensure the generated binaries have file level details (Details tab on the file properties in Windows) for the version. This is required by Windows MSIs that may be used to install the adbc DLLs in order to detect if the DLL being installed is a newer or older version.
- Generate import LIB file for drivers built with go build, which includes flight SQL and Snowflake drivers. This allows the testing projects referencing those DLLs to built on Windows.
- The `GoUtils.cmake` is not automatically copying the driver DLLs to the location of the test executables, causing the tests for those drivers to fail. Added a post build command to ensure the DLLs are copied.
- Fix some type casting mismatch (casting between size_t and int).
- Fix warnings where a variable is hiding a previous one with the same name. Appended `2` to the second variable name.

What I haven't done is update the GitHub actions to verify a complete build on a Windows machine as I'm not too familiar with the CI/CD pipeline in this repo.

Hopefully this is a good start to get everything building successfully and Windows.

FYI @WillAyd @lidavidm 

Closes #2846 