### PR TITLE
chore(go): fix typo

### DIFF
--- a/go/adbc/adbc.go
+++ b/go/adbc/adbc.go
@@ -644,7 +644,7 @@ type Statement interface {
 	SetSqlQuery(query string) error
 
 	// ExecuteQuery executes the current query or prepared statement
-	// and returnes a RecordReader for the results along with the number
+	// and returns a RecordReader for the results along with the number
 	// of rows affected if known, otherwise it will be -1.
 	//
 	// This invalidates any prior result sets on this statement.

--- a/go/adbc/driver/bigquery/statement.go
+++ b/go/adbc/driver/bigquery/statement.go
@@ -569,7 +569,7 @@ func arrowValueToQueryParameterValue(field arrow.Field, value arrow.Array, i int
 		// Encoded as RFC 3339 partial-time format string: 23:20:50.52
 		//
 		// cannot use the default format, which will cause errors like
-		//   googleapi: Error 400: Unparseable query parameter `` in type `TYPE_TIME`,
+		//   googleapi: Error 400: Unparsable query parameter `` in type `TYPE_TIME`,
 		//   Invalid time string "00:00:00.000000001" value: '00:00:00.000000001', invalid
 		encoded := value.(*array.Time64).Value(i).FormattedString(arrow.Microsecond)
 		parameter.Value = &bigquery.QueryParameterValue{

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -426,7 +426,7 @@ func (s *statement) SetSqlQuery(query string) error {
 }
 
 // ExecuteQuery executes the current query or prepared statement
-// and returnes a RecordReader for the results along with the number
+// and returns a RecordReader for the results along with the number
 // of rows affected if known, otherwise it will be -1.
 //
 // This invalidates any prior result sets on this statement.

--- a/go/adbc/driver/internal/driverbase/connection.go
+++ b/go/adbc/driver/internal/driverbase/connection.go
@@ -369,7 +369,7 @@ func (cnxn *ConnectionImplBase) StartSpan(
 func (cnxn *connection) GetObjects(ctx context.Context, depth adbc.ObjectDepth, catalog *string, dbSchema *string, tableName *string, columnName *string, tableType []string) (array.RecordReader, error) {
 	helper := cnxn.dbObjectsEnumerator
 
-	// If the dbObjectsEnumerator has not been set, then the driver implementor has elected to provide their own GetObjects implementation
+	// If the dbObjectsEnumerator has not been set, then the driver implementer has elected to provide their own GetObjects implementation
 	if helper == nil {
 		return cnxn.ConnectionImpl.GetObjects(ctx, depth, catalog, dbSchema, tableName, columnName, tableType)
 	}

--- a/go/adbc/driver/internal/driverbase/rotating_file_writer.go
+++ b/go/adbc/driver/internal/driverbase/rotating_file_writer.go
@@ -257,7 +257,7 @@ func ensureCurrentWriter(base *rotatingFileWriterImpl) error {
 		// check for a candidate file that is not full
 		fullPathLastFile, ok := getCandidateLogFileName(base)
 		if ok {
-			// attempt to open exising candidate file
+			// attempt to open existing candidate file
 			currentWriter, err := os.OpenFile(fullPathLastFile, appendFlags, permissions)
 			if err == nil {
 				base.CurrentWriter = currentWriter
@@ -290,7 +290,7 @@ func getCandidateLogFileName(base *rotatingFileWriterImpl) (string, bool) {
 		return "", false
 	}
 
-	// Assume these file paths are ordered lexigraphically, as documented for filepath.Glob()
+	// Assume these file paths are ordered lexicographically, as documented for filepath.Glob()
 	candiateFilePath := logFiles[len(logFiles)-1]
 	fileSizeMaxBytes := base.FileSizeMaxKb * 1024
 	fileInfo, err := os.Stat(candiateFilePath)

--- a/go/adbc/driver/snowflake/bulk_ingestion.go
+++ b/go/adbc/driver/snowflake/bulk_ingestion.go
@@ -85,7 +85,7 @@ type ingestOptions struct {
 	// Number of Parquet files to upload in parallel.
 	//
 	// Greater concurrency can smooth out TCP congestion and help make use of
-	// available network bandwith, but will increase memory utilization.
+	// available network bandwidth, but will increase memory utilization.
 	// Default is 8. If set to 0, default value is used. Cannot be negative.
 	uploadConcurrency uint
 	// Maximum number of COPY operations to run concurrently.
@@ -488,7 +488,7 @@ func uploadAllStreams(
 		select {
 		case <-ctx.Done():
 			// The context is canceled on error, so we wait for graceful shutdown of in-progress uploads.
-			// The gosnowflake.snowflakeFileTransferAgent does not currently propogate context, so we
+			// The gosnowflake.snowflakeFileTransferAgent does not currently propagate context, so we
 			// have to wait for uploads to finish for proper shutdown. (https://github.com/snowflakedb/gosnowflake/issues/1028)
 			return g.Wait()
 		default:
@@ -558,7 +558,7 @@ func runCopyTasks(ctx context.Context, cn snowflakeConn, tableName string, concu
 		// keep track of each file uploaded to the stage, until it has been copied into the table successfully
 		filesToCopy.Add(filename)
 
-		// readyFn is a no-op if the shutdown signal has already been recieved
+		// readyFn is a no-op if the shutdown signal has already been received
 		select {
 		case _, ok := <-stopCh:
 			if !ok {

--- a/go/adbc/driver/snowflake/driver_test.go
+++ b/go/adbc/driver/snowflake/driver_test.go
@@ -2072,7 +2072,7 @@ func (suite *SnowflakeTests) TestMetadataOnlyQuery() {
 		recv += rdr.Record().NumRows()
 	}
 
-	// verify that we got the exepected number of rows if we sum up
+	// verify that we got the expected number of rows if we sum up
 	// all the rows from each record in the stream.
 	suite.Equal(n, recv)
 }
@@ -2090,7 +2090,7 @@ func (suite *SnowflakeTests) TestEmptyResultSet() {
 		recv += rdr.Record().NumRows()
 	}
 
-	// verify that we got the exepected number of rows if we sum up
+	// verify that we got the expected number of rows if we sum up
 	// all the rows from each record in the stream.
 	suite.Equal(n, recv)
 	suite.Equal(recv, int64(0))

--- a/go/adbc/driver/snowflake/statement.go
+++ b/go/adbc/driver/snowflake/statement.go
@@ -467,7 +467,7 @@ func (st *statement) executeIngest(ctx context.Context) (int64, error) {
 }
 
 // ExecuteQuery executes the current query or prepared statement
-// and returnes a RecordReader for the results along with the number
+// and returns a RecordReader for the results along with the number
 // of rows affected if known, otherwise it will be -1.
 //
 // This invalidates any prior result sets on this statement.

--- a/go/adbc/ext.go
+++ b/go/adbc/ext.go
@@ -65,7 +65,7 @@ type OTelTracing interface {
 	// Gets the trace parent from an external trace span. A blank value, indicates no parent relationship.
 	GetTraceParent() string
 	// Starts a new [span] and returns a [trace.Span] which can be used to
-	// [set the status], [add attributes], [add events], etc. Implementors should enhance
+	// [set the status], [add attributes], [add events], etc. Implementers should enhance
 	// the [context.Context] with the provided trace parent value, if it exists
 	//
 	// [span]: https://opentelemetry.io/docs/concepts/signals/traces/#span-context


### PR DESCRIPTION
Fixed only comments.
There are no code changes. 

Closes #2927 