### PR TITLE
fix(csharp/src/Drivers/Databricks): Change fallback check of Databricks.GetColumnsExtendedAsync

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksStatement.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksStatement.cs
@@ -530,10 +530,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             {
                 descResult = await descStmt.ExecuteQueryAsync();
             }
-            catch (HiveServer2Exception ex) when (ex.Message.Contains("Error running query"))
+            catch (HiveServer2Exception ex) when (ex.SqlState == "42601")
             {
-                // Fallback to base implementation
-                Debug.WriteLine($"[ERROR] Failed to run {query}. Fallback to base::GetColumnsExtendedAsync.Error message:{ex.Message}");
+                // 42601 is error code of syntax error, which this command (DESC TABLE EXTENDED ... AS JSON) is not supported by current DBR
+                // So we should fallback to base implementation
+                Debug.WriteLine($"[WARN] Failed to run {query} (reason={ex.Message}). Fallback to base::GetColumnsExtendedAsync.");
                 return await base.GetColumnsExtendedAsync(cancellationToken);
             }
 


### PR DESCRIPTION
# PR Description

### Motivation 

When `DESC TABLE EXTENDED {fullTableName} AS JSON` fails to run, we will fallback base class `GetColumnsExtendedAsync` which calls 3 metadata query to get the info, but the current check is based on the error message, which is not accurate, instead, we can check the `SqlState` = `42601` which is the error of SQL syntax error, it means the command is not supported by the runtime, then we can fallback to the base class 

### Changes
- Update the fallback condition check in `Databricks` `GetColumnsExtendedAsync`

### Testing

- End-to-end test with the runtime does not support the command