### PR TITLE
chore(csharp/test/Drivers/Databricks): Add isCITesting in DatabricksTestConfiguration

### DIFF
--- a/csharp/test/Drivers/Databricks/E2E/DatabricksTestConfiguration.cs
+++ b/csharp/test/Drivers/Databricks/E2E/DatabricksTestConfiguration.cs
@@ -45,5 +45,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
 
         [JsonPropertyName("traceStateEnabled"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string TraceStateEnabled { get; set; } = string.Empty;
+
+        [JsonPropertyName("isCITesting"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public bool isCITesting { get; set; } = false;
     }
 }


### PR DESCRIPTION
## Motivation 

There are some E2E test in Databricks driver tests ( e.g.`StatusPollerKeepsQueryAlive` in `StatementTest`) should be skipped for various reasons, we can include property `isCITesting` in `DatabricksTestConfiguration` to indicates it is current test environment in run in the CI.

### Changes
- Added `isCITesting` in `DatabricksTestConfiguration` with default value `false`