### PR TITLE
feat(go/adbc): add IngestStream helper for one-call ingestion and add TestIngestStream

### DIFF
--- a/go/adbc/drivermgr/wrapper_sqlite_test.go
+++ b/go/adbc/drivermgr/wrapper_sqlite_test.go
@@ -663,7 +663,7 @@ func (dm *DriverMgrSuite) TestIngestStream() {
 	defer rdr.Release()
 
 	// 3) Use the IngestStream
-	count, err := adbc.IngestStream(dm.ctx, dm.conn, rdr, "ingest_test", adbc.OptionValueIngestModeCreateAppend, adbc.IngestStreamOption{})
+	count, err := adbc.IngestStream(dm.ctx, dm.conn, rdr, "ingest_test", adbc.OptionValueIngestModeCreateAppend, adbc.IngestStreamOptions{})
 	dm.NoError(err)
 	dm.Equal(int64(5), count, "should report 5 rows ingested")
 

--- a/go/adbc/ext.go
+++ b/go/adbc/ext.go
@@ -84,7 +84,7 @@ type OTelTracing interface {
 
 // IngestStreamOption bundles the IngestStream options.
 // Driver specific options can go into Extra.
-type IngestStreamOption struct {
+type IngestStreamOptions struct {
 	// Optional catalog/catalogue name
 	Catalog string
 
@@ -103,7 +103,7 @@ type IngestStreamOption struct {
 // Execute, and Close.
 //
 // This is not part of the ADBC API specification.
-func IngestStream(ctx context.Context, cnxn Connection, reader array.RecordReader, targetTable, ingestMode string, opt IngestStreamOption) (int64, error) {
+func IngestStream(ctx context.Context, cnxn Connection, reader array.RecordReader, targetTable, ingestMode string, opt IngestStreamOptions) (int64, error) {
 	// Create a new statement
 	stmt, err := cnxn.NewStatement()
 	if err != nil {


### PR DESCRIPTION
Solves #3142 

Changes:

1. New freestanding function: func IngestStream(ctx context.Context, cnxn Connection, reader array.RecordReader, opts map[string]string) (int64, error)
2. TestIngestStream added to drivermgr_test



