### PR TITLE
fix(rust/driver_manager): modify SYSTEM path behavior on macOS

### DIFF
--- a/rust/driver_manager/src/lib.rs
+++ b/rust/driver_manager/src/lib.rs
@@ -1774,7 +1774,11 @@ fn get_search_paths(lvls: LoadFlags) -> Vec<PathBuf> {
     // system level for windows is to search the registry keys
     #[cfg(not(windows))]
     if lvls & LOAD_FLAG_SEARCH_SYSTEM != 0 {
+        #[cfg(target_os = "macos")]
+        let system_config_dir = PathBuf::from("/Library/Application Support/ADBC");
+        #[cfg(not(target_os = "macos"))]
         let system_config_dir = PathBuf::from("/etc/adbc");
+
         if system_config_dir.exists() {
             result.push(system_config_dir);
         }
@@ -2184,7 +2188,11 @@ mod tests {
     #[test]
     #[cfg_attr(not(windows), ignore)]
     fn test_get_search_paths() {
+        #[cfg(target_os = "macos")]
+        let system_path = PathBuf::from("/Library/Application Support/ADBC");
+        #[cfg(not(target_os = "macos"))]
         let system_path = PathBuf::from("/etc/adbc");
+
         let search_paths = get_search_paths(LOAD_FLAG_SEARCH_SYSTEM);
         if system_path.exists() {
             assert_eq!(search_paths, vec![system_path]);

--- a/rust/driver_manager/src/lib.rs
+++ b/rust/driver_manager/src/lib.rs
@@ -1753,6 +1753,18 @@ fn user_config_dir() -> Option<PathBuf> {
     }
 }
 
+fn system_config_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(PathBuf::from("/Library/Application Support/ADBC"))
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        Some(PathBuf::from("/etc/adbc"))
+    }
+}
+
 fn get_search_paths(lvls: LoadFlags) -> Vec<PathBuf> {
     let mut result = Vec::new();
     if lvls & LOAD_FLAG_SEARCH_ENV != 0 {
@@ -1774,13 +1786,10 @@ fn get_search_paths(lvls: LoadFlags) -> Vec<PathBuf> {
     // system level for windows is to search the registry keys
     #[cfg(not(windows))]
     if lvls & LOAD_FLAG_SEARCH_SYSTEM != 0 {
-        #[cfg(target_os = "macos")]
-        let system_config_dir = PathBuf::from("/Library/Application Support/ADBC");
-        #[cfg(not(target_os = "macos"))]
-        let system_config_dir = PathBuf::from("/etc/adbc");
-
-        if system_config_dir.exists() {
-            result.push(system_config_dir);
+        if let Some(path) = system_config_dir() {
+            if path.exists() {
+                result.push(path);
+            }
         }
     }
 

--- a/rust/driver_manager/src/lib.rs
+++ b/rust/driver_manager/src/lib.rs
@@ -1763,6 +1763,11 @@ fn system_config_dir() -> Option<PathBuf> {
     {
         Some(PathBuf::from("/etc/adbc"))
     }
+
+    #[cfg(not(unix))]
+    {
+        None
+    }
 }
 
 fn get_search_paths(lvls: LoadFlags) -> Vec<PathBuf> {


### PR DESCRIPTION
Replicates the change in https://github.com/apache/arrow-adbc/pull/3250 to the Rust Driver Manager. Follow-on to #3247 

Modifies the behavior of GetSearchPaths so macOS doesn't follow other Unix-likes but instead uses the more conventional /Library/Application Support/ADBC. /etc/ isn't really a thing on macOS.

Tested manually by debugging the test with and without `/Library/Application Support/ADBC` existing and verifying the right branch gets hit. I'm not too worried exercising this in CI but we could.