### PR TITLE
docs: update installation commands for R

### DIFF
--- a/docs/source/driver/flight_sql.rst
+++ b/docs/source/driver/flight_sql.rst
@@ -75,8 +75,7 @@ Installation
 
       .. code-block:: r
 
-         # install.packages("pak")
-         pak::pak("apache/arrow-adbc/r/adbcflightsql")
+         install.packages("adbcflightsql", repos = "https://community.r-multiverse.org")
 
 Usage
 =====

--- a/docs/source/driver/installation.rst
+++ b/docs/source/driver/installation.rst
@@ -155,13 +155,12 @@ Install the appropriate driver package from CRAN:
    install.packages("adbcpostgresql")
    install.packages("duckdb")
 
-Drivers not yet available on CRAN can be installed from GitHub:
+Drivers not yet available on CRAN can be installed from R-multiverse:
 
 .. code-block:: r
 
-   # install.packages("pak")
-   pak::pak("apache/arrow-adbc/r/adbcflightsql")
-   pak::pak("apache/arrow-adbc/r/adbcsnowflake")
+   install.packages("adbcflightsql", repos = "https://community.r-multiverse.org")
+   install.packages("adbcsnowflake", repos = "https://community.r-multiverse.org")
 
 Ruby
 ====

--- a/docs/source/driver/snowflake.rst
+++ b/docs/source/driver/snowflake.rst
@@ -60,8 +60,7 @@ Installation
 
       .. code-block:: shell
 
-         # install.packages("pak")
-         pak::pak("apache/arrow-adbc/r/adbcsnowflake")
+         install.packages("adbcsnowflake", repos = "https://community.r-multiverse.org")
 
 Usage
 =====


### PR DESCRIPTION
Close #2907

The commands listed in the README of each R package were modified by #2262, but the main site was not updated.
Installation from the R-multiverse community repository has been stable for the past several months and should be recommended to users.