### PR TITLE
chore: revert split arrow and datafusion dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,25 +58,14 @@ updates:
         update-types:
           - "version-update:semver-major"
   - package-ecosystem: "cargo"
-    directory: "/rust/driver/datafusion/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "chore(rust/driver/datafusion): "
-    groups:
-      arrow-datafusion:
-        applies-to: version-updates
-        patterns:
-          - "arrow-*"
-          - "datafusion*"
-  - package-ecosystem: "cargo"
     directory: "/rust/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore(rust): "
     groups:
-      arrow:
+      arrow-datafusion:
         applies-to: version-updates
         patterns:
           - "arrow-*"
+          - "datafusion*"


### PR DESCRIPTION
Reverts apache/arrow-adbc#3328

Looks like it doesn't work https://github.com/apache/arrow-adbc/network/updates/1084373265:
```
Caused by:
  error inheriting `edition` from workspace root manifest's `workspace.package.edition`
```

I guess we'll just handle these bumps manually for now.