### PR TITLE
fix(csharp/test/Drivers/Databricks): Change the default QueryTimeoutSeconds to 3 hours

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -53,7 +53,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 
         // CloudFetch configuration
         private const long DefaultMaxBytesPerFile = 20 * 1024 * 1024; // 20MB
-
+        private const int DefaultQueryTimeSeconds = 3 * 60 * 60; // 3 hours
         private bool _useCloudFetch = true;
         private bool _canDecompressLz4 = true;
         private long _maxBytesPerFile = DefaultMaxBytesPerFile;
@@ -255,6 +255,12 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 {
                     throw new ArgumentException($"Parameter '{DatabricksParameters.TraceStateEnabled}' value '{traceStateEnabledStr}' could not be parsed. Valid values are 'true' and 'false'.");
                 }
+            }
+
+            if (!Properties.ContainsKey(ApacheParameters.QueryTimeoutSeconds))
+            {
+                // Default QueryTimeSeconds in Hive2Connection is only 60s, which is too small for lots of long running query
+                QueryTimeoutSeconds = DefaultQueryTimeSeconds;
             }
         }
 


### PR DESCRIPTION
## Motivation

Currently, the default `QueryTimeoutSeconds` is **60s** (set by `Hive2Server2Connection` [here](https://github.com/apache/arrow-adbc/blob/main/csharp/src/Drivers/Apache/Hive2/HiveServer2Connection.cs#L305)), which is too short as some customers may run some large and complex queries which takes long time.

## Change
Change the `QueryTimeoutSeconds` in the `DatabricksConnection` to 3 hours if it is not configured by the connection parameter in the client

## Test
- Existing E2E test
- Test a long running query ( >. 2 mins) 



