### PR TITLE
ci: fix Windows 3.13 build failing

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -900,6 +900,7 @@ jobs:
       - name: Install Python ${{ matrix.python_version }}
         uses: actions/setup-python@v5
         with:
+          check-latest: true
           python-version: ${{ matrix.python_version }}
 
       - name: Build wheel


### PR DESCRIPTION
There was a regression in a 3.13.x release and the GitHub runners appear to have cached the bad version; force them to grab the new version.