### PR TITLE
chore(dev/release): add Python 3.13 to the default wheel test targets

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -836,7 +836,7 @@ test_linux_wheels() {
     local arch="x86_64"
   fi
 
-  local python_versions="${TEST_PYTHON_VERSIONS:-3.9 3.10 3.11 3.12}"
+  local python_versions="${TEST_PYTHON_VERSIONS:-3.9 3.10 3.11 3.12 3.13}"
 
   for python in ${python_versions}; do
     local pyver=${python/m}
@@ -858,7 +858,7 @@ test_macos_wheels() {
     local platform_tags="x86_64"
   fi
 
-  local python_versions="${TEST_PYTHON_VERSIONS:-3.9 3.10 3.11 3.12}"
+  local python_versions="${TEST_PYTHON_VERSIONS:-3.9 3.10 3.11 3.12 3.13}"
 
   # verify arch-native wheels inside an arch-native conda environment
   for python in ${python_versions}; do


### PR DESCRIPTION
 Fixes #3084.