### PR TITLE
ci(rust): fix build issue on macos

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,6 +131,7 @@ jobs:
             -DADBC_DRIVER_SNOWFLAKE=ON \
             -DADBC_USE_ASAN=OFF \
             -DADBC_USE_UBSAN=OFF \
+            -DADBC_SQLITE_COMPILE_DEFINES=-DADBC_SQLITE_WITH_NO_LOAD_EXTENSION \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=../local \
             ../c


### PR DESCRIPTION
It seems that CI has started to fail as a result of macos-latest changing from macos 14 to 15.

```log
 [ 65%] Building CXX object driver/sqlite/CMakeFiles/adbc_driver_sqlite_objlib.dir/sqlite.cc.o
/Users/runner/work/arrow-adbc/arrow-adbc/c/driver/sqlite/sqlite.cc:718:16: error: use of undeclared identifier 'sqlite3_load_extension'
  718 |       int rc = sqlite3_load_extension(conn_, extension_path_.c_str(),
      |                ^
1 error generated.
make[2]: *** [driver/sqlite/CMakeFiles/adbc_driver_sqlite_objlib.dir/sqlite.cc.o] Error 1
make[1]: *** [driver/sqlite/CMakeFiles/adbc_driver_sqlite_objlib.dir/all] Error 2
make: *** [all] Error 2
```

I don't know why this error is occurring, but it looks like it can be avoided by making a change like #1259.