### PR TITLE
feat(csharp/src/Apache.Arrow.Adbc/Tracing): allow ActivitySource tags to be set from TracingConnection

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/Tracing/ActivityTrace.cs
+++ b/csharp/src/Apache.Arrow.Adbc/Tracing/ActivityTrace.cs
@@ -16,8 +16,8 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
@@ -33,8 +33,11 @@ namespace Apache.Arrow.Adbc.Tracing
         /// Constructs a new <see cref="ActivityTrace"/> object. If <paramref name="activitySourceName"/> is set, it provides the
         /// activity source name, otherwise the current assembly name is used as the activity source name.
         /// </summary>
-        /// <param name="activitySourceName"></param>
-        public ActivityTrace(string? activitySourceName = default, string? activitySourceVersion = default, string? traceParent = default)
+        /// <param name="activitySourceName">The name of the ActivitySource object</param>
+        /// <param name="activitySourceVersion">The version of the component publishing the tracing info.</param>
+        /// <param name="traceParent">The trace parent context, which is used to link the activity to a distributed trace.</param>
+        /// <param name="tags">The tags associated with the activity.</param>
+        public ActivityTrace(string? activitySourceName = default, string? activitySourceVersion = default, string? traceParent = default, IEnumerable<KeyValuePair<string, object?>>? tags = default)
         {
             activitySourceName ??= GetType().Assembly.GetName().Name!;
             // It's okay to have a null version.
@@ -46,7 +49,7 @@ namespace Apache.Arrow.Adbc.Tracing
 
             TraceParent = traceParent;
             // This is required to be disposed
-            ActivitySource = new(activitySourceName, activitySourceVersion);
+            ActivitySource = new(activitySourceName, activitySourceVersion, tags);
         }
 
         /// <summary>

--- a/csharp/src/Apache.Arrow.Adbc/Tracing/TracingConnection.cs
+++ b/csharp/src/Apache.Arrow.Adbc/Tracing/TracingConnection.cs
@@ -27,7 +27,7 @@ namespace Apache.Arrow.Adbc.Tracing
         protected TracingConnection(IReadOnlyDictionary<string, string> properties)
         {
             properties.TryGetValue(AdbcOptions.Telemetry.TraceParent, out string? traceParent);
-            _trace = new ActivityTrace(this.AssemblyName, this.AssemblyVersion, traceParent);
+            _trace = new ActivityTrace(AssemblyName, AssemblyVersion, traceParent, GetActivitySourceTags(properties));
         }
 
         string? IActivityTracer.TraceParent => _trace.TraceParent;
@@ -37,6 +37,13 @@ namespace Apache.Arrow.Adbc.Tracing
         public abstract string AssemblyVersion { get; }
 
         public abstract string AssemblyName { get; }
+
+        public string ActivitySourceName => _trace.ActivitySourceName;
+
+        public virtual IEnumerable<KeyValuePair<string, object?>>? GetActivitySourceTags(IReadOnlyDictionary<string, string> properties)
+        {
+            return null;
+        }
 
         protected void SetTraceParent(string? traceParent)
         {

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -76,6 +76,15 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             ValidateProperties();
         }
 
+        public override IEnumerable<KeyValuePair<string, object?>>? GetActivitySourceTags(IReadOnlyDictionary<string, string> properties)
+        {
+            IEnumerable<KeyValuePair<string, object?>>? tags = base.GetActivitySourceTags(properties);
+            // TODO: Add any additional tags specific to Databricks connection
+            //tags ??= [];
+            //tags.Concat([new("key", "value")]);
+            return tags;
+        }
+
         protected override TCLIService.IAsync CreateTCLIServiceClient(TProtocol protocol)
         {
             return new ThreadSafeClient(new TCLIService.Client(protocol));


### PR DESCRIPTION
Provides an virtual override for `GetActivitySourceTags(properties)` to retrieve tags when creating the `ActivitySource`. 
Also adds the ActivitySourceName property so an `ActivityListener` can create a useful filter.