### PR TITLE
fix(csharp/src/Drivers/Databricks): Set enable_run_async_thrift default true

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -43,7 +43,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         private bool _enableDirectResults = true;
         private bool _enableMultipleCatalogSupport = true;
         private bool _enablePKFK = true;
-        private bool _runAsyncInThrift = false;
+        private bool _runAsyncInThrift = true;
 
         internal static TSparkGetDirectResults defaultGetDirectResults = new()
         {

--- a/csharp/src/Drivers/Databricks/DatabricksParameters.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksParameters.cs
@@ -182,7 +182,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 
         /// <summary>
         /// Whether to enable RunAsync flag in Thrift operation
-        /// Default value is false if not specified.
+        /// Default value is true if not specified.
         /// </summary>
         public const string EnableRunAsyncInThriftOp = "adbc.databricks.enable_run_async_thrift";
 


### PR DESCRIPTION
## Motivation

In PR https://github.com/apache/arrow-adbc/pull/3171, `RunAsync` option in `TExecuteStatementReq` was added and exposed via connection parameter `adbc.databricks.enable_run_async_thrift`, but it is not enabled by default. This is turned on by default in other Databricks drivers, we should turn in on by default in ADBC as well.

## Change
- Set `DatabricksConnection:_runAsyncInThrift` default value to `true`

## Test
- PBI PQTest with all the test cases