### PR TITLE
fix(.github/workflows): update windows os version for csharp workflow

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet: ['8.0.x']
-        os: [ubuntu-latest, windows-2019, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-13, macos-latest]
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v4


### PR DESCRIPTION
Windows 2019 image is being deprecated. Updated to the next supported version.