### PR TITLE
docs: clarify relationship specification.rst to adbc.h

### DIFF
--- a/docs/source/format/specification.rst
+++ b/docs/source/format/specification.rst
@@ -19,13 +19,17 @@
 ADBC API Standard
 =================
 
-This document summarizes the general featureset.
+This document summarizes the general featureset of the ADBC API and should be considered informative only.
+
+For authoritative definitions of the ADBC API, refer to the following sources:
 
 - For C/C++ details, see :external+cpp_adbc:doc:`adbc.h`.
 - For Go details, see the `source <https://github.com/apache/arrow-adbc/blob/main/go/adbc/adbc.go>`__.
 - For Java details, see the `source
   <https://github.com/apache/arrow-adbc/tree/main/java/core>`__, particularly
   the package :jpackage:`org.apache.arrow.adbc.core`.
+
+:external+cpp_adbc:doc:`adbc.h`. is considered canonical.
 
 Databases
 =========


### PR DESCRIPTION
Clarifies the relation between this document and the authoritative definition of the ADBC API.