### PR TITLE
chore(java): bump `org.apache.derby:derby` to 10.15.2.0 (CVE-2022-46337)

### DIFF
--- a/java/driver/jdbc-validation-derby/pom.xml
+++ b/java/driver/jdbc-validation-derby/pom.xml
@@ -52,13 +52,13 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.14.2.0</version>
+      <version>10.15.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derbytools</artifactId>
-      <version>10.14.2.0</version>
+      <version>10.15.2.0</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
- https://github.com/apache/arrow-adbc/security/dependabot/12

https://github.com/apache/arrow-adbc/pull/1479 was closed before because we still had java 8 support. This was removed in https://github.com/apache/arrow-adbc/commit/12a74afdbad3ecb39cb12f6dee808aef9fdbd36a.