### PR TITLE
fix(c/driver_manager): use Driver.entrypoint as per docs

### DIFF
--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -253,7 +253,7 @@ AdbcStatusCode LoadDriverManifest(const std::filesystem::path& driver_manifest,
 
   info.manifest_file = driver_manifest.string();
   info.driver_name = config["name"].value_or(""s);
-  info.entrypoint = config["entrypoint"].value_or(""s);
+  info.entrypoint = config.at_path("Driver.entrypoint").value_or(""s);
   info.version = config["version"].value_or(""s);
   info.source = config["source"].value_or(""s);
 

--- a/c/driver_manager/adbc_driver_manager_test.cc
+++ b/c/driver_manager/adbc_driver_manager_test.cc
@@ -526,6 +526,25 @@ TEST_F(DriverManifest, DisallowEnvConfig) {
   UnsetConfigPath();
 }
 
+TEST_F(DriverManifest, ConfigEntrypoint) {
+  // Override the entrypoint in the manifest
+  simple_manifest.insert("Driver", toml::table{
+                                       {"entrypoint", "BadEntrypointSymbolName"},
+                                   });
+
+  auto filepath = temp_dir / "sqlite.toml";
+  std::ofstream test_manifest_file(filepath);
+  ASSERT_TRUE(test_manifest_file.is_open());
+  test_manifest_file << simple_manifest;
+  test_manifest_file.close();
+
+  ASSERT_THAT(AdbcFindLoadDriver(filepath.string().data(), nullptr, ADBC_VERSION_1_1_0,
+                                 ADBC_LOAD_FLAG_DEFAULT, &driver, &error),
+              Not(IsOkStatus(&error)));
+
+  ASSERT_TRUE(std::filesystem::remove(filepath));
+}
+
 TEST_F(DriverManifest, LoadAbsolutePath) {
   auto filepath = temp_dir / "sqlite.toml";
   std::ofstream test_manifest_file(filepath);

--- a/go/adbc/drivermgr/adbc_driver_manager.cc
+++ b/go/adbc/drivermgr/adbc_driver_manager.cc
@@ -253,7 +253,7 @@ AdbcStatusCode LoadDriverManifest(const std::filesystem::path& driver_manifest,
 
   info.manifest_file = driver_manifest.string();
   info.driver_name = config["name"].value_or(""s);
-  info.entrypoint = config["entrypoint"].value_or(""s);
+  info.entrypoint = config.at_path("Driver.entrypoint").value_or(""s);
   info.version = config["version"].value_or(""s);
   info.source = config["source"].value_or(""s);
 


### PR DESCRIPTION
As per the [docs](https://arrow.apache.org/adbc/main/format/driver_manifests.html#manifest-structure) the Driver manifest allows overriding the `entrypoint` via the `Driver.entrypoint` key. Rust follows this properly, but C++ checks for a top-level key named `entrypoint` instead of following the docs. This PR fixes this so that the C++ driver manager correctly looks for `Driver.entrypoint`.