### PR TITLE
refactor(rust)!: not to mark enums as `non_exhaustive` except for the `AdbcVersion`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -158,11 +158,12 @@ jobs:
           echo "ADBC_DRIVER_MANAGER_TEST_LIB=${{ github.workspace }}/local/bin/adbc_driver_sqlite.dll" >> "$GITHUB_ENV"
       - name: Set search dir for Snowflake Go lib
         run: echo "ADBC_SNOWFLAKE_GO_LIB_DIR=${{ github.workspace }}/local/lib" >> "$GITHUB_ENV"
-      - name: Clippy
+      - name: Clippy (nightly)
         if: ${{ ! matrix.minimal-versions }}
         working-directory: rust
         run: |
-          cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings
+          rustup toolchain install nightly
+          cargo +nightly clippy --workspace --all-targets --all-features --locked -- -Dwarnings -Zcrate-attr='feature(non_exhaustive_omitted_patterns_lint)'
       - name: Test
         working-directory: rust
         # TODO: enable snowflake tests on windows

--- a/rust/core/src/error.rs
+++ b/rust/core/src/error.rs
@@ -24,7 +24,6 @@ use arrow_schema::ArrowError;
 
 /// Status of an operation.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[non_exhaustive]
 pub enum Status {
     /// No error.
     Ok,

--- a/rust/core/src/options.rs
+++ b/rust/core/src/options.rs
@@ -27,7 +27,6 @@ use crate::{
 ///
 /// Can be created with various implementations of [From].
 #[derive(Debug, Clone)]
-#[non_exhaustive]
 pub enum OptionValue {
     String(String),
     Bytes(Vec<u8>),
@@ -150,7 +149,6 @@ impl FromStr for AdbcVersion {
 
 /// Info codes for database/driver metadata.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[non_exhaustive]
 pub enum InfoCode {
     /// The database vendor/product name (type: utf8).
     VendorName,
@@ -232,7 +230,6 @@ impl TryFrom<u32> for InfoCode {
 
 /// Depth parameter for [get_objects][crate::Connection::get_objects] method.
 #[derive(Debug)]
-#[non_exhaustive]
 pub enum ObjectDepth {
     /// Catalogs, schemas, tables, and columns.
     All,
@@ -277,7 +274,6 @@ impl TryFrom<c_int> for ObjectDepth {
 
 /// Database option key.
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
-#[non_exhaustive]
 pub enum OptionDatabase {
     /// Canonical option key for URIs.
     ///
@@ -325,7 +321,6 @@ impl From<&str> for OptionDatabase {
 
 /// Connection option key.
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
-#[non_exhaustive]
 pub enum OptionConnection {
     /// Whether autocommit is enabled.
     AutoCommit,
@@ -373,7 +368,6 @@ impl From<&str> for OptionConnection {
 
 /// Statement option key.
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
-#[non_exhaustive]
 pub enum OptionStatement {
     /// The ingest mode for a bulk insert. See [IngestMode].
     IngestMode,
@@ -462,7 +456,6 @@ impl From<&str> for OptionStatement {
 
 /// Isolation level value for key [OptionConnection::IsolationLevel].
 #[derive(Debug)]
-#[non_exhaustive]
 pub enum IsolationLevel {
     /// Use database or driver default isolation level.
     Default,
@@ -538,7 +531,6 @@ impl From<IsolationLevel> for OptionValue {
 
 /// Ingestion mode value for key [OptionStatement::IngestMode].
 #[derive(Debug)]
-#[non_exhaustive]
 pub enum IngestMode {
     /// Create the table and insert data; error if the table exists.
     Create,
@@ -581,7 +573,6 @@ impl From<IngestMode> for OptionValue {
 
 /// Statistics about the data distribution.
 #[derive(Debug, Clone)]
-#[non_exhaustive]
 pub enum Statistics {
     /// The average byte width statistic. The average size in bytes of a row in
     /// the column. Value type is `float64`. For example, this is roughly the

--- a/rust/driver/snowflake/src/database/builder.rs
+++ b/rust/driver/snowflake/src/database/builder.rs
@@ -40,7 +40,6 @@ use crate::{
 
 /// Authentication types.
 #[derive(Copy, Clone, Debug, Default)]
-#[non_exhaustive]
 pub enum AuthType {
     /// General username password authentication
     #[default]
@@ -103,7 +102,6 @@ impl str::FromStr for AuthType {
 
 /// Protocol types.
 #[derive(Copy, Clone, Debug, Default)]
-#[non_exhaustive]
 pub enum Protocol {
     /// Use `https`.
     #[default]
@@ -146,7 +144,6 @@ impl str::FromStr for Protocol {
 
 /// Log levels.
 #[derive(Copy, Clone, Debug, Default)]
-#[non_exhaustive]
 pub enum LogLevel {
     /// Trace level
     Trace,


### PR DESCRIPTION
As discussed in #3197, enums should not be marked as `non_exhaustive` because they are unlikely to be expanded in the future without breaking changes.

The exception is `AdbcVersion`, but on our side, if this is extended we have to make sure to change adbc_driver_manager as well, so we also have to run the unstable `non_exhaustive_omitted_patterns` lint with nightly toolchain.