### PR TITLE
fix(go/adbc): moving the declaration of functions to go code

### DIFF
--- a/go/adbc/pkg/flightsql/driver.go
+++ b/go/adbc/pkg/flightsql/driver.go
@@ -1813,6 +1813,18 @@ func FlightSQLStatementExecutePartitions(stmt *C.struct_AdbcStatement, schema *C
 	return C.ADBC_STATUS_OK
 }
 
+//export FlightSqlDriverInit
+func FlightSqlDriverInit(version C.int, rawDriver *C.void, err *C.struct_AdbcError) C.AdbcStatusCode {
+  // For backwards compatibility
+  return AdbcDriverFlightsqlInit(version, driver, error);
+}
+
+//export FlightSQLDriverInit
+func FlightSQLDriverInit(version C.int, rawDriver *C.void, err *C.struct_AdbcError) C.AdbcStatusCode {
+  // For backwards compatibility
+  return AdbcDriverFlightsqlInit(version, driver, error);
+}
+
 //export AdbcDriverFlightsqlInit
 func AdbcDriverFlightsqlInit(version C.int, rawDriver *C.void, err *C.struct_AdbcError) C.AdbcStatusCode {
 	driver := (*C.struct_AdbcDriver)(unsafe.Pointer(rawDriver))

--- a/go/adbc/pkg/flightsql/utils.c
+++ b/go/adbc/pkg/flightsql/utils.c
@@ -435,18 +435,6 @@ AdbcStatusCode AdbcDriverInit(int version, void* driver, struct AdbcError* error
 }
 #endif  // ADBC_NO_COMMON_ENTRYPOINTS
 
-ADBC_EXPORT
-AdbcStatusCode FlightSqlDriverInit(int version, void* driver, struct AdbcError* error) {
-  // For backwards compatibility
-  return AdbcDriverFlightsqlInit(version, driver, error);
-}
-
-ADBC_EXPORT
-AdbcStatusCode FlightSQLDriverInit(int version, void* driver, struct AdbcError* error) {
-  // For backwards compatibility
-  return AdbcDriverFlightsqlInit(version, driver, error);
-}
-
 int FlightSQLArrayStreamGetSchema(struct ArrowArrayStream*, struct ArrowSchema*);
 int FlightSQLArrayStreamGetNext(struct ArrowArrayStream*, struct ArrowArray*);
 


### PR DESCRIPTION
FlightSqlDriverInit and FlightSQLDriverInit are a part of legacy init functions. 
We should keep them in place and not lose because of the code generation.