### PR TITLE
ci: bump Maven version used in nightly verification

### DIFF
--- a/ci/scripts/verify_ubuntu.sh
+++ b/ci/scripts/verify_ubuntu.sh
@@ -25,7 +25,7 @@
 set -euo pipefail
 
 : ${JDK:=21}
-: ${MAVEN:=3.9.10}
+: ${MAVEN:=3.9.11}
 
 main() {
     local -r source_dir="${1}"


### PR DESCRIPTION
Fixes #3183.