### PR TITLE
fix(c/driver_manager): Make DriverManifest::SetUp more resilient

### DIFF
--- a/c/driver_manager/adbc_driver_manager_test.cc
+++ b/c/driver_manager/adbc_driver_manager_test.cc
@@ -417,7 +417,9 @@ class DriverManifest : public ::testing::Test {
     auto temp_path = std::filesystem::temp_directory_path();
     temp_path /= "adbc_driver_manager_test";
 
-    ASSERT_TRUE(std::filesystem::create_directories(temp_path));
+    if (!std::filesystem::exists(temp_path)) {
+      ASSERT_TRUE(std::filesystem::create_directories(temp_path));
+    }
     temp_dir = temp_path;
 #endif
   }


### PR DESCRIPTION
This fixes an occasional issue with the SetUp block of the DriverManifest fixture. At least on my macOS system, if a previous test runs fails before running TearDown, SetUp would fail on this assertion. This changes the SetUp behavior so it re-uses the temporary directory.