### PR TITLE
chore(c): fix typo

### DIFF
--- a/c/driver/postgresql/bind_stream.h
+++ b/c/driver/postgresql/bind_stream.h
@@ -215,7 +215,7 @@ struct BindStream {
 
       int64_t param_length = param_buffer->size_bytes - last_offset - sizeof(int32_t);
       if (param_length > (std::numeric_limits<int>::max)()) {
-        return Status::Internal("Paramter ", col, "serialized to >2GB of binary");
+        return Status::Internal("Parameter ", col, "serialized to >2GB of binary");
       }
 
       param_lengths[col] = static_cast<int>(param_length);

--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -181,8 +181,8 @@ class PostgresGetObjectsHelper : public adbc::driver::GetObjectsHelper {
         some_constraints_(conn, ConstraintsQuery()) {}
 
   // Allow Redshift to execute this query without constraints
-  // TODO(paleolimbot): Investigate to see if we can simplify the constraits query so that
-  // it works on both!
+  // TODO(paleolimbot): Investigate to see if we can simplify the constraints query so
+  // that it works on both!
   void SetEnableConstraints(bool enable_constraints) {
     enable_constraints_ = enable_constraints;
   }

--- a/c/driver/postgresql/copy/postgres_copy_test_common.h
+++ b/c/driver/postgresql/copy/postgres_copy_test_common.h
@@ -21,7 +21,7 @@
 
 namespace adbcpq {
 
-// New cases can be genereated using:
+// New cases can be generated using:
 // psql --host 127.0.0.1 --port 5432 --username postgres -c "COPY (SELECT ...) TO STDOUT
 // WITH (FORMAT binary);" > test.copy Rscript -e "dput(brio::read_file_raw('test.copy'))"
 

--- a/c/driver/postgresql/copy/reader.h
+++ b/c/driver/postgresql/copy/reader.h
@@ -864,7 +864,7 @@ static inline ArrowErrorCode MakeCopyFieldReader(
         case PostgresTypeId::kRecord: {
           if (pg_type.n_children() != schema->n_children) {
             ArrowErrorSet(error,
-                          "Can't convert Postgres record type with %ld chlidren to Arrow "
+                          "Can't convert Postgres record type with %ld children to Arrow "
                           "struct type with %ld children",
                           static_cast<long>(pg_type.n_children()),  // NOLINT(runtime/int)
                           static_cast<long>(schema->n_children));   // NOLINT(runtime/int)

--- a/c/driver/postgresql/copy/writer.h
+++ b/c/driver/postgresql/copy/writer.h
@@ -726,7 +726,7 @@ static inline ArrowErrorCode MakeCopyFieldWriter(
     case NANOARROW_TYPE_LARGE_LIST:
     case NANOARROW_TYPE_FIXED_SIZE_LIST: {
       // For now our implementation only supports primitive children types
-      // See PostgresCopyListFieldWriter::Write for limtiations
+      // See PostgresCopyListFieldWriter::Write for limitations
       struct ArrowSchemaView child_schema_view;
       NANOARROW_RETURN_NOT_OK(
           ArrowSchemaViewInit(&child_schema_view, schema->children[0], error));

--- a/c/driver/postgresql/postgres_type.h
+++ b/c/driver/postgresql/postgres_type.h
@@ -211,7 +211,7 @@ class PostgresType {
   // initialize and set the appropriate number of children). Returns NANOARROW_OK
   // on success and perhaps ENOMEM if memory cannot be allocated. Types that
   // do not have a corresponding Arrow type are returned as Binary with field
-  // metadata ADBC:posgresql:typname. These types can be represented as their
+  // metadata ADBC:postgresql:typname. These types can be represented as their
   // binary COPY representation in the output.
   ArrowErrorCode SetSchema(ArrowSchema* schema,
                            const std::string& vendor_name = "PostgreSQL") const {

--- a/c/driver/postgresql/result_helper.h
+++ b/c/driver/postgresql/result_helper.h
@@ -110,7 +110,7 @@ class PqResultRow {
 };
 
 // Helper to manager the lifecycle of a PQResult. The query argument
-// will be evaluated as part of the constructor, with the desctructor handling cleanup
+// will be evaluated as part of the constructor, with the destructor handling cleanup
 // Caller must call Prepare then Execute, checking both for an OK AdbcStatusCode
 // prior to iterating
 class PqResultHelper {

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -302,7 +302,7 @@ struct ADBC_EXPORT AdbcError {
   ///
   /// This field may not be used unless vendor_code is
   /// ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA.  If present, this field is NULLPTR
-  /// iff the error is unintialized/freed.
+  /// iff the error is uninitialized/freed.
   ///
   /// \since ADBC API revision 1.1.0
   void* private_data;
@@ -859,7 +859,7 @@ const struct AdbcError* AdbcErrorFromArrayStream(struct ArrowArrayStream* stream
 /// Must be kept alive as long as any connections exist.
 struct ADBC_EXPORT AdbcDatabase {
   /// \brief Opaque implementation-defined state.
-  /// This field is NULLPTR iff the connection is unintialized/freed.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
   void* private_data;
   /// \brief The associated driver (used by the driver manager to help
   ///   track state).
@@ -882,7 +882,7 @@ struct ADBC_EXPORT AdbcDatabase {
 /// serialize accesses to a connection.
 struct ADBC_EXPORT AdbcConnection {
   /// \brief Opaque implementation-defined state.
-  /// This field is NULLPTR iff the connection is unintialized/freed.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
   void* private_data;
   /// \brief The associated driver (used by the driver manager to help
   ///   track state).
@@ -920,7 +920,7 @@ struct ADBC_EXPORT AdbcConnection {
 /// serialize accesses to a statement.
 struct ADBC_EXPORT AdbcStatement {
   /// \brief Opaque implementation-defined state.
-  /// This field is NULLPTR iff the connection is unintialized/freed.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
   void* private_data;
 
   /// \brief The associated driver (used by the driver manager to help
@@ -959,7 +959,7 @@ struct AdbcPartitions {
   const size_t* partition_lengths;
 
   /// \brief Opaque implementation-defined state.
-  /// This field is NULLPTR iff the connection is unintialized/freed.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
   void* private_data;
 
   /// \brief Release the contained partitions.
@@ -987,11 +987,11 @@ struct AdbcPartitions {
 /// worrying about multiple definitions of the same symbol.
 struct ADBC_EXPORT AdbcDriver {
   /// \brief Opaque driver-defined state.
-  /// This field is NULL if the driver is unintialized/freed (but
+  /// This field is NULL if the driver is uninitialized/freed (but
   /// it need not have a value even if the driver is initialized).
   void* private_data;
   /// \brief Opaque driver manager-defined state.
-  /// This field is NULL if the driver is unintialized/freed (but
+  /// This field is NULL if the driver is uninitialized/freed (but
   /// it need not have a value even if the driver is initialized).
   void* private_manager;
 

--- a/c/validation/adbc_validation_util.cc
+++ b/c/validation/adbc_validation_util.cc
@@ -320,7 +320,7 @@ std::string GetDriverVendorVersion(struct AdbcConnection* connection) {
   reader.GetSchema();
   if (error.release) {
     error.release(&error);
-    throw std::runtime_error("error occured calling AdbcConnectionGetInfo!");
+    throw std::runtime_error("error occurred calling AdbcConnectionGetInfo!");
   }
 
   reader.Next();

--- a/go/adbc/drivermgr/arrow-adbc/adbc.h
+++ b/go/adbc/drivermgr/arrow-adbc/adbc.h
@@ -302,7 +302,7 @@ struct ADBC_EXPORT AdbcError {
   ///
   /// This field may not be used unless vendor_code is
   /// ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA.  If present, this field is NULLPTR
-  /// iff the error is unintialized/freed.
+  /// iff the error is uninitialized/freed.
   ///
   /// \since ADBC API revision 1.1.0
   void* private_data;
@@ -859,7 +859,7 @@ const struct AdbcError* AdbcErrorFromArrayStream(struct ArrowArrayStream* stream
 /// Must be kept alive as long as any connections exist.
 struct ADBC_EXPORT AdbcDatabase {
   /// \brief Opaque implementation-defined state.
-  /// This field is NULLPTR iff the connection is unintialized/freed.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
   void* private_data;
   /// \brief The associated driver (used by the driver manager to help
   ///   track state).
@@ -882,7 +882,7 @@ struct ADBC_EXPORT AdbcDatabase {
 /// serialize accesses to a connection.
 struct ADBC_EXPORT AdbcConnection {
   /// \brief Opaque implementation-defined state.
-  /// This field is NULLPTR iff the connection is unintialized/freed.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
   void* private_data;
   /// \brief The associated driver (used by the driver manager to help
   ///   track state).
@@ -920,7 +920,7 @@ struct ADBC_EXPORT AdbcConnection {
 /// serialize accesses to a statement.
 struct ADBC_EXPORT AdbcStatement {
   /// \brief Opaque implementation-defined state.
-  /// This field is NULLPTR iff the connection is unintialized/freed.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
   void* private_data;
 
   /// \brief The associated driver (used by the driver manager to help
@@ -959,7 +959,7 @@ struct AdbcPartitions {
   const size_t* partition_lengths;
 
   /// \brief Opaque implementation-defined state.
-  /// This field is NULLPTR iff the connection is unintialized/freed.
+  /// This field is NULLPTR iff the connection is uninitialized/freed.
   void* private_data;
 
   /// \brief Release the contained partitions.
@@ -987,11 +987,11 @@ struct AdbcPartitions {
 /// worrying about multiple definitions of the same symbol.
 struct ADBC_EXPORT AdbcDriver {
   /// \brief Opaque driver-defined state.
-  /// This field is NULL if the driver is unintialized/freed (but
+  /// This field is NULL if the driver is uninitialized/freed (but
   /// it need not have a value even if the driver is initialized).
   void* private_data;
   /// \brief Opaque driver manager-defined state.
-  /// This field is NULL if the driver is unintialized/freed (but
+  /// This field is NULL if the driver is uninitialized/freed (but
   /// it need not have a value even if the driver is initialized).
   void* private_manager;
 


### PR DESCRIPTION
Fixed only comments and messages.
There are no code changes. 

This PR is intended to fix typos in `c/`, but I also fix `go/adbc/drivermgr/arrow-adbc/adbc.h` because this needs to be synced with `adbc.h` in `c/`.

Closes #2923 