### PR TITLE
chore(rust): fix typo

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -48,4 +48,4 @@ To write an ADBC driver in Rust you have to:
 1. Implement the abstract API which consists of the traits `Driver`, `Database`, `Connection` and `Statement`.
 1. Export your driver to C with the macro `adbc_core::export_driver!`.
 
-The resulting object file can then be loaded by other languages trough their own driver manager.
+The resulting object file can then be loaded by other languages through their own driver manager.

--- a/rust/core/src/driver_manager.rs
+++ b/rust/core/src/driver_manager.rs
@@ -154,7 +154,7 @@ struct ManagedDriverInner {
     // The dynamic library must be kept loaded for the entire lifetime of the driver.
     // To avoid complex lifetimes we prefer to store it as part of this struct.
     // Besides, the `library` field must always appear after `driver` because of drop order:
-    // `driver` has an implicit dependency on `library` and so it must be droped
+    // `driver` has an implicit dependency on `library` and so it must be dropped
     // before `library` because otherwise `driver` would be full of dangling
     // function pointers.
     // See: https://doc.rust-lang.org/std/ops/trait.Drop.html#drop-order

--- a/rust/core/src/ffi/types.rs
+++ b/rust/core/src/ffi/types.rs
@@ -62,7 +62,7 @@ pub struct FFI_AdbcErrorDetail {
 #[derive(Debug)]
 pub struct FFI_AdbcDatabase {
     /// Opaque implementation-defined state.
-    /// This field is NULLPTR iff the connection is unintialized/freed.
+    /// This field is NULLPTR iff the connection is uninitialized/freed.
     pub(crate) private_data: *mut c_void,
     /// The associated driver (used by the driver manager to help track state).
     pub(crate) private_driver: *const FFI_AdbcDriver,
@@ -74,7 +74,7 @@ unsafe impl Send for FFI_AdbcDatabase {}
 #[derive(Debug)]
 pub struct FFI_AdbcConnection {
     /// Opaque implementation-defined state.
-    /// This field is NULLPTR iff the connection is unintialized/freed.
+    /// This field is NULLPTR iff the connection is uninitialized/freed.
     pub(crate) private_data: *mut c_void,
     /// The associated driver (used by the driver manager to help track state).
     pub(crate) private_driver: *const FFI_AdbcDriver,
@@ -86,7 +86,7 @@ unsafe impl Send for FFI_AdbcConnection {}
 #[derive(Debug)]
 pub struct FFI_AdbcStatement {
     /// Opaque implementation-defined state.
-    /// This field is NULLPTR iff the connection is unintialized/freed.
+    /// This field is NULLPTR iff the connection is uninitialized/freed.
     pub(crate) private_data: *mut c_void,
     /// The associated driver (used by the driver manager to help track state).
     pub(crate) private_driver: *const FFI_AdbcDriver,
@@ -113,7 +113,7 @@ pub struct FFI_AdbcPartitions {
     partition_lengths: *mut usize,
 
     /// Opaque implementation-defined state.
-    /// This field is NULLPTR iff the connection is unintialized/freed.
+    /// This field is NULLPTR iff the connection is uninitialized/freed.
     pub(crate) private_data: *mut c_void,
 
     /// Release the contained partitions.
@@ -126,11 +126,11 @@ pub struct FFI_AdbcPartitions {
 #[derive(Debug)]
 pub struct FFI_AdbcDriver {
     /// Opaque driver-defined state.
-    /// This field is NULL if the driver is unintialized/freed (but
+    /// This field is NULL if the driver is uninitialized/freed (but
     /// it need not have a value even if the driver is initialized).
     pub(crate) private_data: *mut c_void,
     /// Opaque driver manager-defined state.
-    /// This field is NULL if the driver is unintialized/freed (but
+    /// This field is NULL if the driver is uninitialized/freed (but
     /// it need not have a value even if the driver is initialized).
     pub(crate) private_manager: *const c_void,
     pub(crate) release: Option<
@@ -670,7 +670,7 @@ mod tests {
             status: Status::Unknown,
             vendor_code: constants::ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA,
             sqlstate: [1, 2, 3, 4, 5],
-            details: None, // Details are not transfered here because there is no driver
+            details: None, // Details are not transferred here because there is no driver
         };
         let error_ffi: FFI_AdbcError = error_expected.clone().try_into().unwrap();
         let error_actual: Error = error_ffi.try_into().unwrap();

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -53,7 +53,7 @@
 //! # Driver Exporter
 //!
 //! The driver exporter allows exposing native Rust drivers as C drivers to be
-//! used by other langages via their own driver manager. Once you have an
+//! used by other languages via their own driver manager. Once you have an
 //! implementation of [Driver], provided that it also implements [Default], you
 //! can build it as an object file implementing the C API with the
 //! [export_driver] macro.

--- a/rust/driver/dummy/tests/driver_exporter_dummy.rs
+++ b/rust/driver/dummy/tests/driver_exporter_dummy.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 /// This integration test compares the output of the dummy driver when it's used
-/// directly using the Rust API (native) and trough the exported driver via the
+/// directly using the Rust API (native) and through the exported driver via the
 /// driver manager (exported). That allows us to test that data correctly round-trip
 /// between C and Rust.
 use std::ops::Deref;

--- a/rust/driver/snowflake/src/duration.rs
+++ b/rust/driver/snowflake/src/duration.rs
@@ -46,7 +46,7 @@ fn bad_input<T>() -> Result<T> {
     Err(invalid_arg("invalid duration (valid durations are a sequence of decimal numbers, each with optional fraction and a unit suffix, such as 300ms, 1.5h, 2h45m, valid time units are ns, us, ms, s, m, h)"))
 }
 
-/// Parse the given string to a [`Duration`], returning an eror when parsing
+/// Parse the given string to a [`Duration`], returning an error when parsing
 /// fails.
 ///
 /// Following the logic of <https://pkg.go.dev/time#ParseDuration>, except this


### PR DESCRIPTION
Fixed only comments and README.
There are no code changes. 

Closes #2954