### PR TITLE
feat(csharp/src/Drivers): update drivers to .NET 8

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/Apache.Arrow.Adbc.csproj
+++ b/csharp/src/Apache.Arrow.Adbc/Apache.Arrow.Adbc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>

--- a/csharp/src/Client/Apache.Arrow.Adbc.Client.csproj
+++ b/csharp/src/Client/Apache.Arrow.Adbc.Client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>

--- a/csharp/src/Drivers/Apache/Apache.Arrow.Adbc.Drivers.Apache.csproj
+++ b/csharp/src/Drivers/Apache/Apache.Arrow.Adbc.Drivers.Apache.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/src/Drivers/BigQuery/Apache.Arrow.Adbc.Drivers.BigQuery.csproj
+++ b/csharp/src/Drivers/BigQuery/Apache.Arrow.Adbc.Drivers.BigQuery.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>

--- a/csharp/src/Drivers/Databricks/Apache.Arrow.Adbc.Drivers.Databricks.csproj
+++ b/csharp/src/Drivers/Databricks/Apache.Arrow.Adbc.Drivers.Databricks.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>

--- a/csharp/src/Drivers/FlightSql/Apache.Arrow.Adbc.Drivers.FlightSql.csproj
+++ b/csharp/src/Drivers/FlightSql/Apache.Arrow.Adbc.Drivers.FlightSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.3" Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'" />

--- a/csharp/src/Drivers/Interop/FlightSql/Apache.Arrow.Adbc.Drivers.Interop.FlightSql.csproj
+++ b/csharp/src/Drivers/Interop/FlightSql/Apache.Arrow.Adbc.Drivers.Interop.FlightSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <IsPackagingPipeline Condition="'$(IsPackagingPipeline)' == ''">
       false

--- a/csharp/src/Drivers/Interop/Snowflake/Apache.Arrow.Adbc.Drivers.Interop.Snowflake.csproj
+++ b/csharp/src/Drivers/Interop/Snowflake/Apache.Arrow.Adbc.Drivers.Interop.Snowflake.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
     <IsPackagingPipeline Condition="'$(IsPackagingPipeline)' == ''">
       false

--- a/csharp/test/SmokeTests/Interop/FlightSql/Apache.Arrow.Adbc.SmokeTests.Drivers.Interop.FlightSql.csproj
+++ b/csharp/test/SmokeTests/Interop/FlightSql/Apache.Arrow.Adbc.SmokeTests.Drivers.Interop.FlightSql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\Build.props" />
     <PropertyGroup>
-     <TargetFrameworks>net472;net6.0</TargetFrameworks>
+     <TargetFrameworks>net472;net8.0</TargetFrameworks>
    </PropertyGroup>
     <ItemGroup>
       <Compile Include="..\..\..\Drivers\Interop\FlightSql\ClientTests.cs" Link="ClientTests.cs" />

--- a/dev/release/post-07-csharp.sh
+++ b/dev/release/post-07-csharp.sh
@@ -54,8 +54,11 @@ main() {
   local base_names=()
   base_names+=(Apache.Arrow.Adbc.${VERSION_CSHARP})
   base_names+=(Apache.Arrow.Adbc.Client.${VERSION_CSHARP})
+  base_names+=(Apache.Arrow.Adbc.Drivers.Apache.${VERSION_CSHARP})
   base_names+=(Apache.Arrow.Adbc.Drivers.BigQuery.${VERSION_CSHARP})
+  base_names+=(Apache.Arrow.Adbc.Drivers.Databricks.${VERSION_CSHARP})
   base_names+=(Apache.Arrow.Adbc.Drivers.FlightSql.${VERSION_CSHARP})
+  base_names+=(Apache.Arrow.Adbc.Drivers.Interop.FlightSql.${VERSION_CSHARP})
   base_names+=(Apache.Arrow.Adbc.Drivers.Interop.Snowflake.${VERSION_CSHARP})
   for base_name in "${base_names[@]}"; do
     dotnet nuget push \


### PR DESCRIPTION
- Updates the drivers to .NET 8 because the System.Diagnostics.DiagnosticSource package requires it, and .NET 6 support ended last year.
- Updates the publish script to include all drivers now