### PR TITLE
fix(csharp/src/Drivers/Databricks): Set the SqlState of the exception in RetryHttpHandler

### DIFF
--- a/csharp/src/Drivers/Databricks/RetryHttpHandler.cs
+++ b/csharp/src/Drivers/Databricks/RetryHttpHandler.cs
@@ -118,7 +118,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             }
 
             throw new DatabricksException(
-                lastErrorMessage ?? "Service temporarily unavailable and retry timeout exceeded",
+                "[SQLState: 08001]" + (lastErrorMessage ?? "Service temporarily unavailable and retry timeout exceeded"),
                  AdbcStatusCode.IOError);
         }
 

--- a/csharp/src/Drivers/Databricks/RetryHttpHandler.cs
+++ b/csharp/src/Drivers/Databricks/RetryHttpHandler.cs
@@ -117,9 +117,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 throw new OperationCanceledException("Request cancelled during retry wait", cancellationToken);
             }
 
-            throw new DatabricksException(
-                "[SQLState: 08001]" + (lastErrorMessage ?? "Service temporarily unavailable and retry timeout exceeded"),
-                 AdbcStatusCode.IOError);
+            throw new DatabricksException(lastErrorMessage ?? "Service temporarily unavailable and retry timeout exceeded", AdbcStatusCode.IOError)
+                .SetSqlState("08001");
         }
 
         /// <summary>

--- a/csharp/test/Drivers/Databricks/RetryHttpHandlerTest.cs
+++ b/csharp/test/Drivers/Databricks/RetryHttpHandlerTest.cs
@@ -88,8 +88,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             var exception = await Assert.ThrowsAsync<DatabricksException>(async () =>
                 await httpClient.GetAsync("http://test.com"));
 
-            // Verify the exception has the correct SQL state in the message
-            Assert.Contains("[SQLState: 08001]", exception.Message);
+            // Verify the exception has the correct SQL state
+            Assert.Contains("08001", exception.SqlState);
             Assert.Equal(AdbcStatusCode.IOError, exception.Status);
 
             // Verify we only tried once (since the Retry-After value of 2 exceeds our timeout of 1)

--- a/csharp/test/Drivers/Databricks/RetryHttpHandlerTest.cs
+++ b/csharp/test/Drivers/Databricks/RetryHttpHandlerTest.cs
@@ -85,7 +85,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             var httpClient = new HttpClient(retryHandler);
 
             // Send a request and expect an AdbcException
-            var exception = await Assert.ThrowsAsync<AdbcException>(async () =>
+            var exception = await Assert.ThrowsAsync<DatabricksException>(async () =>
                 await httpClient.GetAsync("http://test.com"));
 
             // Verify the exception has the correct SQL state in the message


### PR DESCRIPTION
# PR Description

## Description

This PR set the `SqlState` of the timeout exception raised in Databricks `RetryHttpHandler` to align SqlState used in same exception in other Databricks drivers including JDBC. 

### Changes
- Set the `SqlState` of the timeout exception raised in Databricks `RetryHttpHandler`
- Fixed a bug in the unit test `RetryHttpHandlerTest`

### Motivation 

Fix the failure in unit test `RetryHttpHandlerTest` and align the error message with other Databricks drivers.

### Testing

- Unt test RetryHttpHandlerTest
- End-to-end test