### PR TITLE
feat(csharp/test/Drivers/Databricks): Enable RunAsync option in TExecuteStatementReq

### DIFF
--- a/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
@@ -42,7 +42,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             this.schema = schema;
             this.isLz4Compressed = isLz4Compressed;
             this.statement = statement;
-            if (statement.DirectResults != null && statement.DirectResults.ResultSet != null && !statement.DirectResults.ResultSet.HasMoreRows)
+            if (statement.DirectResults?.ResultSet?.HasMoreRows == true)
             {
                 return;
             }

--- a/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
@@ -42,7 +42,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             this.schema = schema;
             this.isLz4Compressed = isLz4Compressed;
             this.statement = statement;
-            if (statement.DirectResults != null && !statement.DirectResults.ResultSet.HasMoreRows)
+            if (statement.DirectResults != null && statement.DirectResults.ResultSet != null && !statement.DirectResults.ResultSet.HasMoreRows)
             {
                 return;
             }

--- a/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/BaseDatabricksReader.cs
@@ -42,7 +42,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             this.schema = schema;
             this.isLz4Compressed = isLz4Compressed;
             this.statement = statement;
-            if (statement.DirectResults?.ResultSet?.HasMoreRows == true)
+            if (statement.DirectResults?.ResultSet != null && !statement.DirectResults.ResultSet.HasMoreRows)
             {
                 return;
             }

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -42,6 +42,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         private bool _enableDirectResults = true;
         private bool _enableMultipleCatalogSupport = true;
         private bool _enablePKFK = true;
+        private bool _runAsyncInThrift = false;
 
         internal static TSparkGetDirectResults defaultGetDirectResults = new()
         {
@@ -163,6 +164,19 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                     throw new ArgumentException($"Parameter '{DatabricksParameters.UseDescTableExtended}' value '{useDescTableExtendedStr}' could not be parsed. Valid values are 'true' and 'false'.");
                 }
             }
+
+            if (Properties.TryGetValue(DatabricksParameters.EnableRunAsyncInThriftOp, out string? enableRunAsyncInThriftStr))
+            {
+                if (bool.TryParse(enableRunAsyncInThriftStr, out bool enableRunAsyncInThrift))
+                {
+                    _runAsyncInThrift = enableRunAsyncInThrift;
+                }
+                else
+                {
+                    throw new ArgumentException($"Parameter '{DatabricksParameters.EnableRunAsyncInThriftOp}' value '{enableRunAsyncInThriftStr}' could not be parsed. Valid values are 'true' and 'false'.");
+                }
+            }
+
 
             if (Properties.TryGetValue(DatabricksParameters.MaxBytesPerFile, out string? maxBytesPerFileStr))
             {
@@ -288,6 +302,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// Gets whether PK/FK metadata call is enabled
         /// </summary>
         public bool EnablePKFK => _enablePKFK;
+
+        /// <summary>
+        /// Enable RunAsync flag in Thrift Operation
+        /// </summary>
+        public bool RunAsyncInThrift => _runAsyncInThrift;
 
         /// <summary>
         /// Gets a value indicating whether to retry requests that receive a 503 response with a Retry-After header.

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -177,7 +177,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 }
             }
 
-
             if (Properties.TryGetValue(DatabricksParameters.MaxBytesPerFile, out string? maxBytesPerFileStr))
             {
                 if (!long.TryParse(maxBytesPerFileStr, out long maxBytesPerFileValue))

--- a/csharp/src/Drivers/Databricks/DatabricksParameters.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksParameters.cs
@@ -180,6 +180,13 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// </summary>
         public const string UseDescTableExtended = "adbc.databricks.use_desc_table_extended";
 
+
+        /// <summary>
+        /// Whether to enable RunAsync flag in Thrift operation
+        /// Default value is false if not specified.
+        /// </summary>
+        public const string EnableRunAsyncInThriftOp = "adbc.databricks.enable_run_async_thrift";
+
         /// <summary>
         /// Whether to propagate trace parent headers in HTTP requests.
         /// Default value is true if not specified.

--- a/csharp/src/Drivers/Databricks/DatabricksParameters.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksParameters.cs
@@ -180,7 +180,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// </summary>
         public const string UseDescTableExtended = "adbc.databricks.use_desc_table_extended";
 
-
         /// <summary>
         /// Whether to enable RunAsync flag in Thrift operation
         /// Default value is false if not specified.

--- a/csharp/src/Drivers/Databricks/DatabricksStatement.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksStatement.cs
@@ -75,7 +75,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             statement.CanDownloadResult = useCloudFetch;
             statement.CanDecompressLZ4Result = canDecompressLz4;
             statement.MaxBytesPerFile = maxBytesPerFile;
-
             statement.RunAsync = runAsyncInThrift;
 
             if (Connection.AreResultsAvailableDirectly)

--- a/csharp/src/Drivers/Databricks/DatabricksStatement.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksStatement.cs
@@ -41,6 +41,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         private long maxBytesPerFile;
         private bool enableMultipleCatalogSupport;
         private bool enablePKFK;
+        private bool runAsyncInThrift;
 
         public DatabricksStatement(DatabricksConnection connection)
             : base(connection)
@@ -62,6 +63,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             maxBytesPerFile = connection.MaxBytesPerFile;
             enableMultipleCatalogSupport = connection.EnableMultipleCatalogSupport;
             enablePKFK = connection.EnablePKFK;
+
+            runAsyncInThrift = connection.RunAsyncInThrift;
         }
 
         protected override void SetStatementProperties(TExecuteStatementReq statement)
@@ -72,6 +75,8 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             statement.CanDownloadResult = useCloudFetch;
             statement.CanDecompressLZ4Result = canDecompressLz4;
             statement.MaxBytesPerFile = maxBytesPerFile;
+
+            statement.RunAsync = runAsyncInThrift;
 
             if (Connection.AreResultsAvailableDirectly)
             {

--- a/csharp/test/Drivers/Databricks/E2E/StringValueTests.cs
+++ b/csharp/test/Drivers/Databricks/E2E/StringValueTests.cs
@@ -62,7 +62,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
         }
 
         [SkippableTheory]
-        [InlineData("String whose length is too long for VARCHAR(10).", new string[] { "DELTA_EXCEED_CHAR_VARCHAR_LIMIT", "DeltaInvariantViolationException" }, "22001")]
+        [InlineData("String whose length is too long for VARCHAR(10).", new string[] { "DELTA_EXCEED_CHAR_VARCHAR_LIMIT" }, "22001")]
         public async Task TestVarcharExceptionDataDatabricks(string value, string[] expectedTexts, string? expectedSqlState)
         {
             await base.TestVarcharExceptionData(value, expectedTexts, expectedSqlState);


### PR DESCRIPTION
## Motivation

Databricks adds `RunAsync` (default is false) option for all the thrift operations, when it is set as `true`, the operation runs async at the backend and the status can be polled by calling getStatus, it helps Databricks backend to better manage capacity and load on client requests. Furthermore, it can avoid the unnecessary retry on thrift operation (e.g. TExecuteStatementReq) when the warehouse is stopped or unavailable, the backend will returns 503 error when `RunAsync` is false and client has to retry on this thrift operation till the warehouse is up, this generates lots of queries with 503 errors in the Databricks query history and consume more resources. When `RunAsync=true`, server will return 200 with query state `PENDING`, the client will poll the status till the warehouse is up, this only generates one query in the query history. 

## Change
- Add a connection parameter `adbc.databricks.enable_run_async_thrift`, default is `false` (it will be changed to `true` later)
- Set `RunAsync` of `TExecuteStatementReq` with above connection parameter (`RunAsyncInThrift`) in `DatabricksStatement:SetStatementProperties`
- Fix a bug in `BaseDatabricksReader` by adding `null` check on `statement.DirectResults.ResultSet`
- Fix the case `TestVarcharExceptionDataDatabricks` in `StringValuesTest`: when error is in the `DirectResult.status` (case for `RunAsync=true`),  it throw the error with `DisplayMessage` (see [here](https://github.com/apache/arrow-adbc/blob/main/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs#L316)) instead of the `Message` and `DisplayMessage` does not include some internal error info such as error exception class at the backend.


## Test
- Run all the E2E tests under `csharp/test/Drivers/Databricks/E2E` when `Connection.RunAsyncInThrift` is both on and off