### PR TITLE
fix(python/adbc_driver_manager): handle empty params in executemany

### DIFF
--- a/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
@@ -746,10 +746,16 @@ class Cursor(_Closeable):
             The query to execute.  Pass SQL queries as strings,
             (serialized) Substrait plans as bytes.
         seq_of_parameters
-            Parameters to bind.  Can be a list of Python sequences, or
-            an Arrow record batch, table, or record batch reader.  If
-            None, then the query will be executed once, else it will
-            be executed once per row.
+            Parameters to bind.  Can be a list of Python sequences, or an
+            Arrow record batch, table, or record batch reader.  If None, then
+            the query will be executed once, else it will be executed once per
+            row.  (That implies that an empty sequence is equivalent to not
+            executing the query at all.)
+
+        Notes
+        -----
+        Allowing ``None`` for parameters is outside of the DB-API
+        specification.
         """
         self._clear()
         if operation != self._last_query:
@@ -766,8 +772,23 @@ class Cursor(_Closeable):
         else:
             arrow_parameters = None
 
+        print(seq_of_parameters, arrow_parameters)
         if arrow_parameters is not None:
             self._bind(arrow_parameters)
+        elif seq_of_parameters is not None:
+            # arrow_parameters is None and seq_of_parameters is not None =>
+            # empty list or sequence
+
+            # NOTE(https://github.com/apache/arrow-adbc/issues/3319): If there
+            # are no parameters, don't do anything.  (We could give this to
+            # the driver to handle, but it's easier to do it here, especially
+            # in the case that Python objects are given - we would have to
+            # figure out the schema and create temporary Arrow data just to do
+            # nothing.)  Note that for C Data objects, we can't check the
+            # length so the driver might end up having to handle them after
+            # all.
+            return
+
         self._rowcount = _blocking_call(
             self._stmt.execute_update, (), {}, self._stmt.cancel
         )

--- a/python/adbc_driver_manager/tests/test_dbapi.py
+++ b/python/adbc_driver_manager/tests/test_dbapi.py
@@ -339,6 +339,38 @@ def test_executemany_parameters(sqlite, parameters):
 
 
 @pytest.mark.sqlite
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        [],
+        pyarrow.record_batch([[]], schema=pyarrow.schema([("v", pyarrow.int64())])),
+        pyarrow.table([[]], schema=pyarrow.schema([("v", pyarrow.int64())])),
+    ],
+)
+def test_executemany_empty(sqlite, parameters):
+    # Regression test for https://github.com/apache/arrow-adbc/issues/3319
+    with sqlite.cursor() as cur:
+        # With an empty sequence, it should be the same as not executing the
+        # query at all.
+        cur.execute("DROP TABLE IF EXISTS executemany")
+        cur.execute("CREATE TABLE executemany (v)")
+        cur.executemany("INSERT INTO executemany VALUES (?)", parameters)
+        cur.execute("SELECT * FROM executemany")
+        assert cur.fetchall() == []
+
+
+@pytest.mark.sqlite
+def test_executemany_none(sqlite):
+    # Regression test for https://github.com/apache/arrow-adbc/issues/3319
+    with sqlite.cursor() as cur:
+        # With None, it should be the same as executing the query once.
+        cur.execute("DROP TABLE IF EXISTS executemany")
+        cur.execute("CREATE TABLE executemany (v)")
+        with pytest.raises(sqlite.Error):
+            cur.executemany("INSERT INTO executemany VALUES (?)", None)
+
+
+@pytest.mark.sqlite
 def test_query_substrait(sqlite):
     with sqlite.cursor() as cur:
         with pytest.raises(dbapi.NotSupportedError):


### PR DESCRIPTION
Note that params in executemany is a sequence of parameter bindings (not parameters in and of themselves).

"Old" behavior of params:
None and `[]` are a no-op.

"Current" behavior:
None and `[]` are the same as executing without params.

"Fixed" behavior:
None is the same as executing without params.
`[]` is a no-op.

Closes #3319.