### PR TITLE
fix(go/adbc/pkg): add PowerShell option to run when executing in a Windows-based ADO pipeline

### DIFF
--- a/go/adbc/pkg/Makefile
+++ b/go/adbc/pkg/Makefile
@@ -29,9 +29,9 @@ else
 endif
 
 ifeq ($(shell go env GOOS),windows)
-	GIT_VERSION=$(shell powershell -Command "git tag --sort=-v:refname --points-at $(git rev-list --tags --max-count=1) | Select-Object -First 1")
+	GIT_VERSION := $(shell powershell -Command "git tag --sort=-v:refname --points-at $$(git rev-list --tags --max-count=1) | Select-Object -First 1")
 else
-	GIT_VERSION=$(shell git tag --sort=-v:refname --points-at $(shell git rev-list --tags --max-count=1 2>/dev/null) 2>/dev/null | head -n 1)
+	GIT_VERSION=$(shell git tag -l --points-at $(shell git rev-list --tags --max-count=1) --sort=-v:refname | head -n 1)
 endif
 
 GIT_VERSION ?= unknown

--- a/go/adbc/pkg/Makefile
+++ b/go/adbc/pkg/Makefile
@@ -21,13 +21,17 @@ RM := rm -f
 
 ifeq ($(shell go env GOOS),linux)
 	SUFFIX=so
-	GIT_VERSION=$(shell git tag --sort=-v:refname --points-at $(shell git rev-list --tags --max-count=1 2>/dev/null) 2>/dev/null | head -n 1)
 else ifeq ($(shell go env GOOS),windows)
 	SUFFIX=dll
 	RM=del
-	GIT_VERSION=$(shell powershell -Command "git tag --sort=-v:refname --points-at $(git rev-list --tags --max-count=1) | Select-Object -First 1")
 else
 	SUFFIX=dylib
+endif
+
+ifeq ($(shell go env GOOS),windows)
+	GIT_VERSION=$(shell powershell -Command "git tag --sort=-v:refname --points-at $(git rev-list --tags --max-count=1) | Select-Object -First 1")
+else
+	GIT_VERSION=$(shell git tag --sort=-v:refname --points-at $(shell git rev-list --tags --max-count=1 2>/dev/null) 2>/dev/null | head -n 1)
 endif
 
 GIT_VERSION ?= unknown

--- a/go/adbc/pkg/Makefile
+++ b/go/adbc/pkg/Makefile
@@ -21,14 +21,16 @@ RM := rm -f
 
 ifeq ($(shell go env GOOS),linux)
 	SUFFIX=so
+	GIT_VERSION=$(shell git tag --sort=-v:refname --points-at $(shell git rev-list --tags --max-count=1 2>/dev/null) 2>/dev/null | head -n 1)
 else ifeq ($(shell go env GOOS),windows)
 	SUFFIX=dll
 	RM=del
+	GIT_VERSION=$(shell powershell -Command "git tag --sort=-v:refname --points-at $(git rev-list --tags --max-count=1) | Select-Object -First 1")
 else
 	SUFFIX=dylib
 endif
 
-GIT_VERSION=$(shell git tag -l --points-at $(shell git rev-list --tags --max-count=1) --sort=-v:refname | head -n 1)
+GIT_VERSION ?= unknown
 VERSION=$(subst go/adbc/,,$(GIT_VERSION))
 
 # Expand dynamically libadbc_driver_.SUFFIX


### PR DESCRIPTION
When running from the PowerShell script as part of an ADO pipeline, the line

```
GIT_VERSION=$(shell git tag ...
```

was generating the error:

```
EXEC : error : malformed object name '--sort=-v:refname' [C:\__w\1\s\arrow-adbc\csharp\src\Drivers\Interop\FlightSql\Apache.Arrow.Adbc.Drivers.Interop.FlightSql.csproj]
```

This change swaps some of the commands but also has a separate PowerShell command for the Windows OS instead of the shell command.