### PR TITLE
feat(glib): add AdbcStatementGetParameterSchema() bindings

### DIFF
--- a/glib/adbc-arrow-glib/statement.c
+++ b/glib/adbc-arrow-glib/statement.c
@@ -57,6 +57,42 @@ GADBCArrowStatement* gadbc_arrow_statement_new(GADBCConnection* connection,
 }
 
 /**
+ * gadbc_arrow_statement_get_parameter_schema:
+ * @statement: A #GADBCArrowStatement.
+ * @error: (out) (optional): Return location for a #GError or %NULL.
+ *
+ * Get the schema for bound parameters.
+ *
+ * This retrieves an Arrow schema describing the number, names, and
+ * types of the parameters in a parameterized statement. The fields
+ * of the schema should be in order of the ordinal position of the
+ * parameters; named parameters should appear only once.
+ *
+ * If the parameter does not have a name, or the name cannot be
+ * determined, the name of the corresponding field in the schema will
+ * be an empty string. If the type cannot be determined, the type of
+ * the corresponding field will be NA (`NullType`).
+ *
+ * This should be called after gadbc_statement_prepare().
+ *
+ * Returns: (transfer full) (nullable): #GArrowSchema if parameter schema is
+ *   returned successfully, %NULL otherwise.
+ *
+ * Since: 1.8.0
+ */
+GArrowSchema* gadbc_arrow_statement_get_parameter_schema(GADBCArrowStatement* statement,
+                                                         GError** error) {
+  gpointer c_abi_schema = NULL;
+  if (!gadbc_statement_get_parameter_schema(GADBC_STATEMENT(statement), &c_abi_schema,
+                                            error)) {
+    return NULL;
+  }
+  GArrowSchema* schema = garrow_schema_import(c_abi_schema, error);
+  g_free(c_abi_schema);
+  return schema;
+}
+
+/**
  * gadbc_arrow_statement_bind:
  * @statement: A #GADBCArrowStatement.
  * @record_batch: A #GArrowRecordBatch.

--- a/glib/adbc-arrow-glib/statement.h
+++ b/glib/adbc-arrow-glib/statement.h
@@ -36,6 +36,9 @@ struct _GADBCArrowStatementClass {
 GADBC_ARROW_AVAILABLE_IN_0_10
 GADBCArrowStatement* gadbc_arrow_statement_new(GADBCConnection* connection,
                                                GError** error);
+GADBC_ARROW_AVAILABLE_IN_1_8
+GArrowSchema* gadbc_arrow_statement_get_parameter_schema(GADBCArrowStatement* statement,
+                                                         GError** error);
 GADBC_ARROW_AVAILABLE_IN_0_10
 gboolean gadbc_arrow_statement_bind(GADBCArrowStatement* statement,
                                     GArrowRecordBatch* record_batch, GError** error);

--- a/glib/adbc-glib/statement.h
+++ b/glib/adbc-glib/statement.h
@@ -69,6 +69,9 @@ gboolean gadbc_statement_set_ingest_mode(GADBCStatement* statement, GADBCIngestM
                                          GError** error);
 GADBC_AVAILABLE_IN_0_4
 gboolean gadbc_statement_prepare(GADBCStatement* statement, GError** error);
+GADBC_AVAILABLE_IN_1_8
+gboolean gadbc_statement_get_parameter_schema(GADBCStatement* statement,
+                                              gpointer* c_abi_schema, GError** error);
 GADBC_AVAILABLE_IN_0_4
 gboolean gadbc_statement_bind(GADBCStatement* statement, gpointer c_abi_array,
                               gpointer c_abi_schema, GError** error);

--- a/glib/test/test-arrow-statement.rb
+++ b/glib/test/test-arrow-statement.rb
@@ -41,6 +41,14 @@ class ArrowStatementTest < Test::Unit::TestCase
                  reader.read_all)
   end
 
+  def test_parameter_schema
+    @statement.set_sql_query("SELECT ?, $2")
+    @statement.prepare
+    assert_equal(Arrow::Schema.new("0" => :null,
+                                   "$2" => :null),
+                 @statement.parameter_schema)
+  end
+
   def test_bind
     @statement.set_sql_query("CREATE TABLE data (number int)")
     @statement.execute(false)

--- a/glib/test/test-statement.rb
+++ b/glib/test/test-statement.rb
@@ -40,6 +40,19 @@ class StatementTest < Test::Unit::TestCase
     end
   end
 
+  def test_parameter_schema
+    @statement.set_sql_query("SELECT ?, $2")
+    @statement.prepare
+    _, c_abi_schema = @statement.parameter_schema
+    begin
+      assert_equal(Arrow::Schema.new("0" => :null,
+                                     "$2" => :null),
+                   Arrow::Schema.import(c_abi_schema))
+    ensure
+      GLib.free(c_abi_schema)
+    end
+  end
+
   def test_bind
     @statement.set_sql_query("CREATE TABLE data (number int)")
     execute_statement(@statement, need_result: false)

--- a/ruby/lib/adbc/statement.rb
+++ b/ruby/lib/adbc/statement.rb
@@ -23,6 +23,16 @@ module ADBC
     extend StatementOpenable
     include StatementOperations
 
+    alias_method :parameter_schema_raw, :parameter_schema
+    def parameter_schema
+      _, c_abi_schema = parameter_schema_raw
+      begin
+        Arrow::Schema.import(c_abi_schema)
+      ensure
+        GLib.free(c_abi_schema)
+      end
+    end
+
     alias_method :execute_raw, :execute
     def execute(need_result: true)
       _, c_abi_array_stream, n_rows_affected = execute_raw(need_result)

--- a/ruby/test/test-statement.rb
+++ b/ruby/test/test-statement.rb
@@ -32,6 +32,13 @@ class StatementTest < Test::Unit::TestCase
     end
   end
 
+  test("#parameter_schema") do
+    @statement.sql_query = "SELECT ?"
+    @statement.prepare
+    assert_equal(Arrow::Schema.new("0" => :null),
+                 @statement.parameter_schema)
+  end
+
   sub_test_case("#ingest") do
     test("Arrow::RecordBatch") do
       numbers = Arrow::Int64Array.new([10, 20, 30])


### PR DESCRIPTION
* Add `gadbc_statement_get_parameter_schema()`
* Add `gadbc_arrow_statement_get_parameter_schema()`
* Adjust API in Ruby

Fixes #3117.
