### PR TITLE
test(rust/core): use the temp-env package to test with env var

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "libloading",
+ "temp-env",
  "tempfile",
  "toml",
  "windows-registry",
@@ -2902,6 +2903,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -45,6 +45,7 @@ toml = { version = "0.9.0", default-features = false, features = [
 ], optional = true }
 
 [dev-dependencies]
+temp-env = "0.3"
 arrow-select.workspace = true
 tempfile = "3.20.0"
 


### PR DESCRIPTION
Related to #3146

This PR updates tests that depend on environment variables (such as `ADBC_CONFIG_PATH`) to use the temp-env crate.
This ensures proper isolation and reliability of environment variable manipulation during test execution, improving CI stability.