### PR TITLE
feat(go/adbc/driver/snowflake): Add a static version number

### DIFF
--- a/go/adbc/version.go
+++ b/go/adbc/version.go
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package adbc
+
+const DriverVersion = "1.7.0"


### PR DESCRIPTION
We have pre-production workstreams with the Go drivers in them, but when we need to get the driver version, it always comes back as `(unknown or development build)` which makes debugging issues that much more difficult. Dependencies used by the ADBC stack (like gosnowflake and arrow) have a static version that can be used to update the metadata. This PR adds support for a static version number that can be accessed via the metadata call. 