### PR TITLE
fix(python/adbc_driver_bigquery): correct string value of credential enum

### DIFF
--- a/python/adbc_driver_bigquery/adbc_driver_bigquery/__init__.py
+++ b/python/adbc_driver_bigquery/adbc_driver_bigquery/__init__.py
@@ -43,7 +43,7 @@ class DatabaseOptions(enum.Enum):
     #:
     #: or, it should be the encoded JSON string if
     #: AUTH_TYPE is AUTH_VALUE_JSON_CREDENTIAL_STRING
-    AUTH_CREDENTIALS = "adbc.bigquery.sql.auth.credentials"
+    AUTH_CREDENTIALS = "adbc.bigquery.sql.auth_credentials"
 
     #: Specify the client ID, client secret and refresh_token to
     #: use for bigquery connection if AUTH_TYPE is


### PR DESCRIPTION
This enum has an incorrect string value, meaning that the example in readme.md does not work.

We need to change the string value to `adbc.bigquery.sql.auth_credentials`, which I can confirm works locally.

See here for reference:
https://github.com/apache/arrow-adbc/commit/e7e2519fbd330f159d82fd1bed651e67f58b26d1#diff-4b8bab909f2ed237b907b8ed07148ac196124744850cae59fd4b202a01906091R25-R41