### PR TITLE
fix(go/adbc/driver/bigquery): accept old auth option value

### DIFF
--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -581,7 +581,7 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 			}
 		}
 		authOptions = append(authOptions, option.WithTokenSource(c))
-	case OptionValueAuthTypeAppDefaultCredentials, "":
+	case OptionValueAuthTypeAppDefaultCredentials, OptionValueAuthTypeDefault, "":
 		// Use Application Default Credentials (default behavior)
 		// No additional options needed - ADC is used by default
 	default:


### PR DESCRIPTION
Fix a regression.