### PR TITLE
feat(rust/core): add driver manifest definition

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10,6 +10,10 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "libloading",
+ "semver",
+ "serde",
+ "spdx",
+ "toml",
 ]
 
 [[package]]
@@ -2710,6 +2714,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_tokenstream"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,6 +2796,15 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "spdx"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b69356da67e2fc1f542c71ea7e654a361a79c938e4424392ecf4fa065d2193"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "sqlparser"
@@ -3013,6 +3035,40 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3386,6 +3442,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -33,11 +33,18 @@ categories.workspace = true
 [features]
 default = []
 driver_manager = ["dep:libloading"]
+manifest = ["dep:serde", "dep:semver", "dep:spdx", "dep:toml"]
 
 [dependencies]
 arrow-array.workspace = true
 arrow-schema.workspace = true
 libloading = { version = "0.8", optional = true }
+serde = { version = "1.0.219", features = ["derive"], optional = true }
+semver = { version = "1.0.26", features = ["serde"], optional = true }
+spdx = { version = "0.10.8", optional = true }
+toml = { version = "0.8.23", default-features = false, features = [
+    "parse",
+], optional = true }
 
 [dev-dependencies]
 arrow-select.workspace = true

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -65,6 +65,8 @@ pub use driver_exporter::FFIDriver;
 pub mod driver_manager;
 pub mod error;
 pub mod ffi;
+#[cfg(feature = "manifest")]
+pub mod manifest;
 pub mod options;
 pub mod schemas;
 

--- a/rust/core/src/manifest.rs
+++ b/rust/core/src/manifest.rs
@@ -1,0 +1,249 @@
+//! Driver manifest.
+
+use std::{
+    fmt::Display,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use serde::{de, Deserialize, Deserializer};
+
+use crate::{
+    error::{Error, Status},
+    options::AdbcVersion,
+};
+
+/// A driver manifest
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Manifest {
+    /// Driver display name
+    name: Option<String>,
+
+    /// Publisher identifier
+    publisher: Option<String>,
+
+    /// Driver license
+    #[serde(default, deserialize_with = "de_from_str_opt")]
+    license: Option<spdx::Expression>,
+
+    /// Driver version
+    version: Option<semver::Version>,
+
+    /// ADBC
+    #[serde(rename = "ADBC")]
+    adbc: Option<ADBC>,
+
+    /// Driver
+    #[serde(rename = "Driver")]
+    driver: Driver,
+}
+
+impl Manifest {
+    /// Returns the driver display name.
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    /// Returns the publisher identifier.
+    pub fn publisher(&self) -> Option<&str> {
+        self.publisher.as_deref()
+    }
+
+    /// Returns the license.
+    pub fn license(&self) -> Option<&spdx::Expression> {
+        self.license.as_ref()
+    }
+
+    /// Returns the driver version.
+    pub fn version(&self) -> Option<&semver::Version> {
+        self.version.as_ref()
+    }
+
+    // Returns the ADBC field of the manifest.
+    pub fn adbc(&self) -> Option<&ADBC> {
+        self.adbc.as_ref()
+    }
+
+    // Returns the Driver field of the manifest.
+    pub fn driver(&self) -> &Driver {
+        &self.driver
+    }
+}
+
+/// Deserialize an `Option<T>` using the [`FromStr`] impl of `T`.
+fn de_from_str_opt<'de, D, T: FromStr<Err: Display>>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer).and_then(|value| {
+        value
+            .as_deref()
+            .map(|value| T::from_str(value).map_err(de::Error::custom))
+            .transpose()
+    })
+}
+
+impl FromStr for Manifest {
+    type Err = Error;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        toml::from_str(input)
+            .map_err(|e| Error::with_message_and_status(e.to_string(), Status::InvalidArguments))
+    }
+}
+
+/// ADBC information
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ADBC {
+    /// Supported ADBC Spec version
+    #[serde(deserialize_with = "de_from_str_opt")]
+    version: Option<AdbcVersion>,
+
+    /// Features
+    features: Option<Features>,
+}
+
+impl ADBC {
+    /// Returns the supported ADBC Spec version.
+    pub fn version(&self) -> Option<AdbcVersion> {
+        self.version
+    }
+
+    /// Returns the `features`.
+    pub fn features(&self) -> Option<&Features> {
+        self.features.as_ref()
+    }
+}
+
+/// ADBC features
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Features {
+    /// List of supported features
+    supported: Option<Vec<String>>,
+
+    /// List of unsupported features
+    unsupported: Option<Vec<String>>,
+}
+
+impl Features {
+    /// Returns supported features.
+    pub fn supported(&self) -> Option<&[String]> {
+        self.supported.as_deref()
+    }
+
+    /// Returns unsupported features.
+    pub fn unsupported(&self) -> Option<&[String]> {
+        self.unsupported.as_deref()
+    }
+}
+
+/// Driver information
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Driver {
+    /// Path to shared library that should be loaded for this driver
+    shared: PathBuf,
+
+    /// Entrypoint symbol that overrides the default init symbol (`AdbcDriverInit`)
+    entrypoint: Option<String>,
+}
+
+impl Driver {
+    /// Returns the path to the shared library for this driver.
+    pub fn shared(&self) -> &Path {
+        self.shared.as_path()
+    }
+
+    /// Returns the custom entrypoint.
+    pub fn entrypoint(&self) -> Option<&str> {
+        self.entrypoint.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error;
+
+    use super::*;
+
+    #[test]
+    fn minimal() -> error::Result<()> {
+        let input = r#"
+            [Driver]
+            shared = "/path/to/dynamic_lib.so"
+        "#;
+        let manifest = input.parse::<Manifest>()?;
+        assert!(manifest.driver().shared().ends_with("dynamic_lib.so"));
+        Ok(())
+    }
+
+    #[test]
+    fn missing_required() -> error::Result<()> {
+        assert!(""
+            .parse::<Manifest>()
+            .is_err_and(|err| err.message.contains("missing field `Driver`")));
+        assert!("[Driver]"
+            .parse::<Manifest>()
+            .is_err_and(|err| err.message.contains("missing field `shared`")));
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_type() -> error::Result<()> {
+        assert!("name = 123"
+            .parse::<Manifest>()
+            .is_err_and(|err| err.message.contains("invalid type: integer")));
+        assert!("version = 1"
+            .parse::<Manifest>()
+            .is_err_and(|err| err.message.contains("expected semver version")));
+        Ok(())
+    }
+
+    #[test]
+    fn all_fields() -> error::Result<()> {
+        let input = r#"
+            name = "name"
+            publisher = "publisher"
+            license = "Apache-2.0"
+            version = "1.2.3"
+
+            [ADBC]
+            version = "1_1_0"
+
+            [ADBC.features]
+            supported = ["bulk insert"]
+            unsupported = ["async"]
+
+            [Driver]
+            shared = "/path/to/dynamic_lib.so"
+            entrypoint = "custom_entry_symbol"
+        "#;
+        let manifest = input.parse::<Manifest>()?;
+        assert_eq!(manifest.name(), Some("name"));
+        assert_eq!(manifest.publisher(), Some("publisher"));
+        assert!(manifest
+            .license()
+            .map(|license| license
+                .evaluate(|req| req.license.id() == spdx::license_id("Apache-2.0")))
+            .unwrap_or(false));
+        assert_eq!(manifest.version(), Some(&semver::Version::new(1, 2, 3)));
+        assert_eq!(
+            manifest.adbc().and_then(ADBC::version),
+            Some(AdbcVersion::V110)
+        );
+        assert_eq!(
+            manifest
+                .adbc()
+                .and_then(ADBC::features)
+                .and_then(Features::supported),
+            Some(["bulk insert".to_owned()].as_slice())
+        );
+        assert_eq!(
+            manifest
+                .adbc()
+                .and_then(ADBC::features)
+                .and_then(Features::unsupported),
+            Some(["async".to_owned()].as_slice())
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
Instead of suggesting an alternative approach through a review in https://github.com/apache/arrow-adbc/pull/3099 I figured it would be easier to open a PR to demonstrate how (instead of using `toml::Table`) a `Manifest` type definition with `serde::Deserialize` can be used to implement `Manifest` deserialization.