### PR TITLE
fix(csharp/src/Drivers/Databricks): [PECO-2396] Fix timestamp for dbr 6.6 - Set timestamp configuration on OpenSessionReq

### DIFF
--- a/csharp/src/Drivers/Apache/Spark/SparkConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkConnection.cs
@@ -35,11 +35,6 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
 
         internal static TSparkGetDirectResults sparkGetDirectResults = new TSparkGetDirectResults(1000);
 
-        internal static readonly Dictionary<string, string> timestampConfig = new Dictionary<string, string>
-        {
-            { "spark.thriftserver.arrowBasedRowSet.timestampAsString", "false" }
-        };
-
         internal SparkConnection(IReadOnlyDictionary<string, string> properties)
             : base(properties)
         {

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -47,6 +47,11 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         /// </summary>
         public const string DefaultConfigEnvironmentVariable = "DATABRICKS_CONFIG_FILE";
 
+        internal static readonly Dictionary<string, string> timestampConfig = new Dictionary<string, string>
+        {
+            { "spark.thriftserver.arrowBasedRowSet.timestampAsString", "false" },
+        };
+        
         private bool _applySSPWithQueries = false;
         private bool _enableDirectResults = true;
         private bool _enableMultipleCatalogSupport = true;
@@ -582,11 +587,15 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             {
                 req.InitialNamespace = _defaultNamespace;
             }
-
+            req.Configuration = new Dictionary<string, string>();
+            // merge timestampConfig with serverSideProperties
+            foreach (var kvp in timestampConfig)
+            {
+                req.Configuration[kvp.Key] = kvp.Value;
+            }
             // If not using queries to set server-side properties, include them in Configuration
             if (!_applySSPWithQueries)
             {
-                req.Configuration = new Dictionary<string, string>();
                 var serverSideProperties = GetServerSideProperties();
                 foreach (var property in serverSideProperties)
                 {

--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -51,7 +51,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         {
             { "spark.thriftserver.arrowBasedRowSet.timestampAsString", "false" },
         };
-        
         private bool _applySSPWithQueries = false;
         private bool _enableDirectResults = true;
         private bool _enableMultipleCatalogSupport = true;

--- a/csharp/src/Drivers/Databricks/DatabricksStatement.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksStatement.cs
@@ -97,10 +97,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
             statement.EnforceResultPersistenceMode = false;
             statement.CanReadArrowResult = true;
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            statement.ConfOverlay = SparkConnection.timestampConfig;
-#pragma warning restore CS0618 // Type or member is obsolete
-
             statement.UseArrowNativeTypes = new TSparkArrowTypes
             {
                 TimestampAsArrow = true,


### PR DESCRIPTION
### Motivation
ExecuteStatementReq only accepts configuration after dbr 7.0, so timestampasstring did not apply to dbr < 7.0. 

The fix is to move it to Session configuration where possible

### Testing
Verified it works by running StatementTests CanExecuteTimestampQuery on dbr 6.6 (fails before)