### PR TITLE
fix(src/Drivers/Apache): generate type-consistent empty result for GetColumnsExtended query

### DIFF
--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs
@@ -797,7 +797,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
         }
 
         // Helper method to create an empty result with the complete extended columns schema
-        protected QueryResult CreateEmptyExtendedColumnsResult(Schema baseSchema)
+        protected static QueryResult CreateEmptyExtendedColumnsResult(Schema baseSchema)
         {
             // Create the complete schema with all fields
             var allFields = new List<Field>(baseSchema.FieldsList);
@@ -819,8 +819,48 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
             var combinedData = new List<IArrowArray>();
             foreach (var field in allFields)
             {
-                var builder = new StringArray.Builder();
-                combinedData.Add(builder.Build());
+                switch (field.DataType.TypeId)
+                {
+                    case ArrowTypeId.String:
+                        combinedData.Add(new StringArray.Builder().Build());
+                        break;
+                    case ArrowTypeId.Int8:
+                        combinedData.Add(new Int8Array.Builder().Build());
+                        break;
+                    case ArrowTypeId.Int16:
+                        combinedData.Add(new Int16Array.Builder().Build());
+                        break;
+                    case ArrowTypeId.Int32:
+                        combinedData.Add(new Int32Array.Builder().Build());
+                        break;
+                    case ArrowTypeId.Int64:
+                        combinedData.Add(new Int64Array.Builder().Build());
+                        break;
+                    case ArrowTypeId.Boolean:
+                        combinedData.Add(new BooleanArray.Builder().Build());
+                        break;
+                    case ArrowTypeId.Float:
+                        combinedData.Add(new FloatArray.Builder().Build());
+                        break;
+                    case ArrowTypeId.Double:
+                        combinedData.Add(new  DoubleArray.Builder().Build());
+                        break;
+                    case ArrowTypeId.Date32:
+                        combinedData.Add(new Date32Array.Builder().Build());
+                        break;
+                    case ArrowTypeId.Date64:
+                        combinedData.Add(new Date64Array.Builder().Build());
+                        break;
+                    case ArrowTypeId.Timestamp:
+                        combinedData.Add(new TimestampArray.Builder().Build());
+                        break;
+                    case ArrowTypeId.Decimal128:
+                        combinedData.Add(new Decimal128Array.Builder((Decimal128Type)field.DataType).Build());
+                        break;
+                    default:
+                        throw AdbcException.NotImplemented(
+                            $"Data type '{field.DataType}' is not supported for empty extended columns result.");
+                }
             }
 
             return new QueryResult(0, new HiveServer2Connection.HiveInfoArrowStream(combinedSchema, combinedData));

--- a/csharp/test/Drivers/Apache/Common/DriverTests.cs
+++ b/csharp/test/Drivers/Apache/Common/DriverTests.cs
@@ -305,12 +305,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Common
         /// <summary>
         /// Validates if the driver can call GetObjects with GetObjectsDepth as Tables with TableName as a pattern.
         /// </summary>
-        protected void GetObjectsTablesTest(string tableNamePattern)
+        protected void GetObjectsTablesTest(string tableNamePattern, string? expectedTableName = default)
         {
             // need to add the database
             string? databaseName = TestConfiguration.Metadata.Catalog;
             string? schemaName = TestConfiguration.Metadata.Schema;
-            string? tableName = TestConfiguration.Metadata.Table;
+            string? tableName = expectedTableName ?? TestConfiguration.Metadata.Table;
 
             using IArrowArrayStream stream = Connection.GetObjects(
                     depth: AdbcConnection.GetObjectsDepth.Tables,

--- a/csharp/test/Drivers/Databricks/StatementTests.cs
+++ b/csharp/test/Drivers/Databricks/StatementTests.cs
@@ -498,6 +498,207 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             OutputHelper?.WriteLine($"Successfully retrieved {rowCount} columns with extended information");
         }
 
+        [SkippableFact]
+        public async Task CanGetColumnsOnNoColumnTable()
+        {
+            string? catalogName = TestConfiguration.Metadata.Catalog;
+            string? schemaName = TestConfiguration.Metadata.Schema;
+            string tableName = Guid.NewGuid().ToString("N");
+            string fullTableName = string.Format(
+                "{0}{1}{2}",
+                string.IsNullOrEmpty(catalogName) ? string.Empty : DelimitIdentifier(catalogName) + ".",
+                string.IsNullOrEmpty(schemaName) ? string.Empty : DelimitIdentifier(schemaName) + ".",
+                DelimitIdentifier(tableName));
+            using TemporaryTable temporaryTable = await TemporaryTable.NewTemporaryTableAsync(
+                Statement,
+                fullTableName,
+                $"CREATE TABLE IF NOT EXISTS {fullTableName} ();",
+                OutputHelper);
+
+            var statement = Connection.CreateStatement();
+            statement.SetOption(ApacheParameters.IsMetadataCommand, "true");
+            statement.SetOption(ApacheParameters.CatalogName, catalogName);
+            statement.SetOption(ApacheParameters.SchemaName, schemaName);
+            statement.SetOption(ApacheParameters.TableName, tableName);
+            statement.SqlQuery = "GetColumns";
+
+            QueryResult queryResult = await statement.ExecuteQueryAsync();
+            Assert.NotNull(queryResult.Stream);
+
+            // 23 original metadata columns and one added for "base type"
+            Assert.Equal(24, queryResult.Stream.Schema.FieldsList.Count);
+            int actualBatchLength = 0;
+
+            while (queryResult.Stream != null)
+            {
+                RecordBatch? batch = await queryResult.Stream.ReadNextRecordBatchAsync();
+                if (batch == null)
+                {
+                    break;
+                }
+                actualBatchLength += batch.Length;
+            }
+            Assert.Equal(0, actualBatchLength);
+        }
+
+        [SkippableFact]
+        public async Task CanGetColumnsExtendedOnNoColumnTable()
+        {
+            string? catalogName = TestConfiguration.Metadata.Catalog;
+            string? schemaName = TestConfiguration.Metadata.Schema;
+            string tableName = Guid.NewGuid().ToString("N");
+            string fullTableName = string.Format(
+                "{0}{1}{2}",
+                string.IsNullOrEmpty(catalogName) ? string.Empty : DelimitIdentifier(catalogName) + ".",
+                string.IsNullOrEmpty(schemaName) ? string.Empty : DelimitIdentifier(schemaName) + ".",
+                DelimitIdentifier(tableName));
+            using TemporaryTable temporaryTable = await TemporaryTable.NewTemporaryTableAsync(
+                Statement,
+                fullTableName,
+                $"CREATE TABLE IF NOT EXISTS {fullTableName} ();",
+                OutputHelper);
+
+            using AdbcConnection connection = NewConnection();
+
+            // Get the runtime version using GetInfo
+            var infoCodes = new List<AdbcInfoCode> { AdbcInfoCode.VendorVersion };
+            var infoValues = Connection.GetInfo(infoCodes);
+
+            // Set up statement for GetColumnsExtended
+            var statement = connection.CreateStatement();
+            statement.SetOption(ApacheParameters.IsMetadataCommand, "true");
+            statement.SetOption(ApacheParameters.CatalogName, catalogName);
+            statement.SetOption(ApacheParameters.SchemaName, schemaName);
+            statement.SetOption(ApacheParameters.TableName, tableName);
+            statement.SetOption(ApacheParameters.EscapePatternWildcards, "true");
+            statement.SqlQuery = "GetColumnsExtended";
+
+            QueryResult queryResult = await statement.ExecuteQueryAsync();
+            Assert.NotNull(queryResult.Stream);
+
+            // Verify schema has more fields than the regular GetColumns result (which has 24 fields)
+            // We expect additional PK and FK fields
+            OutputHelper?.WriteLine($"Column count in result schema: {queryResult.Stream.Schema.FieldsList.Count}");
+            Assert.True(queryResult.Stream.Schema.FieldsList.Count > 24,
+                "GetColumnsExtended should return more columns than GetColumns (at least 24+)");
+
+            // Verify that key fields from each original metadata call are present
+            bool hasColumnName = false;
+            bool hasPkKeySeq = false;
+            bool hasFkTableName = false;
+
+            foreach (var field in queryResult.Stream.Schema.FieldsList)
+            {
+                OutputHelper?.WriteLine($"Field in schema: {field.Name} ({field.DataType})");
+
+                if (field.Name.Equals("COLUMN_NAME", StringComparison.OrdinalIgnoreCase))
+                    hasColumnName = true;
+                else if (field.Name.Equals("PK_COLUMN_NAME", StringComparison.OrdinalIgnoreCase))
+                    hasPkKeySeq = true;
+                else if (field.Name.Equals("FK_PKTABLE_NAME", StringComparison.OrdinalIgnoreCase))
+                    hasFkTableName = true;
+            }
+
+            Assert.True(hasColumnName, "Schema should contain COLUMN_NAME field from GetColumns");
+            Assert.True(hasPkKeySeq, "Schema should contain PK_KEY_SEQ field from GetPrimaryKeys");
+            Assert.True(hasFkTableName, "Schema should contain FK_PKTABLE_NAME field from GetCrossReference");
+
+            // Define the expected schema as (name, type) pairs
+            var expectedSchema = new (string Name, string Type)[]
+            {
+                ("TABLE_CAT", "Apache.Arrow.Types.StringType"),
+                ("TABLE_SCHEM", "Apache.Arrow.Types.StringType"),
+                ("TABLE_NAME", "Apache.Arrow.Types.StringType"),
+                ("COLUMN_NAME", "Apache.Arrow.Types.StringType"),
+                ("DATA_TYPE", "Apache.Arrow.Types.Int32Type"),
+                ("TYPE_NAME", "Apache.Arrow.Types.StringType"),
+                ("COLUMN_SIZE", "Apache.Arrow.Types.Int32Type"),
+                ("BUFFER_LENGTH", "Apache.Arrow.Types.Int8Type"),
+                ("DECIMAL_DIGITS", "Apache.Arrow.Types.Int32Type"),
+                ("NUM_PREC_RADIX", "Apache.Arrow.Types.Int32Type"),
+                ("NULLABLE", "Apache.Arrow.Types.Int32Type"),
+                ("REMARKS", "Apache.Arrow.Types.StringType"),
+                ("COLUMN_DEF", "Apache.Arrow.Types.StringType"),
+                ("SQL_DATA_TYPE", "Apache.Arrow.Types.Int32Type"),
+                ("SQL_DATETIME_SUB", "Apache.Arrow.Types.Int32Type"),
+                ("CHAR_OCTET_LENGTH", "Apache.Arrow.Types.Int32Type"),
+                ("ORDINAL_POSITION", "Apache.Arrow.Types.Int32Type"),
+                ("IS_NULLABLE", "Apache.Arrow.Types.StringType"),
+                ("SCOPE_CATALOG", "Apache.Arrow.Types.StringType"),
+                ("SCOPE_SCHEMA", "Apache.Arrow.Types.StringType"),
+                ("SCOPE_TABLE", "Apache.Arrow.Types.StringType"),
+                ("SOURCE_DATA_TYPE", "Apache.Arrow.Types.Int16Type"),
+                ("IS_AUTO_INCREMENT", "Apache.Arrow.Types.StringType"),
+                ("BASE_TYPE_NAME", "Apache.Arrow.Types.StringType"),
+                ("PK_COLUMN_NAME", "Apache.Arrow.Types.StringType"),
+                ("FK_PKCOLUMN_NAME", "Apache.Arrow.Types.StringType"),
+                ("FK_PKTABLE_CAT", "Apache.Arrow.Types.StringType"),
+                ("FK_PKTABLE_SCHEM", "Apache.Arrow.Types.StringType"),
+                ("FK_PKTABLE_NAME", "Apache.Arrow.Types.StringType"),
+                ("FK_FKCOLUMN_NAME", "Apache.Arrow.Types.StringType"),
+                ("FK_FK_NAME", "Apache.Arrow.Types.StringType"),
+                ("FK_KEQ_SEQ", "Apache.Arrow.Types.Int32Type"),
+            };
+
+            RecordBatch batch = await queryResult.Stream.ReadNextRecordBatchAsync();
+            Assert.NotNull(batch);
+            // Assert each expected field exists in the actual schema with the correct type
+            for (int i = 0; i < expectedSchema.Length; i++)
+            {
+                (string expectedName, string expectedType) = expectedSchema[i];
+                var actualField = queryResult.Stream?.Schema.FieldsList
+                    .FirstOrDefault(f => f.Name == expectedName);
+
+                Assert.NotNull(actualField); // Field must exist
+                Assert.Equal(expectedType, actualField.DataType.GetType().ToString());
+                var columnArray = batch.Column(i);
+                Assert.Equal(actualField.DataType, columnArray.Data.DataType);
+            }
+
+            //// Read and verify data
+            //var result = await ConvertQueryResultToList(queryResult);
+            //var resultJson = JsonSerializer.Serialize(result);
+            //var rowCount = result.Count;
+
+            //// Load expected result
+            //var rows = new List<Dictionary<string, object?>>();
+            //var resultString = File.ReadAllText(resultLocation)
+            //    .Replace("{CATALOG_NAME}", catalogName)
+            //    .Replace("{SCHEMA_NAME}", schemaName)
+            //    .Replace("{TABLE_NAME}", tableName)
+            //    .Replace("{REF_TABLE_NAME}", refTableName);
+
+            //// Apply extra placeholder replacements if provided
+            //if (extraPlaceholdsInResult != null)
+            //{
+            //    foreach (var placeholderReplacement in extraPlaceholdsInResult)
+            //    {
+            //        var parts = placeholderReplacement.Split(':');
+            //        if (parts.Length == 2)
+            //        {
+            //            var placeholder = parts[0];
+            //            var replacement = parts[1];
+            //            resultString = resultString.Replace("{" + placeholder + "}", replacement);
+            //        }
+            //    }
+            //}
+
+            //var expectedResult = JsonSerializer.Deserialize<List<Dictionary<string, object?>>>(resultString);
+
+            //// For debug
+            //OutputHelper?.WriteLine(resultJson);
+
+            //// Verify we got rows matching the expected column count
+            //Assert.Equal(expectedResult!.Count, rowCount);
+
+            //// Verify the result match expected result
+            //// Assert.Equal cannot do the deep compare between 2 list with nested object, let us compare with json
+            //var expectedResultJson = JsonSerializer.Serialize(expectedResult);
+            //Assert.Equal(expectedResultJson, resultJson);
+
+            //OutputHelper?.WriteLine($"Successfully retrieved {rowCount} columns with extended information");
+        }
+
         // Helper method to get string representation of array values
         private string GetStringValue(IArrowArray array, int index)
         {


### PR DESCRIPTION
Generates a type-consistent empty result for GetColumnsExtended query.

Adds Databricks integration tests to confirm support of tables with no columns (Databricks-specific feature).