### PR TITLE
docs: update jdbc.rst to fix dependency artifact ID mismatch

### DIFF
--- a/docs/source/driver/jdbc.rst
+++ b/docs/source/driver/jdbc.rst
@@ -31,7 +31,7 @@ Installation
    .. tab-item:: Java
       :sync: java
 
-      Add a dependency on ``org.apache.arrow.adbc:adbc-driver-flight-sql``.
+      Add a dependency on ``org.apache.arrow.adbc:adbc-driver-jdbc``.
 
       For Maven users:
 


### PR DESCRIPTION
Update jdbc.rst to fix dependency artifact ID mismatch.
It pointed to "adbc-driver-flight-sql" which is from another page.