### PR TITLE
feat(go/adbc/drivermgr): Set default load flags for drivermgr to load manifests

### DIFF
--- a/go/adbc/drivermgr/wrapper.go
+++ b/go/adbc/drivermgr/wrapper.go
@@ -48,12 +48,6 @@ package drivermgr
 //     return stream;
 // }
 //
-// const AdbcLoadFlags LoadFlagsDefault = ADBC_LOAD_FLAG_DEFAULT;
-// const AdbcLoadFlags LoadFlagsSearchEnv = ADBC_LOAD_FLAG_SEARCH_ENV;
-// const AdbcLoadFlags LoadFlagsSearchPath = ADBC_LOAD_FLAG_SEARCH_USER;
-// const AdbcLoadFlags LoadFlagsSearchSystem = ADBC_LOAD_FLAG_SEARCH_SYSTEM;
-// const AdbcLoadFlags LoadFlagsAllowRelativePaths = ADBC_LOAD_FLAG_ALLOW_RELATIVE_PATHS;
-//
 import "C"
 import (
 	"context"
@@ -68,12 +62,12 @@ import (
 )
 
 const (
-	LoadFlagsDefault            = C.LoadFlagsDefault
-	LoadFlagsSearchEnv          = C.LoadFlagsSearchEnv
-	LoadFlagsSearchPath         = C.LoadFlagsSearchPath
-	LoadFlagsSearchSystem       = C.LoadFlagsSearchSystem
-	LoadFlagsAllowRelativePaths = C.LoadFlagsAllowRelativePaths
+	LoadFlagsSearchEnv = 1 << iota
+	LoadFlagsSearchPath
+	LoadFlagsSearchSystem
+	LoadFlagsAllowRelativePaths
 
+	LoadFlagsDefault = LoadFlagsSearchEnv | LoadFlagsSearchPath | LoadFlagsSearchSystem | LoadFlagsAllowRelativePaths
 	// LoadFlagsOptionKey is the key to use for an option to set specific
 	// load flags for the database to decide where to look for driver manifests.
 	LoadFlagsOptionKey = "load_flags"
@@ -128,7 +122,7 @@ func (d Driver) NewDatabaseWithContext(_ context.Context, opts map[string]string
 		return nil, toAdbcError(code, &err)
 	}
 
-	if code := adbc.Status(C.AdbcDriverManagerDatabaseSetLoadFlags(db.db, C.LoadFlagsDefault, &err)); code != adbc.StatusOK {
+	if code := adbc.Status(C.AdbcDriverManagerDatabaseSetLoadFlags(db.db, C.AdbcLoadFlags(LoadFlagsDefault), &err)); code != adbc.StatusOK {
 		errOut := toAdbcError(code, &err)
 		C.AdbcDatabaseRelease(db.db, &err)
 		db.db = nil

--- a/go/adbc/drivermgr/wrapper.go
+++ b/go/adbc/drivermgr/wrapper.go
@@ -26,6 +26,7 @@ package drivermgr
 // #define ADBC_EXPORTING
 // #endif
 // #include "arrow-adbc/adbc.h"
+// #include "arrow-adbc/adbc_driver_manager.h"
 // #include <stdlib.h>
 // #include <string.h>
 //
@@ -46,6 +47,8 @@ package drivermgr
 //     memset(stream, 0, sizeof(struct ArrowArrayStream));
 //     return stream;
 // }
+//
+// const AdbcLoadFlags LoadFlagsDefault = ADBC_LOAD_FLAG_DEFAULT;
 //
 import "C"
 import (
@@ -106,6 +109,13 @@ func (d Driver) NewDatabaseWithContext(_ context.Context, opts map[string]string
 			db.db = nil
 			return nil, errOut
 		}
+	}
+
+	if code := adbc.Status(C.AdbcDriverManagerDatabaseSetLoadFlags(db.db, C.LoadFlagsDefault, &err)); code != adbc.StatusOK {
+		errOut := toAdbcError(code, &err)
+		C.AdbcDatabaseRelease(db.db, &err)
+		db.db = nil
+		return nil, errOut
 	}
 
 	if code := adbc.Status(C.AdbcDatabaseInit(db.db, &err)); code != adbc.StatusOK {

--- a/go/adbc/drivermgr/wrapper.go
+++ b/go/adbc/drivermgr/wrapper.go
@@ -49,10 +49,15 @@ package drivermgr
 // }
 //
 // const AdbcLoadFlags LoadFlagsDefault = ADBC_LOAD_FLAG_DEFAULT;
+// const AdbcLoadFlags LoadFlagsSearchEnv = ADBC_LOAD_FLAG_SEARCH_ENV;
+// const AdbcLoadFlags LoadFlagsSearchPath = ADBC_LOAD_FLAG_SEARCH_USER;
+// const AdbcLoadFlags LoadFlagsSearchSystem = ADBC_LOAD_FLAG_SEARCH_SYSTEM;
+// const AdbcLoadFlags LoadFlagsAllowRelativePaths = ADBC_LOAD_FLAG_ALLOW_RELATIVE_PATHS;
 //
 import "C"
 import (
 	"context"
+	"strconv"
 	"sync"
 	"unsafe"
 
@@ -60,6 +65,18 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/cdata"
+)
+
+const (
+	LoadFlagsDefault            = C.LoadFlagsDefault
+	LoadFlagsSearchEnv          = C.LoadFlagsSearchEnv
+	LoadFlagsSearchPath         = C.LoadFlagsSearchPath
+	LoadFlagsSearchSystem       = C.LoadFlagsSearchSystem
+	LoadFlagsAllowRelativePaths = C.LoadFlagsAllowRelativePaths
+
+	// LoadFlagsOptionKey is the key to use for an option to set specific
+	// load flags for the database to decide where to look for driver manifests.
+	LoadFlagsOptionKey = "load_flags"
 )
 
 type option struct {
@@ -96,19 +113,19 @@ func (d Driver) NewDatabaseWithContext(_ context.Context, opts map[string]string
 		options: make(map[string]option),
 	}
 
+	defer func() {
+		if db.db == nil { // cleanup options if we failed to create the database
+			for _, o := range dbOptions {
+				C.free(unsafe.Pointer(o.key))
+				C.free(unsafe.Pointer(o.val))
+			}
+		}
+	}()
+
 	var err C.struct_AdbcError
 	db.db = (*C.struct_AdbcDatabase)(unsafe.Pointer(C.calloc(C.sizeof_struct_AdbcDatabase, C.size_t(1))))
 	if code := adbc.Status(C.AdbcDatabaseNew(db.db, &err)); code != adbc.StatusOK {
 		return nil, toAdbcError(code, &err)
-	}
-
-	for _, o := range dbOptions {
-		if code := adbc.Status(C.AdbcDatabaseSetOption(db.db, o.key, o.val, &err)); code != adbc.StatusOK {
-			errOut := toAdbcError(code, &err)
-			C.AdbcDatabaseRelease(db.db, &err)
-			db.db = nil
-			return nil, errOut
-		}
 	}
 
 	if code := adbc.Status(C.AdbcDriverManagerDatabaseSetLoadFlags(db.db, C.LoadFlagsDefault, &err)); code != adbc.StatusOK {
@@ -116,6 +133,35 @@ func (d Driver) NewDatabaseWithContext(_ context.Context, opts map[string]string
 		C.AdbcDatabaseRelease(db.db, &err)
 		db.db = nil
 		return nil, errOut
+	}
+
+	for k, o := range dbOptions {
+		switch k {
+		case LoadFlagsOptionKey:
+			f, errOut := strconv.Atoi(C.GoString(o.val))
+			if errOut != nil {
+				C.AdbcDatabaseRelease(db.db, &err)
+				db.db = nil
+				return nil, adbc.Error{
+					Code: adbc.StatusInvalidArgument,
+					Msg:  "invalid load flags value: " + C.GoString(o.val),
+				}
+			}
+
+			if code := adbc.Status(C.AdbcDriverManagerDatabaseSetLoadFlags(db.db, C.AdbcLoadFlags(f), &err)); code != adbc.StatusOK {
+				errOut := toAdbcError(code, &err)
+				C.AdbcDatabaseRelease(db.db, &err)
+				db.db = nil
+				return nil, errOut
+			}
+		default:
+			if code := adbc.Status(C.AdbcDatabaseSetOption(db.db, o.key, o.val, &err)); code != adbc.StatusOK {
+				errOut := toAdbcError(code, &err)
+				C.AdbcDatabaseRelease(db.db, &err)
+				db.db = nil
+				return nil, errOut
+			}
+		}
 	}
 
 	if code := adbc.Status(C.AdbcDatabaseInit(db.db, &err)); code != adbc.StatusOK {


### PR DESCRIPTION
Use the updated driver manager implementation to set load flags by default so that the Go Driver Manager is able to discover and load drivers via toml Manifest Files.