### PR TITLE
fix(csharp/src/Drivers/Databricks):  Align ConnectionTimeout with TemporarilyUnavailableRetryTimeout

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -527,6 +527,13 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 }
                 TemporarilyUnavailableRetryTimeout = tempUnavailableRetryTimeoutValue;
             }
+
+            // When TemporarilyUnavailableRetry is enabled, we need to make sure connection timeout (which is used to cancel the HttpConnection) is equal 
+            // or greater than TemporarilyUnavailableRetryTimeout so that it won't timeout before server startup timeout (TemporarilyUnavailableRetryTimeout)
+            if (TemporarilyUnavailableRetry && TemporarilyUnavailableRetryTimeout * 1000 > ConnectTimeoutMilliseconds)
+            {
+                ConnectTimeoutMilliseconds = TemporarilyUnavailableRetryTimeout * 1000;
+            }
         }
 
         protected override Task<TGetResultSetMetadataResp> GetResultSetMetadataAsync(TGetSchemasResp response, CancellationToken cancellationToken = default) =>


### PR DESCRIPTION
# PR Description

## Description

This PR sets  the `ConnectTimeoutMilliseconds ` of  `DatabricksConnection` with `TemporarilyUnavailableRetryTimeout` when `TemporarilyUnavailableRetryTimeout` is greater than `ConnectTimeoutMilliseconds` to make sure it can continue the retry when `ConnectTimeoutMilliseconds` is lower than `TemporarilyUnavailableRetryTimeout`.

### Changes
- Updated `DatabricksConnection:ValidateOptions` to set `ConnectTimeoutMilliseconds` with `TemporarilyUnavailableRetryTimeout` when `TemporarilyUnavailableRetryTimeout` is greater than `ConnectTimeoutMilliseconds` and `TemporarilyUnavailableRetry` is enabled

### Motivation 

The default value of `ConnectTimeoutMilliseconds` is 30 seconds (see [here](https://github.com/apache/arrow-adbc/blob/main/csharp/src/Drivers/Apache/Hive2/HiveServer2Connection.cs#L43)), which is lower than the default value (900s) of `TemporarilyUnavailableRetryTimeout`. If client does not set this, it will timeout after 30s, this is normally lower than the Databricks cluster startup time, so the client/user may get the timeout error when opening a connection on an idle cluster.

### Testing

- E2E test by opening a connection and run a query on a cluster that has been stopped