### PR TITLE
fix(csharp/src/Drivers/Databricks): Remove redundant statement close operation

### DIFF
--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs
@@ -330,7 +330,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
 
         public override void Dispose()
         {
-            if (OperationHandle != null)
+            if (OperationHandle != null && _directResults?.CloseOperation?.Status?.StatusCode != TStatusCode.SUCCESS_STATUS)
             {
                 CancellationToken cancellationToken = ApacheUtility.GetCancellationToken(QueryTimeoutSeconds, ApacheUtility.TimeUnit.Seconds);
                 TCloseOperationReq request = new TCloseOperationReq(OperationHandle);


### PR DESCRIPTION
- If DirectResults is set, then after query execution the server will automatically poll operation status, fetch results, and close the operation if all rows were fetched
- In the cases where the close operation has already succeeded in the direct results response, remove the redundant call when disposing the statement