### PR TITLE
ci: bump pipelines to test 3.13 instead of 3.12 or 3.11

### DIFF
--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -539,7 +539,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-13", "macos-latest", "ubuntu-latest"]
-        python: ["3.9", "3.12"]
+        python: ["3.9", "3.13"]
     env:
       # Required for macOS
       # https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
@@ -656,7 +656,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python: ["3.12"]
+        python: ["3.13"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/native-windows.yml
+++ b/.github/workflows/native-windows.yml
@@ -249,7 +249,7 @@ jobs:
     strategy:
       matrix:
         os: ["windows-latest"]
-        python: ["3.9", "3.11"]
+        python: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Fixes #2991.