### PR TITLE
fix(csharp/src/Drivers/Databricks): Add another fallback check of GetColumnsExtendedAsync

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksStatement.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksStatement.cs
@@ -578,9 +578,10 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             {
                 descResult = await descStmt.ExecuteQueryAsync();
             }
-            catch (HiveServer2Exception ex) when (ex.SqlState == "42601")
+            catch (HiveServer2Exception ex) when (ex.SqlState == "42601" || ex.SqlState == "20000")
             {
                 // 42601 is error code of syntax error, which this command (DESC TABLE EXTENDED ... AS JSON) is not supported by current DBR
+                // Sometimes server may also return 20000 (internal error) if it fails to convert some data types of the table columns
                 // So we should fallback to base implementation
                 Debug.WriteLine($"[WARN] Failed to run {query} (reason={ex.Message}). Fallback to base::GetColumnsExtendedAsync.");
                 return await base.GetColumnsExtendedAsync(cancellationToken);


### PR DESCRIPTION
## Motivation

Sometimes Databricks DBR or SQL warehouse fails to execute `DESC TABLE EXTENDED` due to some internal error on data type parsing and returns SQL State `20000 `. In this case, we also want to fallback to the `HiveStatement2.GetColumnsExtendedAsync`

## Change
Add the fallback condition check on `SqlState==20000` in `Databricks GetColumnsExtendedAsync`

## Testing
- E2E test
