### PR TITLE
fix(csharp/src/Drivers/BigQuery): Prevent callers from attempting to use the public project ID to create query jobs

### DIFF
--- a/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryConnection.cs
@@ -111,6 +111,14 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             if (!this.properties.TryGetValue(BigQueryParameters.ProjectId, out projectId))
                 projectId = BigQueryConstants.DetectProjectId;
 
+            // in some situations, the publicProjectId gets passed and causes an error when we try to create a query job:
+            //     Google.GoogleApiException : The service bigquery has thrown an exception. HttpStatusCode is Forbidden.
+            //     Access Denied: Project bigquery-public-data: User does not have bigquery.jobs.create permission in
+            //     project bigquery-public-data.
+            // so if that is the case, treat it as if we need to detect the projectId
+            if (projectId.Equals(publicProjectId, StringComparison.OrdinalIgnoreCase))
+                projectId = BigQueryConstants.DetectProjectId;
+
             // the billing project can be null if it's not specified
             this.properties.TryGetValue(BigQueryParameters.BillingProjectId, out billingProjectId);
 


### PR DESCRIPTION
 In some situations, the publicProjectId gets passed as the actual project ID and causes an error when we try to create a query job:
 ```
     Google.GoogleApiException : The service bigquery has thrown an exception. HttpStatusCode is Forbidden.
      Access Denied: Project bigquery-public-data: User does not have bigquery.jobs.create permission in
      project bigquery-public-data.
``` 
This PR adds a check for the public project ID and treats it as if we need to detect the project ID for the caller.