### PR TITLE
feat(csharp/test/Drivers/Databricks): Add mandatory token exchange

### DIFF
--- a/csharp/src/Drivers/Databricks/Auth/JwtTokenDecoder.cs
+++ b/csharp/src/Drivers/Databricks/Auth/JwtTokenDecoder.cs
@@ -70,6 +70,41 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
         }
 
         /// <summary>
+        /// Tries to extract the issuer (iss) claim from a JWT token.
+        /// </summary>
+        /// <param name="token">The JWT token to parse.</param>
+        /// <param name="issuer">The extracted issuer, if successful.</param>
+        /// <returns>True if the issuer was successfully extracted, false otherwise.</returns>
+        public static bool TryGetIssuer(string token, out string issuer)
+        {
+            issuer = string.Empty;
+
+            try
+            {
+                string[] parts = token.Split('.');
+                if (parts.Length != 3)
+                {
+                    return false;
+                }
+
+                string payload = DecodeBase64Url(parts[1]);
+                using JsonDocument jsonDoc = JsonDocument.Parse(payload);
+
+                if (!jsonDoc.RootElement.TryGetProperty("iss", out JsonElement issElement))
+                {
+                    return false;
+                }
+
+                issuer = issElement.GetString() ?? string.Empty;
+                return !string.IsNullOrEmpty(issuer);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Decodes a base64url encoded string to a regular string.
         /// </summary>
         /// <param name="base64Url">The base64url encoded string.</param>

--- a/csharp/src/Drivers/Databricks/Auth/MandatoryTokenExchangeDelegatingHandler.cs
+++ b/csharp/src/Drivers/Databricks/Auth/MandatoryTokenExchangeDelegatingHandler.cs
@@ -149,12 +149,12 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
             string? bearerToken = request.Headers.Authorization?.Parameter;
             if (!string.IsNullOrEmpty(bearerToken))
             {
-                StartTokenExchangeIfNeeded(bearerToken, cancellationToken);
+                StartTokenExchangeIfNeeded(bearerToken!, cancellationToken);
 
                 string tokenToUse;
                 lock (_tokenLock)
                 {
-                    tokenToUse = _currentToken ?? bearerToken;
+                    tokenToUse = _currentToken ?? bearerToken!;
                 }
 
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenToUse);

--- a/csharp/src/Drivers/Databricks/Auth/MandatoryTokenExchangeDelegatingHandler.cs
+++ b/csharp/src/Drivers/Databricks/Auth/MandatoryTokenExchangeDelegatingHandler.cs
@@ -1,0 +1,189 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
+{
+    /// <summary>
+    /// HTTP message handler that performs mandatory token exchange for non-Databricks tokens.
+    /// Uses a non-blocking approach to exchange tokens in the background.
+    /// </summary>
+    internal class MandatoryTokenExchangeDelegatingHandler : DelegatingHandler
+    {
+        private readonly string? _identityFederationClientId;
+        private readonly object _tokenLock = new object();
+        private readonly ITokenExchangeClient _tokenExchangeClient;
+        private string? _currentToken;
+        private string? _lastSeenToken;
+
+        protected Task? _pendingTokenTask = null;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MandatoryTokenExchangeDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler to delegate to.</param>
+        /// <param name="tokenExchangeClient">The client for token exchange operations.</param>
+        /// <param name="identityFederationClientId">Optional identity federation client ID.</param>
+        public MandatoryTokenExchangeDelegatingHandler(
+            HttpMessageHandler innerHandler,
+            ITokenExchangeClient tokenExchangeClient,
+            string? identityFederationClientId = null)
+            : base(innerHandler)
+        {
+            _tokenExchangeClient = tokenExchangeClient ?? throw new ArgumentNullException(nameof(tokenExchangeClient));
+            _identityFederationClientId = identityFederationClientId;
+        }
+
+        /// <summary>
+        /// Determines if token exchange is needed by checking if the token is a Databricks token.
+        /// </summary>
+        /// <returns>True if token exchange is needed, false otherwise.</returns>
+        private bool NeedsTokenExchange(string bearerToken)
+        {
+            // If we already started exchange for this token, no need to check again
+            if (_lastSeenToken == bearerToken)
+            {
+                return false;
+            }
+
+            // If we already have a pending token task, don't start another exchange
+            if (_pendingTokenTask != null)
+            {
+                return false;
+            }
+
+            // If we can't parse the token as JWT, default to use existing token
+            if (!JwtTokenDecoder.TryGetIssuer(bearerToken, out string issuer))
+            {
+                return false;
+            }
+
+            // Check if the issuer matches the current workspace host
+            // If the issuer is from the same host, it's already a Databricks token
+            string normalizedHost = _tokenExchangeClient.TokenExchangeEndpoint.Replace("/v1/token", "").ToLowerInvariant();
+            string normalizedIssuer = issuer.TrimEnd('/').ToLowerInvariant();
+
+            return normalizedIssuer != normalizedHost;
+        }
+
+        /// <summary>
+        /// Starts token exchange in the background if needed.
+        /// </summary>
+        /// <param name="bearerToken">The bearer token to potentially exchange.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        private void StartTokenExchangeIfNeeded(string bearerToken, CancellationToken cancellationToken)
+        {
+            if (_lastSeenToken == bearerToken)
+            {
+                return;
+            }
+
+            bool needsExchange;
+            lock (_tokenLock)
+            {
+                needsExchange = NeedsTokenExchange(bearerToken);
+
+                _lastSeenToken = bearerToken;
+            }
+
+            if (!needsExchange)
+            {
+                return;
+            }
+
+            // Start token exchange in the background
+            _pendingTokenTask = Task.Run(async () =>
+            {
+                try
+                {
+                    TokenExchangeResponse response = await _tokenExchangeClient.ExchangeTokenAsync(
+                        bearerToken,
+                        _identityFederationClientId,
+                        cancellationToken);
+
+                    lock (_tokenLock)
+                    {
+                        _currentToken = response.AccessToken;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Mandatory token exchange failed: {ex.Message}");
+                }
+            }, cancellationToken).ContinueWith(_ =>
+            {
+                lock (_tokenLock)
+                {
+                    _pendingTokenTask = null;
+                }
+            }, TaskScheduler.Default);
+        }
+
+        /// <summary>
+        /// Sends an HTTP request with the current token.
+        /// </summary>
+        /// <param name="request">The HTTP request message to send.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The HTTP response message.</returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string? bearerToken = request.Headers.Authorization?.Parameter;
+            if (!string.IsNullOrEmpty(bearerToken))
+            {
+                StartTokenExchangeIfNeeded(bearerToken, cancellationToken);
+
+                string tokenToUse;
+                lock (_tokenLock)
+                {
+                    tokenToUse = _currentToken ?? bearerToken;
+                }
+
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", tokenToUse);
+            }
+
+            return await base.SendAsync(request, cancellationToken);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Wait for any pending token task to complete to avoid leaking tasks
+                if (_pendingTokenTask != null)
+                {
+                    try
+                    {
+                        // Try to wait for the task to complete, but don't block indefinitely
+                        _pendingTokenTask.Wait(TimeSpan.FromSeconds(10));
+                    }
+                    catch (Exception ex)
+                    {
+                        // Log any exceptions during disposal
+                        System.Diagnostics.Debug.WriteLine($"Exception during token task cleanup: {ex.Message}");
+                    }
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/csharp/src/Drivers/Databricks/Auth/TokenExchangeClient.cs
+++ b/csharp/src/Drivers/Databricks/Auth/TokenExchangeClient.cs
@@ -157,7 +157,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
 
             if (!string.IsNullOrEmpty(identityFederationClientId))
             {
-                formData.Add(new KeyValuePair<string, string>("identity_federation_client_id", identityFederationClientId));
+                formData.Add(new KeyValuePair<string, string>("identity_federation_client_id", identityFederationClientId!));
             }
             else
             {

--- a/csharp/src/Drivers/Databricks/Auth/TokenRefreshDelegatingHandler.cs
+++ b/csharp/src/Drivers/Databricks/Auth/TokenRefreshDelegatingHandler.cs
@@ -27,7 +27,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
     /// HTTP message handler that automatically refreshes OAuth tokens before they expire.
     /// Uses a non-blocking approach to refresh tokens in the background.
     /// </summary>
-    internal class TokenExchangeDelegatingHandler : DelegatingHandler
+    internal class TokenRefreshDelegatingHandler : DelegatingHandler
     {
         private readonly string _initialToken;
         private readonly int _tokenRenewLimitMinutes;
@@ -40,14 +40,14 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
         private Task? _pendingTokenTask = null;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TokenExchangeDelegatingHandler"/> class.
+        /// Initializes a new instance of the <see cref="TokenRefreshDelegatingHandler"/> class.
         /// </summary>
         /// <param name="innerHandler">The inner handler to delegate to.</param>
         /// <param name="tokenExchangeClient">The client for token exchange operations.</param>
         /// <param name="initialToken">The initial token from the connection string.</param>
         /// <param name="tokenExpiryTime">The expiry time of the initial token.</param>
         /// <param name="tokenRenewLimitMinutes">The minutes before token expiration when we should start renewing the token.</param>
-        public TokenExchangeDelegatingHandler(
+        public TokenRefreshDelegatingHandler(
             HttpMessageHandler innerHandler,
             ITokenExchangeClient tokenExchangeClient,
             string initialToken,
@@ -111,7 +111,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Auth
             {
                 try
                 {
-                    TokenExchangeResponse response = await _tokenExchangeClient.ExchangeTokenAsync(_initialToken, cancellationToken);
+                    TokenExchangeResponse response = await _tokenExchangeClient.RefreshTokenAsync(_initialToken, cancellationToken);
 
                     // Update the token atomically when ready
                     lock (_tokenLock)

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -66,6 +66,9 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         private string _traceParentHeaderName = "traceparent";
         private bool _traceStateEnabled = false;
 
+        // Identity federation client ID for token exchange
+        private string? _identityFederationClientId;
+
         // Default namespace
         private TNamespace? _defaultNamespace;
 
@@ -264,6 +267,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 // Default QueryTimeSeconds in Hive2Connection is only 60s, which is too small for lots of long running query
                 QueryTimeoutSeconds = DefaultQueryTimeSeconds;
             }
+
+            if (Properties.TryGetValue(DatabricksParameters.IdentityFederationClientId, out string? identityFederationClientId))
+            {
+                _identityFederationClientId = identityFederationClientId;
+            }
         }
 
         /// <summary>
@@ -345,61 +353,64 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
                 baseAuthHandler = new RetryHttpHandler(baseAuthHandler, TemporarilyUnavailableRetryTimeout);
             }
 
-            Debug.Assert(_authHttpClient == null, "Auth HttpClient should not be initialized yet.");
-            _authHttpClient = new HttpClient(baseAuthHandler);
-
-            // Add OAuth client credentials handler if OAuth M2M authentication is being used
             if (Properties.TryGetValue(SparkParameters.AuthType, out string? authType) &&
                 SparkAuthTypeParser.TryParse(authType, out SparkAuthType authTypeValue) &&
-                authTypeValue == SparkAuthType.OAuth &&
-                Properties.TryGetValue(DatabricksParameters.OAuthGrantType, out string? grantTypeStr) &&
-                DatabricksOAuthGrantTypeParser.TryParse(grantTypeStr, out DatabricksOAuthGrantType grantType) &&
-                grantType == DatabricksOAuthGrantType.ClientCredentials)
+                authTypeValue == SparkAuthType.OAuth)
             {
+                Debug.Assert(_authHttpClient == null, "Auth HttpClient should not be initialized yet.");
+                _authHttpClient = new HttpClient(baseAuthHandler);
+
                 string host = GetHost();
+                ITokenExchangeClient tokenExchangeClient = new TokenExchangeClient(_authHttpClient, host);
 
-                Properties.TryGetValue(DatabricksParameters.OAuthClientId, out string? clientId);
-                Properties.TryGetValue(DatabricksParameters.OAuthClientSecret, out string? clientSecret);
-                Properties.TryGetValue(DatabricksParameters.OAuthScope, out string? scope);
+                // Mandatory token exchange should be the inner handler so that it happens
+                // AFTER the OAuth handlers (e.g. after M2M sets the access token)
+                baseHandler = new MandatoryTokenExchangeDelegatingHandler(
+                    baseHandler,
+                    tokenExchangeClient,
+                    _identityFederationClientId);
 
-                var tokenProvider = new OAuthClientCredentialsProvider(
-                    _authHttpClient,
-                    clientId!,
-                    clientSecret!,
-                    host!,
-                    scope: scope ?? "sql",
-                    timeoutMinutes: 1
-                );
-
-                baseHandler = new OAuthDelegatingHandler(baseHandler, tokenProvider);
-            }
-            // Add token exchange handler if token renewal is enabled and the auth type is OAuth access token
-            else if (Properties.TryGetValue(DatabricksParameters.TokenRenewLimit, out string? tokenRenewLimitStr) &&
-                int.TryParse(tokenRenewLimitStr, out int tokenRenewLimit) &&
-                tokenRenewLimit > 0 &&
-                Properties.TryGetValue(SparkParameters.AuthType, out string? authTypeForToken) &&
-                SparkAuthTypeParser.TryParse(authTypeForToken, out SparkAuthType authTypeValueForToken) &&
-                authTypeValueForToken == SparkAuthType.OAuth &&
-                Properties.TryGetValue(SparkParameters.AccessToken, out string? accessToken))
-            {
-                if (string.IsNullOrEmpty(accessToken))
+                // Add OAuth client credentials handler if OAuth M2M authentication is being used
+                if (Properties.TryGetValue(DatabricksParameters.OAuthGrantType, out string? grantTypeStr) &&
+                    DatabricksOAuthGrantTypeParser.TryParse(grantTypeStr, out DatabricksOAuthGrantType grantType) &&
+                    grantType == DatabricksOAuthGrantType.ClientCredentials)
                 {
-                    throw new ArgumentException("Access token is required for OAuth authentication with token renewal.");
+                    Properties.TryGetValue(DatabricksParameters.OAuthClientId, out string? clientId);
+                    Properties.TryGetValue(DatabricksParameters.OAuthClientSecret, out string? clientSecret);
+                    Properties.TryGetValue(DatabricksParameters.OAuthScope, out string? scope);
+
+                    var tokenProvider = new OAuthClientCredentialsProvider(
+                        _authHttpClient,
+                        clientId!,
+                        clientSecret!,
+                        host!,
+                        scope: scope ?? "sql",
+                        timeoutMinutes: 1
+                    );
+
+                    baseHandler = new OAuthDelegatingHandler(baseHandler, tokenProvider);
                 }
-
-                // Check if token is a JWT token by trying to decode it
-                if (JwtTokenDecoder.TryGetExpirationTime(accessToken, out DateTime expiryTime))
+                // Add token renewal handler for OAuth access token
+                else if (Properties.TryGetValue(DatabricksParameters.TokenRenewLimit, out string? tokenRenewLimitStr) &&
+                    int.TryParse(tokenRenewLimitStr, out int tokenRenewLimit) &&
+                    tokenRenewLimit > 0 &&
+                    Properties.TryGetValue(SparkParameters.AccessToken, out string? accessToken))
                 {
-                    string host = GetHost();
+                    if (string.IsNullOrEmpty(accessToken))
+                    {
+                        throw new ArgumentException("Access token is required for OAuth authentication with token renewal.");
+                    }
 
-                    var tokenExchangeClient = new TokenExchangeClient(_authHttpClient, host);
-
-                    baseHandler = new TokenExchangeDelegatingHandler(
-                        baseHandler,
-                        tokenExchangeClient,
-                        accessToken,
-                        expiryTime,
-                        tokenRenewLimit);
+                    // Check if token is a JWT token by trying to decode it
+                    if (JwtTokenDecoder.TryGetExpirationTime(accessToken, out DateTime expiryTime))
+                    {
+                        baseHandler = new TokenRefreshDelegatingHandler(
+                            baseHandler,
+                            tokenExchangeClient,
+                            accessToken,
+                            expiryTime,
+                            tokenRenewLimit);
+                    }
                 }
             }
 

--- a/csharp/src/Drivers/Databricks/DatabricksParameters.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksParameters.cs
@@ -212,6 +212,12 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// Default value is 0 (disabled) if not specified.
         /// </summary>
         public const string TokenRenewLimit = "adbc.databricks.token_renew_limit";
+
+        /// <summary>
+        /// The client ID of the service principal when using workload identity federation.
+        /// Default value is empty if not specified.
+        /// </summary>
+        public const string IdentityFederationClientId = "adbc.databricks.identity_federation_client_id";
     }
 
     /// <summary>

--- a/csharp/test/Drivers/Databricks/E2E/Auth/TokenExchangeTests.cs
+++ b/csharp/test/Drivers/Databricks/E2E/Auth/TokenExchangeTests.cs
@@ -92,7 +92,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
             string host = GetHost();
             var tokenExchangeClient = new TokenExchangeClient(_httpClient, host);
 
-            var response = await tokenExchangeClient.ExchangeTokenAsync(TestConfiguration.AccessToken, CancellationToken.None);
+            var response = await tokenExchangeClient.RefreshTokenAsync(TestConfiguration.AccessToken, CancellationToken.None);
 
             Assert.NotNull(response);
             Assert.NotEmpty(response.AccessToken);
@@ -119,7 +119,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
             // Create a token capturing handler to intercept the actual tokens being sent
             var tokenCapturingHandler = new TokenCapturingHandler(new HttpClientHandler());
 
-            var handler = new TokenExchangeDelegatingHandler(
+            var handler = new TokenRefreshDelegatingHandler(
                 tokenCapturingHandler,
                 tokenExchangeClient,
                 TestConfiguration.AccessToken,
@@ -180,7 +180,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Auth
             var tokenCapturingHandler = new TokenCapturingHandler(new HttpClientHandler());
 
             // Create a handler that should not refresh the token (token not near expiry)
-            var handler = new TokenExchangeDelegatingHandler(
+            var handler = new TokenRefreshDelegatingHandler(
                 tokenCapturingHandler,
                 tokenExchangeClient,
                 TestConfiguration.AccessToken,

--- a/csharp/test/Drivers/Databricks/Unit/Auth/MandatoryTokenExchangeDelegatingHandlerTests.cs
+++ b/csharp/test/Drivers/Databricks/Unit/Auth/MandatoryTokenExchangeDelegatingHandlerTests.cs
@@ -116,7 +116,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             Assert.Equal(_databricksToken, capturedRequest.Headers.Authorization?.Parameter);
 
             // Wait for any background tasks
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
             // Verify no token exchange was attempted
             _mockTokenExchangeClient.Verify(
@@ -179,7 +179,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             Assert.Equal(_externalToken, capturedRequest.Headers.Authorization?.Parameter); // First request uses original token
 
             // Wait for background task to complete
-            await Task.Delay(tokenExchangeDelay + TimeSpan.FromMilliseconds(100));
+            await Task.Delay(tokenExchangeDelay + TimeSpan.FromMilliseconds(1000));
 
             // Make a second request - this should use the exchanged token
             var request2 = new HttpRequestMessage(HttpMethod.Get, "https://example.com/2");
@@ -241,7 +241,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             Assert.Equal(_externalToken, capturedRequest.Headers.Authorization?.Parameter); // Should still use original token
 
             // Wait for background task to complete
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
             var request2 = new HttpRequestMessage(HttpMethod.Get, "https://example.com/2");
             request2.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _externalToken);
@@ -305,7 +305,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             }
 
             // Wait for background exchange to complete
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
             // Token exchange should only be called once
             _mockTokenExchangeClient.Verify(
@@ -361,7 +361,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             await httpClient.SendAsync(request1);
 
             // Wait for first exchange to complete
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
             // Make request with second token
             var request2 = new HttpRequestMessage(HttpMethod.Get, "https://example.com/2");
@@ -369,7 +369,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             await httpClient.SendAsync(request2);
 
             // Wait for second exchange to complete
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
             // Verify both tokens were exchanged
             _mockTokenExchangeClient.Verify(
@@ -425,7 +425,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             await Task.WhenAll(tasks);
 
             // Wait for any background token exchange to complete
-            await Task.Delay(300);
+            await Task.Delay(1000);
 
             // Token exchange should only be called once despite concurrent requests
             _mockTokenExchangeClient.Verify(
@@ -465,7 +465,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             Assert.Equal(invalidToken, capturedRequest.Headers.Authorization?.Parameter);
 
             // Wait for any background tasks
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
             // Verify no token exchange was attempted
             _mockTokenExchangeClient.Verify(

--- a/csharp/test/Drivers/Databricks/Unit/Auth/MandatoryTokenExchangeDelegatingHandlerTests.cs
+++ b/csharp/test/Drivers/Databricks/Unit/Auth/MandatoryTokenExchangeDelegatingHandlerTests.cs
@@ -1,0 +1,578 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Apache.Arrow.Adbc.Drivers.Databricks.Auth;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
+{
+    public class MandatoryTokenExchangeDelegatingHandlerTests : IDisposable
+    {
+        private readonly Mock<HttpMessageHandler> _mockInnerHandler;
+        private readonly Mock<ITokenExchangeClient> _mockTokenExchangeClient;
+        private readonly string _identityFederationClientId = "test-client-id";
+
+        // Real JWT tokens for testing (these are valid JWT structure but not real credentials)
+        private readonly string _databricksToken;
+        private readonly string _externalToken;
+        private readonly string _exchangedToken = "exchanged-databricks-token";
+
+        public MandatoryTokenExchangeDelegatingHandlerTests()
+        {
+            _mockInnerHandler = new Mock<HttpMessageHandler>();
+            _mockTokenExchangeClient = new Mock<ITokenExchangeClient>();
+
+            // Setup token exchange endpoint for host comparison
+            _mockTokenExchangeClient.Setup(x => x.TokenExchangeEndpoint)
+                .Returns("https://databricks-workspace.cloud.databricks.com/v1/token");
+
+            // Create real JWT tokens with proper issuers
+            _databricksToken = CreateJwtToken("https://databricks-workspace.cloud.databricks.com", DateTime.UtcNow.AddHours(1));
+            _externalToken = CreateJwtToken("https://external-provider.com", DateTime.UtcNow.AddHours(1));
+        }
+
+        [Fact]
+        public void Constructor_WithValidParameters_InitializesCorrectly()
+        {
+            var handler = new MandatoryTokenExchangeDelegatingHandler(
+                _mockInnerHandler.Object,
+                _mockTokenExchangeClient.Object,
+                _identityFederationClientId);
+
+            Assert.NotNull(handler);
+        }
+
+        [Fact]
+        public void Constructor_WithNullTokenExchangeClient_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new MandatoryTokenExchangeDelegatingHandler(
+                _mockInnerHandler.Object,
+                null!,
+                _identityFederationClientId));
+        }
+
+        [Fact]
+        public void Constructor_WithoutIdentityFederationClientId_InitializesCorrectly()
+        {
+            var handler = new MandatoryTokenExchangeDelegatingHandler(
+                _mockInnerHandler.Object,
+                _mockTokenExchangeClient.Object);
+
+            Assert.NotNull(handler);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithDatabricksToken_UsesTokenDirectlyWithoutExchange()
+        {
+            var handler = new MandatoryTokenExchangeDelegatingHandler(
+                _mockInnerHandler.Object,
+                _mockTokenExchangeClient.Object,
+                _identityFederationClientId);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com");
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _databricksToken);
+            var expectedResponse = new HttpResponseMessage(HttpStatusCode.OK);
+
+            HttpRequestMessage? capturedRequest = null;
+
+            _mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+                .ReturnsAsync(expectedResponse);
+
+            var httpClient = new HttpClient(handler);
+
+            var response = await httpClient.SendAsync(request);
+
+            Assert.Equal(expectedResponse, response);
+            Assert.NotNull(capturedRequest);
+            Assert.Equal("Bearer", capturedRequest.Headers.Authorization?.Scheme);
+            Assert.Equal(_databricksToken, capturedRequest.Headers.Authorization?.Parameter);
+
+            // Wait for any background tasks
+            await Task.Delay(100);
+
+            // Verify no token exchange was attempted
+            _mockTokenExchangeClient.Verify(
+                x => x.ExchangeTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithExternalToken_StartsTokenExchangeInBackground()
+        {
+            var tokenExchangeDelay = TimeSpan.FromMilliseconds(500);
+            var handler = new MandatoryTokenExchangeDelegatingHandler(
+                _mockInnerHandler.Object,
+                _mockTokenExchangeClient.Object,
+                _identityFederationClientId);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com");
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _externalToken);
+            var expectedResponse = new HttpResponseMessage(HttpStatusCode.OK);
+
+            var tokenExchangeResponse = new TokenExchangeResponse
+            {
+                AccessToken = _exchangedToken,
+                TokenType = "Bearer",
+                ExpiresIn = 3600,
+                ExpiryTime = DateTime.UtcNow.AddHours(1)
+            };
+
+            _mockTokenExchangeClient
+                .Setup(x => x.ExchangeTokenAsync(_externalToken, _identityFederationClientId, It.IsAny<CancellationToken>()))
+                .Returns(async (string token, string clientId, CancellationToken ct) =>
+                {
+                    await Task.Delay(tokenExchangeDelay, ct);
+                    return tokenExchangeResponse;
+                });
+
+            HttpRequestMessage? capturedRequest = null;
+
+            _mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+                .ReturnsAsync(expectedResponse);
+
+            var httpClient = new HttpClient(handler);
+
+            // First request should use original token and start background exchange
+            var startTime = DateTime.UtcNow;
+            var response = await httpClient.SendAsync(request);
+            var requestDuration = DateTime.UtcNow - startTime;
+
+            Assert.Equal(expectedResponse, response);
+            Assert.True(requestDuration < tokenExchangeDelay,
+                $"Request took {requestDuration.TotalMilliseconds}ms, which is longer than the token exchange delay of {tokenExchangeDelay.TotalMilliseconds}ms");
+
+            Assert.NotNull(capturedRequest);
+            Assert.Equal("Bearer", capturedRequest.Headers.Authorization?.Scheme);
+            Assert.Equal(_externalToken, capturedRequest.Headers.Authorization?.Parameter); // First request uses original token
+
+            // Wait for background task to complete
+            await Task.Delay(tokenExchangeDelay + TimeSpan.FromMilliseconds(100));
+
+            // Make a second request - this should use the exchanged token
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "https://example.com/2");
+            request2.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _externalToken);
+            HttpRequestMessage? capturedRequest2 = null;
+
+            _mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.PathAndQuery == "/2"),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest2 = req)
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+            await httpClient.SendAsync(request2);
+
+            Assert.NotNull(capturedRequest2);
+            Assert.Equal("Bearer", capturedRequest2.Headers.Authorization?.Scheme);
+            Assert.Equal(_exchangedToken, capturedRequest2.Headers.Authorization?.Parameter); // Second request uses exchanged token
+
+            _mockTokenExchangeClient.Verify(
+                x => x.ExchangeTokenAsync(_externalToken, _identityFederationClientId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithTokenExchangeFailure_ContinuesWithOriginalToken()
+        {
+            var handler = new MandatoryTokenExchangeDelegatingHandler(
+                _mockInnerHandler.Object,
+                _mockTokenExchangeClient.Object,
+                _identityFederationClientId);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com");
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _externalToken);
+            var expectedResponse = new HttpResponseMessage(HttpStatusCode.OK);
+
+            // Setup token exchange to fail
+            _mockTokenExchangeClient
+                .Setup(x => x.ExchangeTokenAsync(_externalToken, _identityFederationClientId, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("Token exchange failed"));
+
+            HttpRequestMessage? capturedRequest = null;
+
+            _mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+                .ReturnsAsync(expectedResponse);
+
+            var httpClient = new HttpClient(handler);
+            var response = await httpClient.SendAsync(request);
+
+            Assert.Equal(expectedResponse, response);
+            Assert.NotNull(capturedRequest);
+            Assert.Equal("Bearer", capturedRequest.Headers.Authorization?.Scheme);
+            Assert.Equal(_externalToken, capturedRequest.Headers.Authorization?.Parameter); // Should still use original token
+
+            // Wait for background task to complete
+            await Task.Delay(100);
+
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "https://example.com/2");
+            request2.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _externalToken);
+            HttpRequestMessage? capturedRequest2 = null;
+
+            _mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(r => r.RequestUri!.PathAndQuery == "/2"),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest2 = req)
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+            await httpClient.SendAsync(request2);
+
+            Assert.NotNull(capturedRequest2);
+            Assert.Equal("Bearer", capturedRequest2.Headers.Authorization?.Scheme);
+            Assert.Equal(_externalToken, capturedRequest2.Headers.Authorization?.Parameter); // Should still use original token
+
+            // Verify token exchange was attempted
+            _mockTokenExchangeClient.Verify(
+                x => x.ExchangeTokenAsync(_externalToken, _identityFederationClientId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithSameExternalTokenMultipleTimes_ExchangesTokenOnlyOnce()
+        {
+            var handler = new MandatoryTokenExchangeDelegatingHandler(
+                _mockInnerHandler.Object,
+                _mockTokenExchangeClient.Object,
+                _identityFederationClientId);
+
+            var tokenExchangeResponse = new TokenExchangeResponse
+            {
+                AccessToken = _exchangedToken,
+                TokenType = "Bearer",
+                ExpiresIn = 3600,
+                ExpiryTime = DateTime.UtcNow.AddHours(1)
+            };
+
+            _mockTokenExchangeClient
+                .Setup(x => x.ExchangeTokenAsync(_externalToken, _identityFederationClientId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(tokenExchangeResponse);
+
+            _mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+            var httpClient = new HttpClient(handler);
+
+            // Make multiple requests with the same token
+            for (int i = 0; i < 3; i++)
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, $"https://example.com/{i}");
+                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _externalToken);
+                await httpClient.SendAsync(request);
+            }
+
+            // Wait for background exchange to complete
+            await Task.Delay(100);
+
+            // Token exchange should only be called once
+            _mockTokenExchangeClient.Verify(
+                x => x.ExchangeTokenAsync(_externalToken, _identityFederationClientId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithDifferentExternalTokens_ExchangesEachTokenOnce()
+        {
+            var handler = new MandatoryTokenExchangeDelegatingHandler(
+                _mockInnerHandler.Object,
+                _mockTokenExchangeClient.Object,
+                _identityFederationClientId);
+
+            var externalToken1 = CreateJwtToken("https://external-provider.com", DateTime.UtcNow.AddHours(1));
+            var externalToken2 = CreateJwtToken("https://another-provider.com", DateTime.UtcNow.AddHours(1));
+            var exchangedToken1 = "exchanged-token-1";
+            var exchangedToken2 = "exchanged-token-2";
+
+            _mockTokenExchangeClient
+                .Setup(x => x.ExchangeTokenAsync(externalToken1, _identityFederationClientId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TokenExchangeResponse
+                {
+                    AccessToken = exchangedToken1,
+                    TokenType = "Bearer",
+                    ExpiresIn = 3600,
+                    ExpiryTime = DateTime.UtcNow.AddHours(1)
+                });
+
+            _mockTokenExchangeClient
+                .Setup(x => x.ExchangeTokenAsync(externalToken2, _identityFederationClientId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TokenExchangeResponse
+                {
+                    AccessToken = exchangedToken2,
+                    TokenType = "Bearer",
+                    ExpiresIn = 3600,
+                    ExpiryTime = DateTime.UtcNow.AddHours(1)
+                });
+
+            _mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+            var httpClient = new HttpClient(handler);
+
+            // Make request with first token
+            var request1 = new HttpRequestMessage(HttpMethod.Get, "https://example.com/1");
+            request1.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", externalToken1);
+            await httpClient.SendAsync(request1);
+
+            // Wait for first exchange to complete
+            await Task.Delay(100);
+
+            // Make request with second token
+            var request2 = new HttpRequestMessage(HttpMethod.Get, "https://example.com/2");
+            request2.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", externalToken2);
+            await httpClient.SendAsync(request2);
+
+            // Wait for second exchange to complete
+            await Task.Delay(100);
+
+            // Verify both tokens were exchanged
+            _mockTokenExchangeClient.Verify(
+                x => x.ExchangeTokenAsync(externalToken1, _identityFederationClientId, It.IsAny<CancellationToken>()),
+                Times.Once);
+            _mockTokenExchangeClient.Verify(
+                x => x.ExchangeTokenAsync(externalToken2, _identityFederationClientId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithConcurrentRequestsSameToken_ExchangesTokenOnlyOnce()
+        {
+            var handler = new MandatoryTokenExchangeDelegatingHandler(
+                _mockInnerHandler.Object,
+                _mockTokenExchangeClient.Object,
+                _identityFederationClientId);
+
+            var tokenExchangeResponse = new TokenExchangeResponse
+            {
+                AccessToken = _exchangedToken,
+                TokenType = "Bearer",
+                ExpiresIn = 3600,
+                ExpiryTime = DateTime.UtcNow.AddHours(1)
+            };
+
+            // Add a small delay to token exchange to simulate concurrent access
+            _mockTokenExchangeClient
+                .Setup(x => x.ExchangeTokenAsync(_externalToken, _identityFederationClientId, It.IsAny<CancellationToken>()))
+                .Returns(async () =>
+                {
+                    await Task.Delay(200);
+                    return tokenExchangeResponse;
+                });
+
+            _mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+            var httpClient = new HttpClient(handler);
+
+            // Make concurrent requests with the same token
+            var tasks = new[]
+            {
+                CreateAndSendRequest(httpClient, _externalToken, "https://example.com/1"),
+                CreateAndSendRequest(httpClient, _externalToken, "https://example.com/2"),
+                CreateAndSendRequest(httpClient, _externalToken, "https://example.com/3")
+            };
+
+            await Task.WhenAll(tasks);
+
+            // Wait for any background token exchange to complete
+            await Task.Delay(300);
+
+            // Token exchange should only be called once despite concurrent requests
+            _mockTokenExchangeClient.Verify(
+                x => x.ExchangeTokenAsync(_externalToken, _identityFederationClientId, It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithInvalidJwtToken_UsesTokenDirectlyWithoutExchange()
+        {
+            var handler = new MandatoryTokenExchangeDelegatingHandler(
+                _mockInnerHandler.Object,
+                _mockTokenExchangeClient.Object,
+                _identityFederationClientId);
+
+            var invalidToken = "invalid-jwt-token";
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com");
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", invalidToken);
+            var expectedResponse = new HttpResponseMessage(HttpStatusCode.OK);
+
+            HttpRequestMessage? capturedRequest = null;
+
+            _mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+                .ReturnsAsync(expectedResponse);
+
+            var httpClient = new HttpClient(handler);
+            var response = await httpClient.SendAsync(request);
+
+            Assert.Equal(expectedResponse, response);
+            Assert.NotNull(capturedRequest);
+            Assert.Equal("Bearer", capturedRequest.Headers.Authorization?.Scheme);
+            Assert.Equal(invalidToken, capturedRequest.Headers.Authorization?.Parameter);
+
+            // Wait for any background tasks
+            await Task.Delay(100);
+
+            // Verify no token exchange was attempted
+            _mockTokenExchangeClient.Verify(
+                x => x.ExchangeTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task SendAsync_WithNoAuthorizationHeader_PassesThroughWithoutModification()
+        {
+            var handler = new MandatoryTokenExchangeDelegatingHandler(
+                _mockInnerHandler.Object,
+                _mockTokenExchangeClient.Object,
+                _identityFederationClientId);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://example.com");
+            var expectedResponse = new HttpResponseMessage(HttpStatusCode.OK);
+
+            HttpRequestMessage? capturedRequest = null;
+
+            _mockInnerHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+                .ReturnsAsync(expectedResponse);
+
+            var httpClient = new HttpClient(handler);
+            var response = await httpClient.SendAsync(request);
+
+            Assert.Equal(expectedResponse, response);
+            Assert.NotNull(capturedRequest);
+            Assert.Null(capturedRequest.Headers.Authorization);
+
+            // Verify no token exchange was attempted
+            _mockTokenExchangeClient.Verify(
+                x => x.ExchangeTokenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        private async Task<HttpResponseMessage> CreateAndSendRequest(HttpClient httpClient, string token, string url)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+            return await httpClient.SendAsync(request);
+        }
+
+        /// <summary>
+        /// Creates a valid JWT token with the specified issuer and expiration time.
+        /// This is for testing purposes only and creates a properly formatted JWT.
+        /// </summary>
+        private static string CreateJwtToken(string issuer, DateTime expiryTime)
+        {
+            // Create header
+            var header = new
+            {
+                alg = "HS256",
+                typ = "JWT"
+            };
+
+            // Create payload
+            var payload = new
+            {
+                iss = issuer,
+                exp = new DateTimeOffset(expiryTime).ToUnixTimeSeconds(),
+                iat = new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds(),
+                sub = "test-subject"
+            };
+
+            // Encode header and payload
+            string encodedHeader = EncodeBase64Url(JsonSerializer.Serialize(header));
+            string encodedPayload = EncodeBase64Url(JsonSerializer.Serialize(payload));
+
+            // For testing, we'll use a dummy signature
+            string signature = EncodeBase64Url("dummy-signature");
+
+            return $"{encodedHeader}.{encodedPayload}.{signature}";
+        }
+
+        /// <summary>
+        /// Encodes a string to base64url format.
+        /// </summary>
+        private static string EncodeBase64Url(string input)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(input);
+            string base64 = Convert.ToBase64String(bytes);
+
+            // Convert base64 to base64url
+            return base64
+                .Replace('+', '-')
+                .Replace('/', '_')
+                .TrimEnd('=');
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _mockInnerHandler?.Object?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/csharp/test/Drivers/Databricks/Unit/Auth/MandatoryTokenExchangeDelegatingHandlerTests.cs
+++ b/csharp/test/Drivers/Databricks/Unit/Auth/MandatoryTokenExchangeDelegatingHandlerTests.cs
@@ -27,7 +27,7 @@ using Moq;
 using Moq.Protected;
 using Xunit;
 
-namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
 {
     public class MandatoryTokenExchangeDelegatingHandlerTests : IDisposable
     {

--- a/csharp/test/Drivers/Databricks/Unit/Auth/TokenExchangeClientTests.cs
+++ b/csharp/test/Drivers/Databricks/Unit/Auth/TokenExchangeClientTests.cs
@@ -22,11 +22,12 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Apache.Arrow.Adbc.Drivers.Databricks.Auth;
+using Apache.Arrow.Adbc.Drivers.Databricks;
 using Moq;
 using Moq.Protected;
 using Xunit;
 
-namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
 {
     public class TokenExchangeClientTests : IDisposable
     {

--- a/csharp/test/Drivers/Databricks/Unit/Auth/TokenExchangeClientTests.cs
+++ b/csharp/test/Drivers/Databricks/Unit/Auth/TokenExchangeClientTests.cs
@@ -122,13 +122,21 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             };
 
             HttpRequestMessage? capturedRequest = null;
+            string? capturedFormContent = null;
 
             _mockHttpMessageHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+                .Callback<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+                {
+                    capturedRequest = req;
+                    if (req.Content != null)
+                    {
+                        capturedFormContent = await req.Content.ReadAsStringAsync();
+                    }
+                })
                 .ReturnsAsync(httpResponseMessage);
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
@@ -140,12 +148,9 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             Assert.Equal($"https://{_testHost}/oidc/v1/token", capturedRequest?.RequestUri?.ToString());
             Assert.True(capturedRequest?.Headers.Accept.Contains(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("*/*")));
 
-            var content = capturedRequest?.Content as FormUrlEncodedContent;
-            Assert.NotNull(content);
-
-            var formContent = await content.ReadAsStringAsync();
-            Assert.Contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer", formContent);
-            Assert.Contains($"assertion={testToken}", formContent);
+            Assert.NotNull(capturedFormContent);
+            Assert.Contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer", capturedFormContent);
+            Assert.Contains($"assertion={testToken}", capturedFormContent);
         }
 
         [Fact]
@@ -421,13 +426,21 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             };
 
             HttpRequestMessage? capturedRequest = null;
+            string? capturedFormContent = null;
 
             _mockHttpMessageHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+                .Callback<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+                {
+                    capturedRequest = req;
+                    if (req.Content != null)
+                    {
+                        capturedFormContent = await req.Content.ReadAsStringAsync();
+                    }
+                })
                 .ReturnsAsync(httpResponseMessage);
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
@@ -438,13 +451,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             Assert.Equal("exchanged-token", result.AccessToken);
 
             Assert.NotNull(capturedRequest);
-            Assert.NotNull(capturedRequest.Content);
-            var formContent = await capturedRequest.Content.ReadAsStringAsync();
-            Assert.Contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer", formContent);
-            Assert.Contains($"assertion={testToken}", formContent);
-            Assert.Contains("scope=sql", formContent);
-            Assert.Contains("return_original_token_if_authenticated=true", formContent);
-            Assert.DoesNotContain("identity_federation_client_id", formContent);
+            Assert.NotNull(capturedFormContent);
+            Assert.Contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer", capturedFormContent);
+            Assert.Contains($"assertion={testToken}", capturedFormContent);
+            Assert.Contains("scope=sql", capturedFormContent);
+            Assert.Contains("return_original_token_if_authenticated=true", capturedFormContent);
+            Assert.DoesNotContain("identity_federation_client_id", capturedFormContent);
         }
 
         [Fact]
@@ -465,13 +477,21 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             };
 
             HttpRequestMessage? capturedRequest = null;
+            string? capturedFormContent = null;
 
             _mockHttpMessageHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+                .Callback<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+                {
+                    capturedRequest = req;
+                    if (req.Content != null)
+                    {
+                        capturedFormContent = await req.Content.ReadAsStringAsync();
+                    }
+                })
                 .ReturnsAsync(httpResponseMessage);
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
@@ -482,13 +502,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             Assert.Equal("exchanged-token", result.AccessToken);
 
             Assert.NotNull(capturedRequest);
-            Assert.NotNull(capturedRequest.Content);
-            var formContent = await capturedRequest.Content.ReadAsStringAsync();
-            Assert.Contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer", formContent);
-            Assert.Contains($"assertion={testToken}", formContent);
-            Assert.Contains("scope=sql", formContent);
-            Assert.Contains($"identity_federation_client_id={clientId}", formContent);
-            Assert.DoesNotContain("return_original_token_if_authenticated", formContent);
+            Assert.NotNull(capturedFormContent);
+            Assert.Contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer", capturedFormContent);
+            Assert.Contains($"assertion={testToken}", capturedFormContent);
+            Assert.Contains("scope=sql", capturedFormContent);
+            Assert.Contains($"identity_federation_client_id={clientId}", capturedFormContent);
+            Assert.DoesNotContain("return_original_token_if_authenticated", capturedFormContent);
         }
 
         [Fact]
@@ -509,13 +528,21 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             };
 
             HttpRequestMessage? capturedRequest = null;
+            string? capturedFormContent = null;
 
             _mockHttpMessageHandler.Protected()
                 .Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
+                .Callback<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+                {
+                    capturedRequest = req;
+                    if (req.Content != null)
+                    {
+                        capturedFormContent = await req.Content.ReadAsStringAsync();
+                    }
+                })
                 .ReturnsAsync(httpResponseMessage);
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
@@ -524,10 +551,9 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
 
             Assert.NotNull(result);
             Assert.NotNull(capturedRequest);
-            Assert.NotNull(capturedRequest.Content);
-            var formContent = await capturedRequest.Content.ReadAsStringAsync();
-            Assert.Contains("return_original_token_if_authenticated=true", formContent);
-            Assert.DoesNotContain("identity_federation_client_id", formContent);
+            Assert.NotNull(capturedFormContent);
+            Assert.Contains("return_original_token_if_authenticated=true", capturedFormContent);
+            Assert.DoesNotContain("identity_federation_client_id", capturedFormContent);
         }
 
         [Fact]

--- a/csharp/test/Drivers/Databricks/Unit/Auth/TokenExchangeClientTests.cs
+++ b/csharp/test/Drivers/Databricks/Unit/Auth/TokenExchangeClientTests.cs
@@ -129,15 +129,15 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+                .Returns<HttpRequestMessage, CancellationToken>(async (req, ct) =>
                 {
                     capturedRequest = req;
                     if (req.Content != null)
                     {
                         capturedFormContent = await req.Content.ReadAsStringAsync();
                     }
-                })
-                .ReturnsAsync(httpResponseMessage);
+                    return httpResponseMessage;
+                });
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
@@ -433,15 +433,15 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+                .Returns<HttpRequestMessage, CancellationToken>(async (req, ct) =>
                 {
                     capturedRequest = req;
                     if (req.Content != null)
                     {
                         capturedFormContent = await req.Content.ReadAsStringAsync();
                     }
-                })
-                .ReturnsAsync(httpResponseMessage);
+                    return httpResponseMessage;
+                });
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
@@ -484,15 +484,15 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+                .Returns<HttpRequestMessage, CancellationToken>(async (req, ct) =>
                 {
                     capturedRequest = req;
                     if (req.Content != null)
                     {
                         capturedFormContent = await req.Content.ReadAsStringAsync();
                     }
-                })
-                .ReturnsAsync(httpResponseMessage);
+                    return httpResponseMessage;
+                });
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
@@ -535,15 +535,15 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback<HttpRequestMessage, CancellationToken>(async (req, ct) =>
+                .Returns<HttpRequestMessage, CancellationToken>(async (req, ct) =>
                 {
                     capturedRequest = req;
                     if (req.Content != null)
                     {
                         capturedFormContent = await req.Content.ReadAsStringAsync();
                     }
-                })
-                .ReturnsAsync(httpResponseMessage);
+                    return httpResponseMessage;
+                });
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
@@ -601,8 +601,12 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
                     ItExpr.IsAny<CancellationToken>())
-                .Callback<HttpRequestMessage, CancellationToken>((req, ct) => capturedRequest = req)
-                .ReturnsAsync(httpResponseMessage);
+                .Returns<HttpRequestMessage, CancellationToken>((req, ct) =>
+                {
+                    capturedRequest = req;
+                    return Task.FromResult(httpResponseMessage);
+                });
+
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
 

--- a/csharp/test/Drivers/Databricks/Unit/Auth/TokenExchangeClientTests.cs
+++ b/csharp/test/Drivers/Databricks/Unit/Auth/TokenExchangeClientTests.cs
@@ -85,7 +85,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
-            var result = await client.ExchangeTokenAsync(testToken, CancellationToken.None);
+            var result = await client.RefreshTokenAsync(testToken, CancellationToken.None);
 
             Assert.NotNull(result);
             Assert.Equal(expectedAccessToken, result.AccessToken);
@@ -123,7 +123,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
-            await client.ExchangeTokenAsync(testToken, CancellationToken.None);
+            await client.RefreshTokenAsync(testToken, CancellationToken.None);
 
             Assert.NotNull(capturedRequest);
             Assert.Equal(HttpMethod.Post, capturedRequest.Method);
@@ -157,7 +157,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
             await Assert.ThrowsAsync<HttpRequestException>(() =>
-                client.ExchangeTokenAsync(testToken, CancellationToken.None));
+                client.RefreshTokenAsync(testToken, CancellationToken.None));
         }
 
         [Fact]
@@ -185,7 +185,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
             var exception = await Assert.ThrowsAsync<DatabricksException>(() =>
-                client.ExchangeTokenAsync(testToken, CancellationToken.None));
+                client.RefreshTokenAsync(testToken, CancellationToken.None));
 
             Assert.Contains("access_token", exception.Message);
         }
@@ -216,7 +216,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
             var exception = await Assert.ThrowsAsync<DatabricksException>(() =>
-                client.ExchangeTokenAsync(testToken, CancellationToken.None));
+                client.RefreshTokenAsync(testToken, CancellationToken.None));
 
             Assert.Contains("access_token was null or empty", exception.Message);
         }
@@ -246,7 +246,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
             var exception = await Assert.ThrowsAsync<DatabricksException>(() =>
-                client.ExchangeTokenAsync(testToken, CancellationToken.None));
+                client.RefreshTokenAsync(testToken, CancellationToken.None));
 
             Assert.Contains("token_type", exception.Message);
         }
@@ -276,7 +276,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
             var exception = await Assert.ThrowsAsync<DatabricksException>(() =>
-                client.ExchangeTokenAsync(testToken, CancellationToken.None));
+                client.RefreshTokenAsync(testToken, CancellationToken.None));
 
             Assert.Contains("expires_in", exception.Message);
         }
@@ -307,7 +307,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
             var exception = await Assert.ThrowsAsync<DatabricksException>(() =>
-                client.ExchangeTokenAsync(testToken, CancellationToken.None));
+                client.RefreshTokenAsync(testToken, CancellationToken.None));
 
             Assert.Contains("expires_in value must be positive", exception.Message);
         }
@@ -333,7 +333,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
             await Assert.ThrowsAnyAsync<JsonException>(() =>
-                client.ExchangeTokenAsync(testToken, CancellationToken.None));
+                client.RefreshTokenAsync(testToken, CancellationToken.None));
         }
 
         [Fact]
@@ -353,7 +353,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
             await Assert.ThrowsAsync<TaskCanceledException>(() =>
-                client.ExchangeTokenAsync(testToken, cts.Token));
+                client.RefreshTokenAsync(testToken, cts.Token));
         }
 
         [Fact]
@@ -384,7 +384,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
 
             var client = new TokenExchangeClient(_httpClient, _testHost);
 
-            var result = await client.ExchangeTokenAsync(testToken, CancellationToken.None);
+            var result = await client.RefreshTokenAsync(testToken, CancellationToken.None);
             var afterCall = DateTime.UtcNow;
 
             var expectedMinExpiry = beforeCall.AddSeconds(expiresIn);

--- a/csharp/test/Drivers/Databricks/Unit/Auth/TokenRefreshDelegatingHandlerTests.cs
+++ b/csharp/test/Drivers/Databricks/Unit/Auth/TokenRefreshDelegatingHandlerTests.cs
@@ -109,7 +109,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             Assert.Equal(_initialToken, capturedRequest.Headers.Authorization?.Parameter);
 
             // Wait for background task to complete
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
             _mockTokenExchangeClient.Verify(
                 x => x.RefreshTokenAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
@@ -177,7 +177,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             Assert.Equal(_initialToken, capturedRequest.Headers.Authorization?.Parameter); // First request uses original token
 
             // Wait a bit for the background task to complete
-            await Task.Delay(tokenExchangeDelay + TimeSpan.FromMilliseconds(100));
+            await Task.Delay(tokenExchangeDelay + TimeSpan.FromMilliseconds(1000));
 
             // Make a second request - this should use the new token
             var request2 = new HttpRequestMessage(HttpMethod.Get, "https://example.com/2");
@@ -241,7 +241,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             Assert.Equal(_initialToken, capturedRequest.Headers.Authorization?.Parameter); // Should still use original token
 
             // Wait for background task to complete
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
             var request2 = new HttpRequestMessage(HttpMethod.Get, "https://example.com/2");
             HttpRequestMessage? capturedRequest2 = null;
@@ -304,7 +304,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://example.com/1"));
 
             // Wait for background renewal to complete
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
             // Make second request
             await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, "https://example.com/2"));
@@ -366,7 +366,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             await Task.WhenAll(tasks);
 
             // Wait for any background token renewal to complete
-            await Task.Delay(300);
+            await Task.Delay(1000);
 
             // Token exchange should only be called once despite concurrent requests
             _mockTokenExchangeClient.Verify(
@@ -500,7 +500,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             await httpClient.SendAsync(request);
 
             // Wait for background renewal to complete
-            await Task.Delay(100);
+            await Task.Delay(1000);
 
             _mockTokenExchangeClient.Verify(
                 x => x.RefreshTokenAsync(_initialToken, It.IsAny<CancellationToken>()),

--- a/csharp/test/Drivers/Databricks/Unit/Auth/TokenRefreshDelegatingHandlerTests.cs
+++ b/csharp/test/Drivers/Databricks/Unit/Auth/TokenRefreshDelegatingHandlerTests.cs
@@ -25,7 +25,7 @@ using Moq;
 using Moq.Protected;
 using Xunit;
 
-namespace Apache.Arrow.Adbc.Drivers.Databricks.Tests.Auth
+namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
 {
     public class TokenRefreshDelegatingHandlerTests : IDisposable
     {


### PR DESCRIPTION
## Motivation

Databricks will eventually require that all non-inhouse OAuth tokens be exchanged for Databricks OAuth tokens before accessing resources. This change implements mandatory token exchange before sending Thrift requests. This check and exchange is performed in the background for now to reduce latency, but it will eventually need to be blocking if non-inhouse OAuth tokens will fail to access Databricks resources in the future. 

## Key Components

  1. JWT Token Decoder - Decodes JWT tokens to inspect the issuer claim and determine if token exchange is necessary
  2. MandatoryTokenExchangeDelegatingHandler - HTTP handler that intercepts requests and performs token exchange when required
  3. TokenExchangeClient - Handles the token exchange logic with the same /oidc/v1/token endpoint as token refresh, with slightly different parameters

## Changes

  - Added new connection string parameter: IdentityFederationClientId for service principal workload identity federation scenarios
  - Implemented token exchange logic that checks JWT issuer against workspace host
  - Introduced fallback behavior to maintain backward compatibility if token exchange fails

## Testing
`dotnet test --filter "FullyQualifiedName~MandatoryTokenExchangeDelegatingHandlerTests"`

```
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.1+bf6400fd51 (64-bit .NET 8.0.7)
[xUnit.net 00:00:00.06]   Discovering: Apache.Arrow.Adbc.Tests.Drivers.Databricks
[xUnit.net 00:00:00.15]   Discovered:  Apache.Arrow.Adbc.Tests.Drivers.Databricks
[xUnit.net 00:00:00.16]   Starting:    Apache.Arrow.Adbc.Tests.Drivers.Databricks
[xUnit.net 00:00:01.77]   Finished:    Apache.Arrow.Adbc.Tests.Drivers.Databricks
  Apache.Arrow.Adbc.Tests.Drivers.Databricks test net8.0 succeeded (2.6s)

Test summary: total: 11, failed: 0, succeeded: 11, skipped: 0, duration: 2.6s
```

`dotnet test --filter "FullyQualifiedName~TokenExchangeClientTests"`

```
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.1+bf6400fd51 (64-bit .NET 8.0.7)
[xUnit.net 00:00:00.06]   Discovering: Apache.Arrow.Adbc.Tests.Drivers.Databricks
[xUnit.net 00:00:00.14]   Discovered:  Apache.Arrow.Adbc.Tests.Drivers.Databricks
[xUnit.net 00:00:00.15]   Starting:    Apache.Arrow.Adbc.Tests.Drivers.Databricks
[xUnit.net 00:00:00.23]   Finished:    Apache.Arrow.Adbc.Tests.Drivers.Databricks
  Apache.Arrow.Adbc.Tests.Drivers.Databricks test net8.0 succeeded (0.8s)

Test summary: total: 19, failed: 0, succeeded: 19, skipped: 0, duration: 0.8s
```

`dotnet test --filter "FullyQualifiedName~JwtTokenDecoderTests"`

```
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.1+bf6400fd51 (64-bit .NET 8.0.7)
[xUnit.net 00:00:00.06]   Discovering: Apache.Arrow.Adbc.Tests.Drivers.Databricks
[xUnit.net 00:00:00.14]   Discovered:  Apache.Arrow.Adbc.Tests.Drivers.Databricks
[xUnit.net 00:00:00.15]   Starting:    Apache.Arrow.Adbc.Tests.Drivers.Databricks
[xUnit.net 00:00:00.19]   Finished:    Apache.Arrow.Adbc.Tests.Drivers.Databricks
  Apache.Arrow.Adbc.Tests.Drivers.Databricks test net8.0 succeeded (0.8s)

Test summary: total: 10, failed: 0, succeeded: 10, skipped: 0, duration: 0.8s
```

Also tested E2E manually with AAD tokens for Azure Databricks workspaces, AAD tokens for AWS Databricks workspaces, and service principal workload identity federation tokens