### PR TITLE
fix(r/adbcbigquery,r/adbcflightsql,r/adbcsnowflake): fix warnings on R CMD check for  Go-based drivers

### DIFF
--- a/.github/workflows/r-basic.yml
+++ b/.github/workflows/r-basic.yml
@@ -59,8 +59,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       pkg: ${{ matrix.pkg }}
-      # For the r-basic check (that runs on many PRs), just check ERRORs
-      # (e.g., build failure, test failure)
-      error-on: error
+      # If update this to `error`, warnings will not fail the job
+      error-on: warning
     secrets:
       SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}

--- a/r/adbcbigquery/src/Makevars.in
+++ b/r/adbcbigquery/src/Makevars.in
@@ -27,6 +27,9 @@ GOMAXPROCS = @nproc@
 all: purify
 $(SHLIB): gostatic
 
+# R CMD check issues a warning for this `.a` file.
+# We remove this file after SHLIB generation to suppress the warning.
+# <https://github.com/apache/arrow-adbc/issues/3059>
 purify: $(SHLIB)
 	rm -Rf "$(CURDIR)/go/libadbc_driver_bigquery.a"
 

--- a/r/adbcbigquery/src/Makevars.in
+++ b/r/adbcbigquery/src/Makevars.in
@@ -23,9 +23,12 @@ CGO_CXX = @cxx@
 CGO_CFLAGS = $(ALL_CPPFLAGS)
 GOMAXPROCS = @nproc@
 
-.PHONY: all gostatic
-all: $(SHLIB)
+.PHONY: all purify gostatic
+all: purify
 $(SHLIB): gostatic
+
+purify: $(SHLIB)
+	rm -Rf "$(CURDIR)/go/libadbc_driver_bigquery.a"
 
 gostatic:
 		(cd "$(CURDIR)/go/adbc"; GOMAXPROCS=$(GOMAXPROCS) GOPATH="$(CURDIR)/.go-path" GOCACHE="$(CURDIR)/.go-cache" GOFLAGS=-modcacherw CC="$(CGO_CC)" CXX="$(CGO_CXX)" CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(PKG_LIBS)" "@gobin@" build -v -tags driverlib -o $(CURDIR)/go/libadbc_driver_bigquery.a -buildmode=c-archive "./pkg/bigquery")

--- a/r/adbcflightsql/src/Makevars.in
+++ b/r/adbcflightsql/src/Makevars.in
@@ -23,9 +23,12 @@ CGO_CXX = @cxx@
 CGO_CFLAGS = $(ALL_CPPFLAGS)
 GOMAXPROCS = @nproc@
 
-.PHONY: all gostatic
-all: $(SHLIB)
+.PHONY: all purify gostatic
+all: purify
 $(SHLIB): gostatic
+
+purify: $(SHLIB)
+	rm -Rf "$(CURDIR)/go/libadbc_driver_flightsql.a"
 
 gostatic:
 		(cd "$(CURDIR)/go/adbc"; GOMAXPROCS=$(GOMAXPROCS) GOPATH="$(CURDIR)/.go-path" GOCACHE="$(CURDIR)/.go-cache" GOFLAGS=-modcacherw CC="$(CGO_CC)" CXX="$(CGO_CXX)" CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(PKG_LIBS)" "@gobin@" build -v -tags driverlib -o $(CURDIR)/go/libadbc_driver_flightsql.a -buildmode=c-archive "./pkg/flightsql")

--- a/r/adbcflightsql/src/Makevars.in
+++ b/r/adbcflightsql/src/Makevars.in
@@ -27,6 +27,9 @@ GOMAXPROCS = @nproc@
 all: purify
 $(SHLIB): gostatic
 
+# R CMD check issues a warning for this `.a` file.
+# We remove this file after SHLIB generation to suppress the warning.
+# <https://github.com/apache/arrow-adbc/issues/3059>
 purify: $(SHLIB)
 	rm -Rf "$(CURDIR)/go/libadbc_driver_flightsql.a"
 

--- a/r/adbcsnowflake/src/Makevars.in
+++ b/r/adbcsnowflake/src/Makevars.in
@@ -23,9 +23,12 @@ CGO_CXX = @cxx@
 CGO_CFLAGS = $(ALL_CPPFLAGS)
 GOMAXPROCS = @nproc@
 
-.PHONY: all gostatic
-all: $(SHLIB)
+.PHONY: all purify gostatic
+all: purify
 $(SHLIB): gostatic
+
+purify: $(SHLIB)
+	rm -Rf "$(CURDIR)/go/libadbc_driver_snowflake.a"
 
 gostatic:
 		(cd "$(CURDIR)/go/adbc"; GOMAXPROCS=$(GOMAXPROCS) GOPATH="$(CURDIR)/.go-path" GOCACHE="$(CURDIR)/.go-cache" GOFLAGS=-modcacherw CC="$(CGO_CC)" CXX="$(CGO_CXX)" CGO_CFLAGS="$(CGO_CFLAGS)" CGO_LDFLAGS="$(PKG_LIBS)" "@gobin@" build -v -tags driverlib -o $(CURDIR)/go/libadbc_driver_snowflake.a -buildmode=c-archive "./pkg/snowflake")

--- a/r/adbcsnowflake/src/Makevars.in
+++ b/r/adbcsnowflake/src/Makevars.in
@@ -27,6 +27,9 @@ GOMAXPROCS = @nproc@
 all: purify
 $(SHLIB): gostatic
 
+# R CMD check issues a warning for this `.a` file.
+# We remove this file after SHLIB generation to suppress the warning.
+# <https://github.com/apache/arrow-adbc/issues/3059>
 purify: $(SHLIB)
 	rm -Rf "$(CURDIR)/go/libadbc_driver_snowflake.a"
 


### PR DESCRIPTION
Fix #3059 (Supersede #2708)