### PR TITLE
fix(csharp/src/Drivers/Databricks): correct tracing instrumentation for assembly name and version

### DIFF
--- a/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
@@ -16,11 +16,8 @@
 */
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Apache.Arrow;
+using Apache.Arrow.Adbc.Drivers.Apache;
 using Apache.Arrow.Adbc.Tracing;
-using Apache.Arrow.Ipc;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks
 {
@@ -29,6 +26,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
     /// </summary>
     internal abstract class BaseDatabricksReader : TracingReader
     {
+        private static readonly string s_assemblyName = ApacheUtility.GetAssemblyName(typeof(BaseDatabricksReader));
+        private static readonly string s_assemblyVersion = ApacheUtility.GetAssemblyVersion(typeof(BaseDatabricksReader));
+
         protected DatabricksStatement statement;
         protected readonly Schema schema;
         protected readonly bool isLz4Compressed;
@@ -93,5 +93,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 throw new ObjectDisposedException(GetType().Name);
             }
         }
+
+        public override string AssemblyName => s_assemblyName;
+
+        public override string AssemblyVersion => s_assemblyVersion;
     }
 }

--- a/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchReader.cs
+++ b/csharp/src/Drivers/Databricks/CloudFetch/CloudFetchReader.cs
@@ -20,7 +20,6 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Apache.Arrow.Adbc.Drivers.Apache;
 using Apache.Arrow.Adbc.Tracing;
 using Apache.Arrow.Ipc;
 using Apache.Hive.Service.Rpc.Thrift;
@@ -33,9 +32,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
     /// </summary>
     internal sealed class CloudFetchReader : BaseDatabricksReader
     {
-        private static readonly string s_assemblyName = ApacheUtility.GetAssemblyName(typeof(CloudFetchReader));
-        private static readonly string s_assemblyVersion = ApacheUtility.GetAssemblyVersion(typeof(CloudFetchReader));
-
         private ICloudFetchDownloadManager? downloadManager;
         private ArrowStreamReader? currentReader;
         private IDownloadResult? currentDownloadResult;
@@ -79,10 +75,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch
                 downloadManager.StartAsync().Wait();
             }
         }
-
-        public override string AssemblyName => s_assemblyName;
-
-        public override string AssemblyVersion => s_assemblyVersion;
 
         /// <summary>
         /// Reads the next record batch from the result set.

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -28,8 +28,6 @@ using Apache.Arrow.Adbc.Drivers.Apache.Hive2;
 using Apache.Arrow.Adbc.Drivers.Apache.Hive2.Client;
 using Apache.Arrow.Adbc.Drivers.Apache.Spark;
 using Apache.Arrow.Adbc.Drivers.Databricks.Auth;
-using Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch;
-using Apache.Arrow.Adbc.Tracing;
 using Apache.Arrow.Ipc;
 using Apache.Hive.Service.Rpc.Thrift;
 using Thrift.Protocol;
@@ -38,6 +36,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 {
     internal class DatabricksConnection : SparkHttpConnection
     {
+        private static readonly string s_assemblyName = ApacheUtility.GetAssemblyName(typeof(DatabricksConnection));
+        private static readonly string s_assemblyVersion = ApacheUtility.GetAssemblyVersion(typeof(DatabricksConnection));
+
         private bool _applySSPWithQueries = false;
         private bool _enableDirectResults = true;
         private bool _enableMultipleCatalogSupport = true;
@@ -647,6 +648,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 base.ValidateOAuthParameters();
             }
         }
+
+        public override string AssemblyName => s_assemblyName;
+
+        public override string AssemblyVersion => s_assemblyVersion;
 
         internal static string? HandleSparkCatalog(string? CatalogName)
         {

--- a/csharp/src/Drivers/Databricks/DatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksReader.cs
@@ -28,9 +28,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 {
     internal sealed class DatabricksReader : BaseDatabricksReader
     {
-        private static readonly string s_assemblyName = ApacheUtility.GetAssemblyName(typeof(DatabricksReader));
-        private static readonly string s_assemblyVersion = ApacheUtility.GetAssemblyVersion(typeof(DatabricksReader));
-
         List<TSparkArrowBatch>? batches;
         int index;
         IArrowReader? reader;
@@ -49,10 +46,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 this.hasNoMoreRows = !initialResults.HasMoreRows;
             }
         }
-
-        public override string AssemblyName => s_assemblyName;
-
-        public override string AssemblyVersion => s_assemblyVersion;
 
         public override async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
         {

--- a/csharp/src/Drivers/Databricks/DatabricksStatement.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksStatement.cs
@@ -21,6 +21,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Apache;
 using Apache.Arrow.Adbc.Drivers.Apache.Hive2;
 using Apache.Arrow.Adbc.Drivers.Apache.Spark;
 using Apache.Arrow.Adbc.Drivers.Databricks.CloudFetch;
@@ -36,6 +37,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
     /// </summary>
     internal class DatabricksStatement : SparkStatement, IHiveServer2Statement
     {
+        private static readonly string s_assemblyName = ApacheUtility.GetAssemblyName(typeof(DatabricksStatement));
+        private static readonly string s_assemblyVersion = ApacheUtility.GetAssemblyVersion(typeof(DatabricksStatement));
+
         private bool useCloudFetch;
         private bool canDecompressLz4;
         private long maxBytesPerFile;
@@ -566,6 +570,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             }
             return CreateExtendedColumnsResult(columnMetadataSchema,result);
         }
+
+        public override string AssemblyName => s_assemblyName;
+
+        public override string AssemblyVersion => s_assemblyVersion;
 
         /// <summary>
         /// Creates the schema for the column metadata result set.


### PR DESCRIPTION
Corrected instrumentation/implementation/overrides for `AssemblyName` / `AssemblyVersion` for the Databricks driver.

They must be overridden in each unique assembly.