### PR TITLE
fix(csharp/src/Drivers/Databricks): Fix parsing of lowercase server side properties

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -345,7 +345,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         private Dictionary<string, string> GetServerSideProperties()
         {
             return Properties
-                .Where(p => p.Key.StartsWith(DatabricksParameters.ServerSidePropertyPrefix))
+                .Where(p => p.Key.ToLowerInvariant().StartsWith(DatabricksParameters.ServerSidePropertyPrefix))
                 .ToDictionary(
                     p => p.Key.Substring(DatabricksParameters.ServerSidePropertyPrefix.Length),
                     p => p.Value

--- a/csharp/src/Drivers/Databricks/DatabricksParameters.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksParameters.cs
@@ -79,10 +79,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// <summary>
         /// Prefix for server-side properties. Properties with this prefix will be passed to the server
         /// by executing a "set key=value" query when opening a session.
-        /// For example, a property with key "adbc.databricks.SSP_use_cached_result"
+        /// For example, a property with key "adbc.databricks.ssp_use_cached_result"
         /// and value "true" will result in executing "set use_cached_result=true" on the server.
         /// </summary>
-        public const string ServerSidePropertyPrefix = "adbc.databricks.SSP_";
+        public const string ServerSidePropertyPrefix = "adbc.databricks.ssp_";
+
         /// Controls whether to retry requests that receive a 503 response with a Retry-After header.
         /// Default value is true (enabled). Set to false to disable retry behavior.
         /// </summary>


### PR DESCRIPTION
- The Mashup engine will convert all property keys to lower case before opening a connection with the driver
- So, using server side property passthrough with Power BI/PQTest doesn't work, because none of the properties will start with `SSP_`
- This PR will change the prefix to `ssp_` and convert keys to lowercase so that the driver still works with properties set with `SSP_`
- Tested by setting server side property through PQTest