### PR TITLE
Make now considers more source files as dependencies

### DIFF
--- a/go/adbc/pkg/Makefile
+++ b/go/adbc/pkg/Makefile
@@ -14,8 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GO_BUILD=go build
-RM=rm -f
+MANAGERS = bigquery flightsql panicdummy snowflake
+
+GO_BUILD := go build
+RM := rm -f
+
 ifeq ($(shell go env GOOS),linux)
 	SUFFIX=so
 else ifeq ($(shell go env GOOS),windows)
@@ -28,17 +31,18 @@ endif
 GIT_VERSION=$(shell git tag -l --points-at $(shell git rev-list --tags --max-count=1) --sort=-v:refname | head -n 1)
 VERSION=$(subst go/adbc/,,$(GIT_VERSION))
 
-DRIVERS := \
-	libadbc_driver_bigquery.$(SUFFIX) \
-	libadbc_driver_flightsql.$(SUFFIX) \
-	libadbc_driver_panicdummy.$(SUFFIX) \
-	libadbc_driver_snowflake.$(SUFFIX)
+# Expand dynamically libadbc_driver_.SUFFIX
+DRIVERS := $(addsuffix .$(SUFFIX),$(addprefix libadbc_driver_,$(MANAGERS)))
+
+# =========
+#  Targets
+# =========
 
 .PHONY: all regenerate
 all: $(DRIVERS)
 
-libadbc_driver_%.$(SUFFIX): %
-	$(GO_BUILD) -buildvcs=true -tags driverlib -o $@ -buildmode=c-shared -ldflags "-s -w -X github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase.infoDriverVersion=$(VERSION)" ./$<
+libadbc_driver_%.$(SUFFIX): % ../driver/% ../go.mod ../go.sum
+	$(GO_BUILD) -buildvcs=true -tags driverlib -o $@ -buildmode=c-shared -ldflags "-s -w -X github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase.infoDriverVersion=$(VERSION)" ./$*
 	$(RM) $(basename $@).h
 
 regenerate:


### PR DESCRIPTION
QoL upgrade for driver development. More complete tracking for local changes. Saves on `rm`-ing before rebuilding libraries to integrate source changes!

Also I replaced an error-prone `$<` (subtarget position dependent) with `$*` 

## Demo

![demo](https://github.com/user-attachments/assets/8f9ff140-5bac-402a-934e-077e01e2d475)

## Scenarios covered
1. edit already tracked driver files
2. edit `go.mod`
3. edit `../driver/bigquery` files
4. (not shown but works) edit other package like `../driver/databricks` and `../go.sum` --> triggers no rebuild