### PR TITLE
fix(go/adbc): adding back compatibility for function FlightSQLDriverInit

### DIFF
--- a/go/adbc/pkg/flightsql/utils.c
+++ b/go/adbc/pkg/flightsql/utils.c
@@ -441,6 +441,12 @@ AdbcStatusCode FlightSqlDriverInit(int version, void* driver, struct AdbcError* 
   return AdbcDriverFlightsqlInit(version, driver, error);
 }
 
+ADBC_EXPORT
+AdbcStatusCode FlightSQLDriverInit(int version, void* driver, struct AdbcError* error) {
+  // For backwards compatibility
+  return AdbcDriverFlightsqlInit(version, driver, error);
+}
+
 int FlightSQLArrayStreamGetSchema(struct ArrowArrayStream*, struct ArrowSchema*);
 int FlightSQLArrayStreamGetNext(struct ArrowArrayStream*, struct ArrowArray*);
 

--- a/go/adbc/pkg/flightsql/utils.h
+++ b/go/adbc/pkg/flightsql/utils.h
@@ -158,6 +158,8 @@ AdbcStatusCode AdbcDriverFlightsqlInit(int version, void* rawDriver,
                                        struct AdbcError* err);
 AdbcStatusCode FlightSqlDriverInit(int version, void* rawDriver, struct AdbcError* err);
 
+AdbcStatusCode FlightSQLDriverInit(int version, void* rawDriver, struct AdbcError* err);
+
 static inline void FlightSQLerrRelease(struct AdbcError* error) {
   if (error->release) {
     error->release(error);


### PR DESCRIPTION
returning back function FlightSQLDriverInit
Fixes [3055](https://github.com/apache/arrow-adbc/issues/3055).