### PR TITLE
feat(csharp/src/Drivers/Databricks): Add cloud fetch heartbeat polling tests

### DIFF
--- a/csharp/test/Drivers/Databricks/StatementTests.cs
+++ b/csharp/test/Drivers/Databricks/StatementTests.cs
@@ -436,7 +436,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
 
         // NOTE: this is a thirty minute test. As of writing, databricks commands have 20 minutes of idle time (and checked every 5 mintues)
         [SkippableTheory]
-        [InlineData(false, "CloudFetch disabled")] // TODO: test cloudfetch enabled
+        [InlineData(false, "CloudFetch disabled")]
+        [InlineData(true, "CloudFetch enabled")]
         public async Task StatusPollerKeepsQueryAlive(bool useCloudFetch, string configName)
         {
             OutputHelper?.WriteLine($"Testing status poller with long delay between reads ({configName})");
@@ -450,7 +451,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             using var statement = connection.CreateStatement();
 
             // Execute a query that should return data - using a larger dataset to ensure multiple batches
-            statement.SqlQuery = "SELECT id, CAST(id AS STRING) as id_string, id * 2 as id_doubled FROM RANGE(3000000)";
+            statement.SqlQuery = "SELECT id, CAST(id AS STRING) as id_string, id * 2 as id_doubled FROM RANGE(30000000)";
             QueryResult result = statement.ExecuteQuery();
 
             Assert.NotNull(result.Stream);
@@ -475,7 +476,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             }
 
             // Verify we got all rows
-            Assert.Equal(3000000, totalRows);
+            Assert.Equal(30000000, totalRows);
             Assert.True(batchCount > 1, "Should have read multiple batches");
             OutputHelper?.WriteLine($"Successfully read {totalRows} rows in {batchCount} batches after 30 minute delay with {configName}");
         }


### PR DESCRIPTION
This PR:
https://github.com/apache/arrow-adbc/commit/317c9c90c690a8dedb2f4557337c12ad9cd673df

Re-fetches expired cloudfetch URLs, enabling longer cloud fetch streaming reads 