### PR TITLE
feat(csharp/src/Drivers/Databricks): Remove redundant closeoperation

### DIFF
--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs
@@ -566,6 +566,9 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
 
         private async Task<QueryResult> GetQueryResult(TSparkDirectResults? directResults, CancellationToken cancellationToken)
         {
+            // Set _directResults so that dispose logic can check if operation was already closed
+            _directResults = directResults;
+
             Schema schema;
             if (Connection.AreResultsAvailableDirectly && directResults?.ResultSet?.Results != null)
             {


### PR DESCRIPTION
The PR to introduce tracing also added logic to throw errors from CloseOperation in Dispose. Previously, we had been silently ignoring CloseOperation failures. The CloseOperation failure occurred because we weren't properly checking for DirectResults.CloseOperation status for Metadata queries.