### PR TITLE
fix(csharp/src/Drivers/Databricks): fix CloudFetchResultFetcher initial results processing logic

### DIFF
--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchResultFetcher.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchResultFetcher.cs
@@ -213,9 +213,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
             try
             {
                 // Process direct results first, if available
-                if (_statement.HasDirectResults &&
-                    (_statement.DirectResults?.ResultSet?.Results?.ResultLinks?.Count > 0 ||
-                    _initialResults?.Results?.ResultLinks?.Count > 0))
+                if ((_statement.HasDirectResults && _statement.DirectResults?.ResultSet?.Results?.ResultLinks?.Count > 0) ||
+                    _initialResults?.Results?.ResultLinks?.Count > 0)
                 {
                     // Yield execution so the download queue doesn't get blocked before downloader is started
                     await Task.Yield();


### PR DESCRIPTION


  ## Summary
  - Fixed failing unit tests in CloudFetchResultFetcherTest by correcting the conditional logic for processing initial results
  - The fetcher now properly handles initial results regardless of the `HasDirectResults` flag state

  ## Problem
  Two unit tests were failing:
  - `InitialResults_ProcessesInitialResultsCorrectly`
  - `InitialResults_WithMoreRows_ContinuesFetching`

  The issue was in the condition that checks whether to process direct/initial results. The previous logic required
  `_statement.HasDirectResults` to be true even when processing initial results passed to the constructor, which
  prevented the initial results from being processed in test scenarios.

  ## Solution
  Changed the conditional logic from:
  ```csharp
  if (_statement.HasDirectResults &&
      (_statement.DirectResults?.ResultSet?.Results?.ResultLinks?.Count > 0 ||
      _initialResults?.Results?.ResultLinks?.Count > 0))

  To:
  if ((_statement.HasDirectResults && _statement.DirectResults?.ResultSet?.Results?.ResultLinks?.Count > 0) ||
      _initialResults?.Results?.ResultLinks?.Count > 0)

  This ensures that initial results are processed when provided, regardless of the HasDirectResults flag.

  Test plan

  - All 12 tests in CloudFetchResultFetcherTest pass
  - No regression in other CloudFetch-related tests
  - Verified the fetcher correctly processes both direct results and initial results scenarios