### PR TITLE
fix(csharp/src/Drivers/Databricks): Set GetObjectsPatternsRequireLowerCase true

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -360,6 +360,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 
         protected internal override bool AreResultsAvailableDirectly => _enableDirectResults;
 
+        protected override bool GetObjectsPatternsRequireLowerCase => true;
+
         protected override void SetDirectResults(TGetColumnsReq request) => request.GetDirectResults = defaultGetDirectResults;
 
         protected override void SetDirectResults(TGetCatalogsReq request) => request.GetDirectResults = defaultGetDirectResults;


### PR DESCRIPTION
## Motivation 

The default value of `GetObjectsPatternsRequireLowerCase` of `DatabricksConnection` is `false` (inherit from `SparkConnection`, see [here](https://github.com/apache/arrow-adbc/blob/main/csharp/src/Drivers/Apache/Spark/SparkConnection.cs#L116)), so when it is called with table pattern in uppercase as below, it does not return all the tables start with `test` and fails some test cases [DriverTest:GetObjectsTablesTest](https://github.com/apache/arrow-adbc/blob/main/csharp/test/Drivers/Apache/Common/DriverTests.cs#L308) (when `tableNamePattern` is uppercase)

```
Connection.GetObjects(
                    depth: AdbcConnection.GetObjectsDepth.Tables,
                    catalogPattern = "catalog1",
                    dbSchemaPattern = "default",
                    tableNamePattern = "TEST%");
```

## Changes
- Override `GetObjectsPatternsRequireLowerCase` to `true` in `DatabricksConnection`

## Test
Apache.Arrow.Adbc.Tests.Drivers.Databricks.DriverTests.CanGetObjectsTables
