### PR TITLE
chore: fix typo

### DIFF
--- a/.codespell-dictionary
+++ b/.codespell-dictionary
@@ -1,0 +1,1 @@
+arrpw->arrow

--- a/.codespellrc
+++ b/.codespellrc
@@ -16,5 +16,6 @@
 # under the License.
 
 [codespell]
+dictionary = .codespell-dictionary,-
 ignore-words = .codespell-ignore
 skip = go/adbc/go.sum

--- a/csharp/src/Drivers/FlightSql/FlightSqlDriver.cs
+++ b/csharp/src/Drivers/FlightSql/FlightSqlDriver.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 namespace Apache.Arrow.Adbc.Drivers.FlightSql
 {
     /// <summary>
-    /// Represents an Arrpw Flight SQL driver for connecting to
+    /// Represents an Arrow Flight SQL driver for connecting to
     /// data sources that support Arrow Flight SQL.
     /// </summary>
     public class FlightSqlDriver : AdbcDriver

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -1,6 +1,7 @@
 *.json
 *.Rproj
 *.Rd
+.codespell-dictionary
 .codespell-ignore
 c/subprojects/fmt.wrap
 c/subprojects/gtest.wrap


### PR DESCRIPTION
Adding a user dictionary allows detection of a typo `Arrpw`.

```console
$ pre-commit run codespell --all-files
codespell................................................................Failed
- hook id: codespell
- exit code: 65

csharp/src/Drivers/FlightSql/FlightSqlDriver.cs:23: Arrpw ==> Arrow
```

Closes #3128 