### PR TITLE
fix(rust/core): URLs pointing to `adbc.h` in docs

### DIFF
--- a/rust/core/src/driver_manager.rs
+++ b/rust/core/src/driver_manager.rs
@@ -19,7 +19,7 @@
 //!
 //! The driver manager provides an implementation of the ADBC interface which
 //! uses FFI to wrap an object file implementation of
-//! [`adbc.h`](https://github.com/apache/arrow-adbc/blob/main/adbc.h).
+//! [`adbc.h`](https://github.com/apache/arrow-adbc/blob/main/c/include/arrow-adbc/adbc.h).
 //!
 //! There are two ways that drivers can be used:
 //! 1. By linking (either statically or dynamically) the driver implementation

--- a/rust/core/src/ffi/mod.rs
+++ b/rust/core/src/ffi/mod.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! C-compatible items as defined in [`adbc.h`](https://github.com/apache/arrow-adbc/blob/main/adbc.h)
+//! C-compatible items as defined in [`adbc.h`](https://github.com/apache/arrow-adbc/blob/main/c/include/arrow-adbc/adbc.h)
 
 pub mod constants;
 pub(crate) mod methods;

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -28,7 +28,7 @@
 //! This library currently provides:
 //! - An abstract Rust API to be implemented by vendor-specific drivers.
 //! - A driver manager which implements this same API, but dynamically loads
-//!   drivers internally and forwards calls appropriately using the [C API](https://github.com/apache/arrow-adbc/blob/main/adbc.h).
+//!   drivers internally and forwards calls appropriately using the [C API](https://github.com/apache/arrow-adbc/blob/main/c/include/arrow-adbc/adbc.h).
 //! - A driver exporter that takes an implementation of the abstract API and
 //!   turns it into an object file that implements the C API.
 //!


### PR DESCRIPTION
docs(rust/core): Update URLs pointing to `adbc.h` in Rust documentation.

Fixes #2882 . Update of URLs pointing to the `adbc.h` in the Rust crate documentation, which moved in #1965 (I think).