### PR TITLE
feat(go/adbc/driver/bigquery): Add "adbc.bigquery.sql.location" param

### DIFF
--- a/go/adbc/driver/bigquery/bigquery_database.go
+++ b/go/adbc/driver/bigquery/bigquery_database.go
@@ -46,6 +46,7 @@ type databaseImpl struct {
 	// datasetID is the schema
 	datasetID string
 	tableID   string
+	location  string
 }
 
 func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
@@ -63,6 +64,7 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 		tableID:                    d.tableID,
 		catalog:                    d.projectID,
 		dbSchema:                   d.datasetID,
+		location:                   d.location,
 		resultRecordBufferSize:     defaultQueryResultBufferSize,
 		prefetchConcurrency:        defaultQueryPrefetchConcurrency,
 	}
@@ -94,6 +96,8 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 		return d.clientSecret, nil
 	case OptionStringAuthRefreshToken:
 		return d.refreshToken, nil
+	case OptionStringLocation:
+		return d.location, nil
 	case OptionStringProjectID:
 		return d.projectID, nil
 	case OptionStringDatasetID:
@@ -175,6 +179,8 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 		d.datasetID = value
 	case OptionStringTableID:
 		d.tableID = value
+	case OptionStringLocation:
+		d.location = value
 	default:
 		return d.DatabaseImplBase.SetOption(key, value)
 	}

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -57,6 +57,8 @@ type connectionImpl struct {
 	impersonateScopes          []string
 	impersonateLifetime        time.Duration
 
+	// the default location to use for all BigQuery requests
+	location string
 	// catalog is the same as the project id in BigQuery
 	catalog string
 	// dbSchema is the same as the dataset id in BigQuery
@@ -626,6 +628,10 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 	client, err := bigquery.NewClient(ctx, c.catalog, authOptions...)
 	if err != nil {
 		return err
+	}
+
+	if c.location != "" {
+		client.Location = c.location
 	}
 
 	err = client.EnableStorageReadClient(ctx, authOptions...)

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	OptionStringAuthType  = "adbc.bigquery.sql.auth_type"
+	OptionStringLocation  = "adbc.bigquery.sql.location"
 	OptionStringProjectID = "adbc.bigquery.sql.project_id"
 	OptionStringDatasetID = "adbc.bigquery.sql.dataset_id"
 	OptionStringTableID   = "adbc.bigquery.sql.table_id"

--- a/python/adbc_driver_bigquery/adbc_driver_bigquery/__init__.py
+++ b/python/adbc_driver_bigquery/adbc_driver_bigquery/__init__.py
@@ -52,6 +52,9 @@ class DatabaseOptions(enum.Enum):
     AUTH_CLIENT_SECRET = "adbc.bigquery.sql.auth.client_secret"
     AUTH_REFRESH_TOKEN = "adbc.bigquery.sql.auth.refresh_token"
 
+    #: Specify the location to use for bigquery connection.
+    LOCATION = "adbc.bigquery.sql.location"
+
     #: Specify the project ID to use for bigquery connection.
     PROJECT_ID = "adbc.bigquery.sql.project_id"
 


### PR DESCRIPTION
This commit adds a new `adbc.bigquery.sql.location` parameter to the BigQuery ADBC driver.

I piped it through the `databaseImpl`, down to the `connectionImpl` down to the actual BigQuery `Client`.

Since the Python driver links to the Go one, I also made it a possible connection parameter there.