### PR TITLE
chore(csharp/test/Drivers/Databricks): Skip StatusPollerKeepsQueryAlive in CI test

### DIFF
--- a/csharp/test/Drivers/Databricks/E2E/StatementTests.cs
+++ b/csharp/test/Drivers/Databricks/E2E/StatementTests.cs
@@ -886,6 +886,8 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
         [InlineData(true, "CloudFetch enabled")]
         public async Task StatusPollerKeepsQueryAlive(bool useCloudFetch, string configName)
         {
+            Skip.If(TestConfiguration.IsCITesting, "Skip test in CI testing");
+
             OutputHelper?.WriteLine($"Testing status poller with long delay between reads ({configName})");
 
             // Create a connection using the test configuration


### PR DESCRIPTION
## Motivation 

The test `StatementTest:StatusPollerKeepsQueryAlive` runs 30 minutes as it tests if Databricks connection is still alive after 30 idle time after using KeepAlive poller, which is not applicable for CI test. We should exclude it from the CI.

## Changes
- Skip `StatementTest:StatusPollerKeepsQueryAlive` test when `TestConfiguration.IsCITesting` is true