### PR TITLE
chore: the local directory used for building libs should be gitignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ docker_cache
 .*.swo
 CMakeUserPresets.json
 build/
+local/
 
 site/
 


### PR DESCRIPTION
The `local` directory must be out of Git control because it may be used as an installation location during development.