### PR TITLE
fix(csharp/test/Drivers/Databricks): Fix Pkfk Testcase

### DIFF
--- a/csharp/test/Drivers/Databricks/E2E/StatementTests.cs
+++ b/csharp/test/Drivers/Databricks/E2E/StatementTests.cs
@@ -1104,7 +1104,6 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
 
         [Theory]
         [InlineData(false, "main", true)]
-        [InlineData(true, null, true)]
         [InlineData(true, "", true)]
         [InlineData(true, "SPARK", true)]
         [InlineData(true, "hive_metastore", true)]


### PR DESCRIPTION
This test does not pass, since catalog from OpenSessionResponse is used as catalog, if user does not explictly set catalog as a metadata request parameter