### PR TITLE
docs: need empty lines before lists

### DIFF
--- a/docs/source/format/driver_manifests.rst
+++ b/docs/source/format/driver_manifests.rst
@@ -271,6 +271,7 @@ to control which directories will be searched for manifests, with the behavior b
        :sync: cpp
 
         The type :c:type:`AdbcLoadFlags` is a set of bitflags to control the directories to be searched. The flags are
+
         * :c:macro:`ADBC_LOAD_FLAG_SEARCH_ENV` - search the environment variable ``ADBC_CONFIG_PATH``
         * :c:macro:`ADBC_LOAD_FLAG_SEARCH_USER` - search the user configuration directory
         * :c:macro:`ADBC_LOAD_FLAG_SEARCH_SYSTEM` - search the system configuration directory
@@ -283,7 +284,8 @@ to control which directories will be searched for manifests, with the behavior b
        :sync: glib
 
         The type ``GADBCLoadFlags`` is a set of bitflags to control the directories to be searched. The flags are
-        * ``GADBC_LOAD_SEARCH_ENV` - search the environment variable ``ADBC_CONFIG_PATH``
+
+        * ``GADBC_LOAD_SEARCH_ENV`` - search the environment variable ``ADBC_CONFIG_PATH``
         * ``GADBC_LOAD_FLAG_SEARCH_USER`` - search the user configuration directory
         * ``GADBC_LOAD_FLAG_SEARCH_SYSTEM`` - search the system configuration directory
         * ``GADBC_LOAD_FLAG_ALLOW_RELATIVE_PATHS`` - allow a relative path to be provided
@@ -298,6 +300,7 @@ to control which directories will be searched for manifests, with the behavior b
         configuration directory, and system configuration directory. You can set the flags to use by passing the option
         ``drivermgr.LoadFlagsOptionKey`` with the value being the ``strconv.Itoa`` of the flags you want to use when you call ``NewDatabase``
         or ``NewDatabaseWithContext``. The flags are defined in the ``drivermgr`` package as constants:
+
         * ``drivermgr.LoadFlagsSearchEnv`` - search the environment variable ``ADBC_CONFIG_PATH``
         * ``drivermgr.LoadFlagsSearchUser`` - search the user configuration directory
         * ``drivermgr.LoadFlagsSearchSystem`` - search the system configuration directory
@@ -320,7 +323,8 @@ to control which directories will be searched for manifests, with the behavior b
        :sync: ruby
 
         The class ``ADBC::LoadFlags`` is a set of bitflags to control the directories to be searched. The flags are
-        * ``ADBC::LoadFlags::SEARCH_ENV` - search the environment variable ``ADBC_CONFIG_PATH``
+
+        * ``ADBC::LoadFlags::SEARCH_ENV`` - search the environment variable ``ADBC_CONFIG_PATH``
         * ``ADBC::LoadFlags::SEARCH_USER`` - search the user configuration directory
         * ``ADBC::LoadFlags::SEARCH_SYSTEM`` - search the system configuration directory
         * ``ADBC::LoadFlags::ALLOW_RELATIVE_PATHS`` - allow a relative path to be provided
@@ -335,11 +339,12 @@ to control which directories will be searched for manifests, with the behavior b
 
        The ``ManagedDriver`` type has a method ``load_dynamic_from_name`` which takes an optional ``load_flags`` parameter. The flags as a ``u32`` with
        the type ``adbc_core::driver_manager::LoadFlags``, which has the following constants:
-       * `LOAD_FLAG_SEARCH_ENV` - search the environment variable ``ADBC_CONFIG_PATH``
-       * `LOAD_FLAG_SEARCH_USER` - search the user configuration directory
-       * `LOAD_FLAG_SEARCH_SYSTEM` - search the system configuration directory
-       * `LOAD_FLAG_ALLOW_RELATIVE_PATHS` - allow a relative path to be used
-       * `LOAD_FLAG_DEFAULT` - default value with all flags set
+
+       * ``LOAD_FLAG_SEARCH_ENV`` - search the environment variable ``ADBC_CONFIG_PATH``
+       * ``LOAD_FLAG_SEARCH_USER`` - search the user configuration directory
+       * ``LOAD_FLAG_SEARCH_SYSTEM`` - search the system configuration directory
+       * ``LOAD_FLAG_ALLOW_RELATIVE_PATHS`` - allow a relative path to be used
+       * ``LOAD_FLAG_DEFAULT`` - default value with all flags set
 
 For unix-like platforms, (e.g. Linux, macOS), the driver manager will search the following directories based on the options provided, in
 the given order:


### PR DESCRIPTION
After looking at the resulting docs, I noticed that some of the tabs came across strangely. 

Fixing up some typos and spacing/formatting.