### PR TITLE
fix(csharp/src/Drivers/Apache/Hive2): Remove unnecessary CloseOperation in Statement.Dispose when query is metadata query

### DIFF
--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs
@@ -437,6 +437,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
                 TableName,
                 cancellationToken);
             OperationHandle = resp.OperationHandle;
+            _directResults = resp.DirectResults;
 
             return await GetQueryResult(resp.DirectResults, cancellationToken);
         }

--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs
@@ -457,6 +457,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
                 ForeignTableName,
                 cancellationToken);
             OperationHandle = resp.OperationHandle;
+            _directResults = resp.DirectResults;
 
             return await GetQueryResult(resp.DirectResults, cancellationToken);
         }
@@ -474,6 +475,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
                 TableName,
                 cancellationToken);
             OperationHandle = resp.OperationHandle;
+            _directResults = resp.DirectResults;
 
             return await GetQueryResult(resp.DirectResults, cancellationToken);
         }
@@ -482,6 +484,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
         {
             TGetCatalogsResp resp = await Connection.GetCatalogsAsync(cancellationToken);
             OperationHandle = resp.OperationHandle;
+            _directResults = resp.DirectResults;
 
             return await GetQueryResult(resp.DirectResults, cancellationToken);
         }
@@ -493,6 +496,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
                 EscapePatternWildcardsInName(SchemaName),
                 cancellationToken);
             OperationHandle = resp.OperationHandle;
+            _directResults = resp.DirectResults;
 
             return await GetQueryResult(resp.DirectResults, cancellationToken);
         }
@@ -507,6 +511,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
                 tableTypesList,
                 cancellationToken);
             OperationHandle = resp.OperationHandle;
+            _directResults = resp.DirectResults;
 
             return await GetQueryResult(resp.DirectResults, cancellationToken);
         }


### PR DESCRIPTION
## Motivation
 
When the client calls `HiveServer2Statement` to execute metadata query (e.g. GetCatalogsAsync, GetSchemasAsync), it won't set `_directResults`, which leads to a unnecessary thrift call (`CloseOperation`) in its `HiveServer2Statement.Dispose`, this is because it will make a blocking call `CloseOperation` if `_directResults=null`  (see code [here](https://github.com/apache/arrow-adbc/blob/main/csharp/src/Drivers/Apache/Hive2/HiveServer2Statement.cs#L378)), it introduces 100ms-200ms latency for every metadata call/query

## Change
Set `HiveServer2Statement._directResults` from resp.DirectResult in every metadata API in `HiveServer2Statement`, thus thrift `CloseOperation`  won't be called in `Dispose` if metadata query/option returns a successful `DirectResult`.

## Testing
- All the E2E testing on Databricks driver
- PGPerf.exe and saw 200-300ms performance improvement for every query scenario with Databricks