### PR TITLE
fix(go/adbc/driver/internal/driverbase): fix missing interface func

### DIFF
--- a/go/adbc/driver/internal/driverbase/driver_test.go
+++ b/go/adbc/driver/internal/driverbase/driver_test.go
@@ -553,6 +553,10 @@ func (base *statement) ExecuteQuery(ctx context.Context) (array.RecordReader, in
 	return nil, 0, base.Base().ErrorHelper.Errorf(adbc.StatusNotImplemented, "ExecuteQuery")
 }
 
+func (base *statement) ExecuteSchema(ctx context.Context) (*arrow.Schema, error) {
+	return nil, base.Base().ErrorHelper.Errorf(adbc.StatusNotImplemented, "ExecuteSchema")
+}
+
 func (base *statement) ExecuteUpdate(ctx context.Context) (int64, error) {
 	return 0, base.Base().ErrorHelper.Errorf(adbc.StatusNotImplemented, "ExecuteUpdate")
 }

--- a/go/adbc/driver/internal/driverbase/statement.go
+++ b/go/adbc/driver/internal/driverbase/statement.go
@@ -34,6 +34,7 @@ const (
 
 type StatementImpl interface {
 	adbc.Statement
+	adbc.StatementExecuteSchema
 	adbc.GetSetOptions
 	adbc.OTelTracing
 	Base() *StatementImplBase


### PR DESCRIPTION
Looks like the changes and update for the Otel infrastructure introduced a mismatch with how the interface for ExecuteSchema is handled. As a result we have a failing test: https://github.com/apache/arrow-adbc/actions/runs/15828865854/job/44625340147

This change updates the interface definition to fix the tests.