### PR TITLE
chore: split arrow and datafusion dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,18 @@ updates:
         update-types:
           - "version-update:semver-major"
   - package-ecosystem: "cargo"
+    directory: "/rust/driver/datafusion/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(rust): "
+    groups:
+      arrow-datafusion:
+        applies-to: version-updates
+        patterns:
+          - "arrow-*"
+          - "datafusion*"
+  - package-ecosystem: "cargo"
     directory: "/rust/"
     schedule:
       interval: "weekly"
@@ -68,7 +80,3 @@ updates:
         applies-to: version-updates
         patterns:
           - "arrow-*"
-      datafusion:
-        applies-to: version-updates
-        patterns:
-          - "datafusion*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,8 +64,11 @@ updates:
     commit-message:
       prefix: "chore(rust): "
     groups:
-      arrow-datafusion:
+      arrow:
         applies-to: version-updates
         patterns:
           - "arrow-*"
+      datafusion:
+        applies-to: version-updates
+        patterns:
           - "datafusion*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,7 +62,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(rust): "
+      prefix: "chore(rust/driver/datafusion): "
     groups:
       arrow-datafusion:
         applies-to: version-updates


### PR DESCRIPTION
e.g. https://github.com/apache/arrow-adbc/pull/3305 doesn't work because datafusion requires arrow 55.