### PR TITLE
feat(csharp/src/Drivers/Databricks): Fix EnablePkFk

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -438,7 +438,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 if (!FeatureVersionNegotiator.IsDatabricksProtocolVersion(version)) {
                     throw new DatabricksException("Attempted to use databricks driver with a non-databricks server");
                 }
-                _enablePKFK = FeatureVersionNegotiator.SupportsPKFK(version);
+                _enablePKFK = _enablePKFK && FeatureVersionNegotiator.SupportsPKFK(version);
                 _enableMultipleCatalogSupport = session.__isset.canUseMultipleCatalogs ? session.CanUseMultipleCatalogs : false;
                 if (session.__isset.initialNamespace)
                 {


### PR DESCRIPTION
FeatureVersionNegotiator introduced a bug where user-set enablePKFK is overridden by server negotiation logic. This means that if user specifies enablePKFK = false, but server version is high enough, it will override and set enablePKFK = true. 

ShouldReturnEmptyPkFkResult_WorksAsExpected fully passes after this change