### PR TITLE
fix(python/adbc_driver_manager): don't leak array streams

### DIFF
--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyi
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyi
@@ -141,13 +141,19 @@ class AdbcStatusCode(enum.IntEnum):
     UNKNOWN = ...
 
 class ArrowArrayHandle:
-    address: Any
+    address: int
+    is_valid: bool
+    def release(self) -> None: ...
 
 class ArrowArrayStreamHandle:
-    address: Any
+    address: int
+    is_valid: bool
+    def release(self) -> None: ...
 
 class ArrowSchemaHandle:
-    address: Any
+    address: int
+    is_valid: bool
+    def release(self) -> None: ...
 
 class DataError(DatabaseError): ...
 class DatabaseError(Error): ...

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -420,6 +420,22 @@ cdef class ArrowArrayStreamHandle:
         """The address of the ArrowArrayStream."""
         return <uintptr_t> &self.stream
 
+    @property
+    def is_valid(self) -> bool:
+        """Check validility (object has non-NULL release pointer)."""
+        return self.stream.release != NULL
+
+    def release(self):
+        """Release this stream without having to import it.
+
+        No-op if already released (if ``not self.is_valid``).
+
+        Postcondition: ``not self.is_valid``.
+        """
+        if self.stream.release != NULL:
+            self.stream.release(&self.stream)
+            self.stream.release = NULL
+
     def __arrow_c_stream__(self, requested_schema=None) -> object:
         """Consume this object to get a PyCapsule."""
         if requested_schema is not None:

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -370,10 +370,29 @@ cdef class ArrowSchemaHandle:
     cdef:
         CArrowSchema schema
 
+    def __del__(self):
+        self.release()
+
     @property
     def address(self) -> int:
         """The address of the ArrowSchema."""
         return <uintptr_t> &self.schema
+
+    @property
+    def is_valid(self) -> bool:
+        """Check validility (object has non-NULL release pointer)."""
+        return self.schema.release != NULL
+
+    def release(self):
+        """Release this schema without having to import it.
+
+        No-op if already released (if ``not self.is_valid``).
+
+        Postcondition: ``not self.is_valid``.
+        """
+        if self.schema.release != NULL:
+            self.schema.release(&self.schema)
+            self.schema.release = NULL
 
     def __arrow_c_schema__(self) -> object:
         """Consume this object to get a PyCapsule."""
@@ -398,6 +417,25 @@ cdef class ArrowArrayHandle:
     cdef:
         CArrowArray array
 
+    def __del__(self):
+        self.release()
+
+    @property
+    def is_valid(self) -> bool:
+        """Check validility (object has non-NULL release pointer)."""
+        return self.array.release != NULL
+
+    def release(self):
+        """Release this array without having to import it.
+
+        No-op if already released (if ``not self.is_valid``).
+
+        Postcondition: ``not self.is_valid``.
+        """
+        if self.array.release != NULL:
+            self.array.release(&self.array)
+            self.array.release = NULL
+
     @property
     def address(self) -> int:
         """
@@ -414,6 +452,9 @@ cdef class ArrowArrayStreamHandle:
     """
     cdef:
         CArrowArrayStream stream
+
+    def __del__(self):
+        self.release()
 
     @property
     def address(self) -> int:


### PR DESCRIPTION
The driver manager was leaking array streams in the case that you executed a query, *did not fetch the result*, then did another operation.  In this case, because the stream was never imported, it would silently leak.  Avoid this by explicitly/directly releasing any extant array stream before another driver operation.