### PR TITLE
feat(csharp/src/Drivers/Databricks): Fix for older DBR versions incorrect ResultFormat

### DIFF
--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloadManager.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchDownloadManager.cs
@@ -22,6 +22,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow.Adbc.Drivers.Apache.Hive2;
+using Apache.Hive.Service.Rpc.Thrift;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
 {
@@ -59,7 +60,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
         /// <param name="statement">The HiveServer2 statement.</param>
         /// <param name="schema">The Arrow schema.</param>
         /// <param name="isLz4Compressed">Whether the results are LZ4 compressed.</param>
-        public CloudFetchDownloadManager(DatabricksStatement statement, Schema schema, bool isLz4Compressed, HttpClient httpClient)
+        public CloudFetchDownloadManager(DatabricksStatement statement, Schema schema, TFetchResultsResp? initialResults, bool isLz4Compressed, HttpClient httpClient)
         {
             _statement = statement ?? throw new ArgumentNullException(nameof(statement));
             _schema = schema ?? throw new ArgumentNullException(nameof(schema));
@@ -193,6 +194,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
             // Initialize the result fetcher with URL management capabilities
             _resultFetcher = new CloudFetchResultFetcher(
                 _statement,
+                initialResults,
                 _memoryManager,
                 _downloadQueue,
                 DefaultFetchBatchSize,

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchReader.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchReader.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 using Apache.Arrow.Adbc.Drivers.Apache;
 using Apache.Arrow.Adbc.Tracing;
 using Apache.Arrow.Ipc;
+using Apache.Hive.Service.Rpc.Thrift;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
 {
@@ -46,7 +47,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
         /// <param name="statement">The Databricks statement.</param>
         /// <param name="schema">The Arrow schema.</param>
         /// <param name="isLz4Compressed">Whether the results are LZ4 compressed.</param>
-        public CloudFetchReader(DatabricksStatement statement, Schema schema, bool isLz4Compressed, HttpClient httpClient)
+        public CloudFetchReader(DatabricksStatement statement, Schema schema, TFetchResultsResp? initialResults, bool isLz4Compressed, HttpClient httpClient)
             : base(statement, schema, isLz4Compressed)
         {
             // Check if prefetch is enabled
@@ -67,14 +68,14 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
             // Initialize the download manager
             if (isPrefetchEnabled)
             {
-                downloadManager = new CloudFetchDownloadManager(statement, schema, isLz4Compressed, httpClient);
+                downloadManager = new CloudFetchDownloadManager(statement, schema, initialResults, isLz4Compressed, httpClient);
                 downloadManager.StartAsync().Wait();
             }
             else
             {
                 // For now, we only support the prefetch implementation
                 // This flag is reserved for future use if we need to support a non-prefetch mode
-                downloadManager = new CloudFetchDownloadManager(statement, schema, isLz4Compressed, httpClient);
+                downloadManager = new CloudFetchDownloadManager(statement, schema, initialResults, isLz4Compressed, httpClient);
                 downloadManager.StartAsync().Wait();
             }
         }

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchResultFetcher.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchResultFetcher.cs
@@ -213,8 +213,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
             try
             {
                 // Process direct results first, if available
-                if (_statement.HasDirectResults && _statement.DirectResults?.ResultSet?.Results?.ResultLinks?.Count > 0 ||
-                 (_initialResults?.Results?.ResultLinks?.Count > 0))
+                if (_statement.HasDirectResults &&
+                    (_statement.DirectResults?.ResultSet?.Results?.ResultLinks?.Count > 0 ||
+                    _initialResults?.Results?.ResultLinks?.Count > 0))
                 {
                     // Yield execution so the download queue doesn't get blocked before downloader is started
                     await Task.Yield();

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchResultFetcher.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchResultFetcher.cs
@@ -32,6 +32,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
     internal class CloudFetchResultFetcher : ICloudFetchResultFetcher
     {
         private readonly IHiveServer2Statement _statement;
+        private readonly TFetchResultsResp? _initialResults;
         private readonly ICloudFetchMemoryBufferManager _memoryManager;
         private readonly BlockingCollection<IDownloadResult> _downloadQueue;
         private readonly SemaphoreSlim _fetchLock = new SemaphoreSlim(1, 1);
@@ -57,6 +58,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
         /// <param name="clock">Clock implementation for time operations. If null, uses system clock.</param>
         public CloudFetchResultFetcher(
             IHiveServer2Statement statement,
+            TFetchResultsResp? initialResults,
             ICloudFetchMemoryBufferManager memoryManager,
             BlockingCollection<IDownloadResult> downloadQueue,
             long batchSize,
@@ -64,6 +66,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
             IClock? clock = null)
         {
             _statement = statement ?? throw new ArgumentNullException(nameof(statement));
+            _initialResults = initialResults;
             _memoryManager = memoryManager ?? throw new ArgumentNullException(nameof(memoryManager));
             _downloadQueue = downloadQueue ?? throw new ArgumentNullException(nameof(downloadQueue));
             _batchSize = batchSize;
@@ -210,7 +213,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
             try
             {
                 // Process direct results first, if available
-                if (_statement.HasDirectResults && _statement.DirectResults?.ResultSet?.Results?.ResultLinks?.Count > 0)
+                if (_statement.HasDirectResults && _statement.DirectResults?.ResultSet?.Results?.ResultLinks?.Count > 0 ||
+                 (_initialResults?.Results?.ResultLinks?.Count > 0))
                 {
                     // Yield execution so the download queue doesn't get blocked before downloader is started
                     await Task.Yield();
@@ -328,7 +332,18 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
 
         private void ProcessDirectResultsAsync(CancellationToken cancellationToken)
         {
-            List<TSparkArrowResultLink> resultLinks = _statement.DirectResults!.ResultSet.Results.ResultLinks;
+            TFetchResultsResp fetchResults;
+            if (_statement.HasDirectResults && _statement.DirectResults?.ResultSet?.Results?.ResultLinks?.Count > 0)
+            {
+                fetchResults = _statement.DirectResults!.ResultSet;
+            }
+            else
+            {
+                fetchResults = _initialResults!;
+            }
+
+            List<TSparkArrowResultLink> resultLinks = fetchResults.Results.ResultLinks;
+
             long maxOffset = 0;
 
             // Process each link
@@ -350,7 +365,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
             _startOffset = maxOffset;
 
             // Update whether there are more results
-            _hasMoreResults = _statement.DirectResults!.ResultSet.HasMoreRows;
+            _hasMoreResults = fetchResults.HasMoreRows;
         }
     }
 }

--- a/csharp/src/Drivers/Databricks/DatabricksCompositeReader.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksCompositeReader.cs
@@ -35,9 +35,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
     /// A composite reader for Databricks that delegates to either CloudFetchReader or DatabricksReader
     /// based on CloudFetch configuration and result set characteristics.
     /// </summary>
-    public sealed class DatabricksCompositeReader : TracingReader
+    internal sealed class DatabricksCompositeReader : TracingReader
     {
-
         private static readonly string s_assemblyName = ApacheUtility.GetAssemblyName(typeof(DatabricksCompositeReader));
         private static readonly string s_assemblyVersion = ApacheUtility.GetAssemblyVersion(typeof(DatabricksCompositeReader));
 
@@ -46,7 +45,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         public override string AssemblyVersion => s_assemblyVersion;
 
         public override Schema Schema { get { return _schema; } }
-
 
         private BaseDatabricksReader? _activeReader;
         private readonly DatabricksStatement _statement;

--- a/csharp/src/Drivers/Databricks/DatabricksCompositeReader.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksCompositeReader.cs
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow;
+using Apache.Arrow.Adbc;
+using Apache.Arrow.Adbc.Drivers.Apache;
+using Apache.Arrow.Adbc.Drivers.Apache.Hive2;
+using Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch;
+using Apache.Arrow.Adbc.Tracing;
+using Apache.Arrow.Ipc;
+using Apache.Hive.Service.Rpc.Thrift;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks
+{
+    /// <summary>
+    /// A composite reader for Databricks that delegates to either CloudFetchReader or DatabricksReader
+    /// based on CloudFetch configuration and result set characteristics.
+    /// </summary>
+    public sealed class DatabricksCompositeReader : TracingReader
+    {
+
+        private static readonly string s_assemblyName = ApacheUtility.GetAssemblyName(typeof(DatabricksCompositeReader));
+        private static readonly string s_assemblyVersion = ApacheUtility.GetAssemblyVersion(typeof(DatabricksCompositeReader));
+
+        public override string AssemblyName => s_assemblyName;
+
+        public override string AssemblyVersion => s_assemblyVersion;
+
+        public override Schema Schema { get { return _schema; } }
+
+
+        private BaseDatabricksReader? _activeReader;
+        private readonly DatabricksStatement _statement;
+        private readonly Schema _schema;
+        private readonly bool _isLz4Compressed;
+        private readonly TlsProperties _tlsOptions;
+        private readonly HiveServer2ProxyConfigurator _proxyConfigurator;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DatabricksCompositeReader"/> class.
+        /// </summary>
+        /// <param name="statement">The Databricks statement.</param>
+        /// <param name="schema">The Arrow schema.</param>
+        /// <param name="isLz4Compressed">Whether the results are LZ4 compressed.</param>
+        /// <param name="httpClient">The HTTP client for CloudFetch operations.</param>
+        internal DatabricksCompositeReader(DatabricksStatement statement, Schema schema, bool isLz4Compressed, TlsProperties tlsOptions, HiveServer2ProxyConfigurator proxyConfigurator): base(statement)
+        {
+            _statement = statement ?? throw new ArgumentNullException(nameof(statement));
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+            _isLz4Compressed = isLz4Compressed;
+            _tlsOptions = tlsOptions;
+            _proxyConfigurator = proxyConfigurator;
+
+            // use direct results if available
+            if (_statement.HasDirectResults && _statement.DirectResults != null && _statement.DirectResults.__isset.resultSet)
+            {
+                _activeReader = DetermineReader(_statement.DirectResults.ResultSet);
+            }
+        }
+
+        private BaseDatabricksReader DetermineReader(TFetchResultsResp initialResults)
+        {
+            // if it has links, use cloud fetch
+            if (initialResults.__isset.results &&
+                initialResults.Results.__isset.resultLinks &&
+                initialResults.Results.ResultLinks?.Count > 0)
+            {
+                HttpClient cloudFetchHttpClient = new HttpClient(HiveServer2TlsImpl.NewHttpClientHandler(_tlsOptions, _proxyConfigurator));
+                return new CloudFetchReader(_statement, _schema, initialResults, _isLz4Compressed, cloudFetchHttpClient);
+            }
+            else
+            {
+                return new DatabricksReader(_statement, _schema, initialResults, _isLz4Compressed);
+            }
+        }
+
+        /// <summary>
+        /// Reads the next record batch from the active reader.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The next record batch, or null if there are no more batches.</returns>
+        public override async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
+        {
+            // Initialize the active reader if not already done
+            if (_activeReader == null)
+            {
+                // if no reader, we did not have direct results
+                // Make a FetchResults call to get the initial result set
+                // and determine the reader based on the result set
+                TFetchResultsReq request = new TFetchResultsReq(this._statement.OperationHandle!, TFetchOrientation.FETCH_NEXT, this._statement.BatchSize);
+                TFetchResultsResp response = await this._statement.Connection.Client!.FetchResults(request, cancellationToken);
+                _activeReader = DetermineReader(response);
+            }
+
+            return await _activeReader.ReadNextRecordBatchAsync(cancellationToken);
+        }
+    }
+}

--- a/csharp/src/Drivers/Databricks/DatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksReader.cs
@@ -35,18 +35,18 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         int index;
         IArrowReader? reader;
 
-        public DatabricksReader(DatabricksStatement statement, Schema schema, bool isLz4Compressed) : base(statement, schema, isLz4Compressed)
+        public DatabricksReader(DatabricksStatement statement, Schema schema, TFetchResultsResp? initialResults, bool isLz4Compressed) : base(statement, schema, isLz4Compressed)
         {
             // If we have direct results, initialize the batches from them
             if (statement.HasDirectResults)
             {
                 this.batches = statement.DirectResults!.ResultSet.Results.ArrowBatches;
-
-                if (!statement.DirectResults.ResultSet.HasMoreRows)
-                {
-                    this.hasNoMoreRows = true;
-                    return;
-                }
+                this.hasNoMoreRows = !statement.DirectResults.ResultSet.HasMoreRows;
+            }
+            else if (initialResults != null)
+            {
+                this.batches = initialResults.Results.ArrowBatches;
+                this.hasNoMoreRows = !initialResults.HasMoreRows;
             }
         }
 

--- a/csharp/test/Drivers/Databricks/CloudFetchE2ETest.cs
+++ b/csharp/test/Drivers/Databricks/CloudFetchE2ETest.cs
@@ -46,7 +46,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             yield return new object[] { smallQuery, 1000, true, false };
             yield return new object[] { smallQuery, 1000, false, false };
 
-            string largeQuery = $"SELECT * FROM system.access.audit LIMIT 1000000";
+            string largeQuery = $"SELECT * FROM main.tpcds_sf10_delta.catalog_sales LIMIT 1000000";
             yield return new object[] { largeQuery, 1000000, true, true };
             yield return new object[] { largeQuery, 1000000, false, true };
             yield return new object[] { largeQuery, 1000000, true, false };

--- a/csharp/test/Drivers/Databricks/CloudFetchE2ETest.cs
+++ b/csharp/test/Drivers/Databricks/CloudFetchE2ETest.cs
@@ -46,7 +46,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             yield return new object[] { smallQuery, 1000, true, false };
             yield return new object[] { smallQuery, 1000, false, false };
 
-            string largeQuery = $"SELECT * FROM main.tpcds_sf10_delta.catalog_sales LIMIT 1000000";
+            string largeQuery = $"SELECT * FROM system.access.audit LIMIT 1000000";
             yield return new object[] { largeQuery, 1000000, true, true };
             yield return new object[] { largeQuery, 1000000, false, true };
             yield return new object[] { largeQuery, 1000000, true, false };


### PR DESCRIPTION
This is because there is a bug on runtime-side:

 >   Sometimes TSparkDirectResults.TFetchResultsResp.TRowSet could be non-link responses (ARROW_BASED_SET), but still TSparkDirectResults.TGetResultSetMetadataResp.ResultFormat == URL_BASED_SET

This PR gets around that by directly inspecting the results. Since we do not always have DirectResults, we make an additional FetchResult call to determine whether to use `CloudFetchReader` or arrow-based `DatabricksReader`. Only if the result contains links does it decide to use `CloudFetchReader`.

This test does not pass in 11.3, 10.4 DBR until this commit.
dotnet test --filter "FullyQualifiedName~LZ4DecompressionCapabilityTest"



## Remaining work:
Remaining work: need to update status polling to start earlier, ideally should be managed by new DatabricksCompositeReader
