### PR TITLE
feat(csharp/src/Drivers/Databricks): Multiple catalogs with default database

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -165,8 +165,17 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             // Parse default namespace
             string? defaultCatalog = null;
             string? defaultSchema = null;
-            Properties.TryGetValue(AdbcOptions.Connection.CurrentCatalog, out defaultCatalog);
+            // only if enableMultipleCatalogSupport is true, do we supply catalog from connection properties
+            if (_enableMultipleCatalogSupport)
+            {
+                Properties.TryGetValue(AdbcOptions.Connection.CurrentCatalog, out defaultCatalog);
+            }
             Properties.TryGetValue(AdbcOptions.Connection.CurrentDbSchema, out defaultSchema);
+
+            // This maintains backward compatibility with older workspaces, where the Hive metastore was accessed via the spark catalog name.
+            // In newer DBR versions with Unity Catalog, the default catalog is typically hive_metastore.
+            // Passing null here allows the runtime to fall back to the workspace-defined default catalog for the session.
+            defaultCatalog = HandleSparkCatalog(defaultCatalog);
 
             if (!string.IsNullOrWhiteSpace(defaultCatalog) || !string.IsNullOrWhiteSpace(defaultSchema))
             {
@@ -470,7 +479,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 
         protected override void ValidateOptions()
         {
-             base.ValidateOptions();
+            base.ValidateOptions();
 
             if (Properties.TryGetValue(DatabricksParameters.TemporarilyUnavailableRetry, out string? tempUnavailableRetryStr))
             {
@@ -573,6 +582,15 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 // For other auth flows, use default OAuth validation
                 base.ValidateOAuthParameters();
             }
+        }
+
+        internal static string? HandleSparkCatalog(string? CatalogName)
+        {
+            if (CatalogName != null && CatalogName.Equals("SPARK", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+            return CatalogName;
         }
     }
 }

--- a/csharp/src/Drivers/Databricks/DatabricksStatement.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksStatement.cs
@@ -46,13 +46,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             var defaultNamespace = ((DatabricksConnection)Connection).DefaultNamespace;
             if (defaultNamespace != null)
             {
+                // TODO: we should not blindly overwrite, for crossReferenceAsync handling (though, still works)
                 if (CatalogName == null && connection.EnableMultipleCatalogSupport)
                 {
                     CatalogName = defaultNamespace.CatalogName;
-                }
-                if (SchemaName == null)
-                {
-                    SchemaName = defaultNamespace.SchemaName;
                 }
             }
             // Inherit CloudFetch settings from connection
@@ -190,10 +187,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// </summary>
         private void HandleSparkCatalog()
         {
-            if (CatalogName != null && CatalogName.Equals("SPARK", StringComparison.OrdinalIgnoreCase))
-            {
-                CatalogName = null;
-            }
+            CatalogName = DatabricksConnection.HandleSparkCatalog(CatalogName);
         }
 
         /// <summary>

--- a/csharp/src/Drivers/Databricks/DatabricksStatement.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksStatement.cs
@@ -46,7 +46,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             var defaultNamespace = ((DatabricksConnection)Connection).DefaultNamespace;
             if (defaultNamespace != null)
             {
-                if (CatalogName == null)
+                if (CatalogName == null && connection.EnableMultipleCatalogSupport)
                 {
                     CatalogName = defaultNamespace.CatalogName;
                 }

--- a/csharp/test/Drivers/Databricks/StatementTests.cs
+++ b/csharp/test/Drivers/Databricks/StatementTests.cs
@@ -819,7 +819,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
 
         // run this test with dbr < 10.4
         [SkippableFact]
-        public async Task OlderDBRVersion_ShouldSetSchemaViaUseStatement()
+        public async Task ShouldSetSuccessfullySchema()
         {
             // Test case: Older DBR version should still set schema via USE statement.
             // skip if no schema is provided by user

--- a/csharp/test/Drivers/Databricks/StatementTests.cs
+++ b/csharp/test/Drivers/Databricks/StatementTests.cs
@@ -819,7 +819,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
 
         // run this test with dbr < 10.4
         [SkippableFact]
-        public async Task ShouldSetSuccessfullySchema()
+        public async Task OlderDBRVersion_ShouldSetSchemaViaUseStatement()
         {
             // Test case: Older DBR version should still set schema via USE statement.
             // skip if no schema is provided by user


### PR DESCRIPTION
### Changes
This PR makes changes to be consistent with odbc behavior


#### ODBC behavior:
- Does not attach default schema (from OpenSessionResp) in subsequent queries. This PR changes to be like ODBC here, just to not break anything.
- If catalog == "SPARK", do not set catalog in initial namespace; let server return default catalog

#### ODBC does the following when `EnableMultipleCatalogsSupport=0`
- Do not set catalog in the initial namespace.
- Do not use the OpenSessionResp catalog for subsequent queries (including metadata queries)


#### ODBC Driver Behavior Testing

| Connection String Catalog/Schema                | EnableMultipleCatalogs=False                                                                 | EnableMultipleCatalogs=True                                                                  |
|--------------------------------------------------|-----------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
| Only default catalog = x                         | OpenSession(null, “default”)<br>GetColumns(null, null, null, null)                           | OpenSession(x, “default”)<br>GetColumns(x, null, null, null)                                |
| Only default schema = x                          | OpenSession(null, x)<br>GetColumns(null, null, null, null)                                   | OpenSession(null, x)<br>GetColumns(hive_metastore, null, null, null)                        |
| Both catalog + schema x, y                       | OpenSession(null, y)<br>GetColumns(null, null, null, null)                                      | OpenSession(x, y)<br>GetColumns(x, null, null, null)                                        |
| Only default Catalog “SPARK”, schema = null      | OpenSessionReq(null, “default”)<br>GetColumns(null, null, null, null)                        | OpenSessionReq(null, “default”)<br>GetColumns(hive_metastore, null, null, null)             |
| Both with default catalog “SPARK”, schema = x    | OpenSessionReq: null Catalog, x schema<br>GetColumns(null, null, null, null)                 | OpenSessionReq(null, x)<br>GetColumns(hive_metastore, null, null, null)                     |


### Testing
Adds an extensive grid test to validate different edge cases during creation



### TODO
- Make initial_namespace.schema "default" as default behavior
- CatalogName + Foreign CatlogName
- Add testing for old dbr (dbr 7.3, 9.1)