### PR TITLE
ci: keep testing sdists with manylinux2014

### DIFF
--- a/ci/scripts/python_sdist_test.sh
+++ b/ci/scripts/python_sdist_test.sh
@@ -51,7 +51,7 @@ done
 # Explicitly install the last version of PyArrow supporting manylinux2014.
 # - https://github.com/apache/arrow-adbc/issues/3182
 # - https://github.com/apache/arrow/issues/46959
-pip install importlib-resources pytest pyarrow==19.0.1 pandas polars protobuf
+pip install importlib-resources pytest pyarrow==20.0.0 pandas polars protobuf
 
 echo "=== (${PYTHON_VERSION}) Testing sdists ==="
 test_packages


### PR DESCRIPTION
While we will want to drop this eventually, for now it seems there's no real problem to support this and we don't need to build with anything newer.  This is also our _only_ manylinux build so there's nothing to be saved by trying to drop it.

Fixes #3182.