### PR TITLE
feat(rust): re-export `arrow-*` crates in `adbc_core`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -15,10 +15,6 @@ name = "adbc_datafusion"
 version = "0.20.0"
 dependencies = [
  "adbc_core",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
- "arrow-select",
  "datafusion",
  "datafusion-substrait",
  "prost",
@@ -30,8 +26,6 @@ name = "adbc_driver_manager"
 version = "0.20.0"
 dependencies = [
  "adbc_core",
- "arrow-array",
- "arrow-schema",
  "arrow-select",
  "libloading",
  "temp-env",
@@ -47,9 +41,7 @@ version = "0.20.0"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
- "arrow-array",
  "arrow-buffer",
- "arrow-schema",
  "arrow-select",
 ]
 
@@ -59,8 +51,6 @@ version = "0.20.0"
 dependencies = [
  "adbc_core",
  "adbc_driver_manager",
- "arrow-array",
- "arrow-schema",
  "dotenvy",
  "regex",
  "test-with",

--- a/rust/core/src/driver_exporter.rs
+++ b/rust/core/src/driver_exporter.rs
@@ -20,12 +20,18 @@ use std::ffi::{CStr, CString};
 use std::hash::Hash;
 use std::os::raw::{c_char, c_int, c_void};
 
-use arrow_array::ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema};
-use arrow_array::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
-use arrow_array::StructArray;
-use arrow_schema::DataType;
+use crate::{
+    arrow::{
+        arrow_array::{
+            ffi::{from_ffi, FFI_ArrowArray, FFI_ArrowSchema},
+            ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream},
+            StructArray,
+        },
+        arrow_schema::DataType,
+    },
+    error::{Error, Result, Status},
+};
 
-use crate::error::{Error, Result, Status};
 use crate::ffi::constants::ADBC_STATUS_OK;
 use crate::ffi::{
     types::ErrorPrivateData, FFI_AdbcConnection, FFI_AdbcDatabase, FFI_AdbcDriver, FFI_AdbcError,

--- a/rust/core/src/error.rs
+++ b/rust/core/src/error.rs
@@ -20,7 +20,7 @@
 use std::os::raw::c_char;
 use std::{ffi::NulError, fmt::Display};
 
-use arrow_schema::ArrowError;
+use crate::arrow::arrow_schema::ArrowError;
 
 /// Status of an operation.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/rust/core/src/ffi/methods.rs
+++ b/rust/core/src/ffi/methods.rs
@@ -19,8 +19,10 @@
 
 use std::os::raw::{c_char, c_int};
 
-use arrow_array::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
-use arrow_array::ffi_stream::FFI_ArrowArrayStream;
+use crate::arrow::arrow_array::{
+    ffi::{FFI_ArrowArray, FFI_ArrowSchema},
+    ffi_stream::FFI_ArrowArrayStream,
+};
 
 use super::{
     constants::ADBC_STATUS_NOT_IMPLEMENTED, FFI_AdbcConnection, FFI_AdbcDatabase, FFI_AdbcError,

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -66,10 +66,16 @@ pub mod ffi;
 pub mod options;
 pub mod schemas;
 
+/// Re-export `arrow-rs` crates used in `adbc_core`.
+pub mod arrow {
+    pub use arrow_array;
+    pub use arrow_schema;
+}
+
 use std::collections::HashSet;
 
-use arrow_array::{RecordBatch, RecordBatchReader};
-use arrow_schema::Schema;
+use self::arrow::arrow_array::{RecordBatch, RecordBatchReader};
+use self::arrow::arrow_schema::Schema;
 
 use error::Result;
 use options::{OptionConnection, OptionDatabase, OptionStatement, OptionValue};

--- a/rust/core/src/schemas.rs
+++ b/rust/core/src/schemas.rs
@@ -19,7 +19,7 @@
 
 use std::sync::{Arc, LazyLock};
 
-use arrow_schema::{DataType, Field, Schema, SchemaRef, UnionFields, UnionMode};
+use crate::arrow::arrow_schema::{DataType, Field, Schema, SchemaRef, UnionFields, UnionMode};
 
 /// Schema of the data returned by [get_table_types][crate::Connection::get_table_types].
 pub static GET_TABLE_TYPES_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {

--- a/rust/driver/datafusion/Cargo.toml
+++ b/rust/driver/datafusion/Cargo.toml
@@ -32,16 +32,10 @@ categories.workspace = true
 
 [dependencies]
 adbc_core.workspace = true
-arrow-array = "55.2.0"
-arrow-buffer = "55.2.0"
-arrow-schema = "55.2.0"
 datafusion = { version = "49.0.0", default-features = false }
 datafusion-substrait = { version = "49.0.0", default-features = false }
 tokio = { version = "1.47", features = ["rt-multi-thread"] }
 prost = "0.13.5"
-
-[dev-dependencies]
-arrow-select = "55.2.0"
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/rust/driver/datafusion/README.md
+++ b/rust/driver/datafusion/README.md
@@ -28,11 +28,11 @@
 ## Example Usage
 
 ```
+use adbc_core::arrow::arrow_array::RecordBatch;
 use adbc_core::driver_manager::ManagedDriver;
 use adbc_core::options::AdbcVersion;
 use adbc_core::{Connection, Database, Driver, Statement};
 use arrow_cast::pretty::print_batches;
-use arrow_array::RecordBatch;
 
 fn main() {
     let mut driver = ManagedDriver::load_dynamic_from_name(

--- a/rust/driver/datafusion/tests/test_datafusion.rs
+++ b/rust/driver/datafusion/tests/test_datafusion.rs
@@ -17,11 +17,11 @@
 
 use adbc_core::{Connection, Database, Driver, Optionable, Statement};
 use adbc_datafusion::{DataFusionConnection, DataFusionDriver};
-use arrow_array::RecordBatch;
+use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::compute::concat_batches;
 use datafusion::prelude::*;
 
 use adbc_core::options::{OptionConnection, OptionStatement, OptionValue};
-use arrow_select::concat::concat_batches;
 use datafusion_substrait::logical_plan::producer::to_substrait_plan;
 use datafusion_substrait::substrait::proto::Plan;
 use prost::Message;

--- a/rust/driver/dummy/Cargo.toml
+++ b/rust/driver/dummy/Cargo.toml
@@ -27,9 +27,7 @@ publish = false
 [dependencies]
 adbc_core.workspace = true
 adbc_driver_manager.workspace = true
-arrow-array.workspace = true
 arrow-buffer.workspace = true
-arrow-schema.workspace = true
 
 [dev-dependencies]
 arrow-select.workspace = true

--- a/rust/driver/dummy/src/lib.rs
+++ b/rust/driver/dummy/src/lib.rs
@@ -15,27 +15,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::{collections::HashMap, fmt::Debug, hash::Hash};
-
-use adbc_core::options::Statistics;
-use arrow_array::{
-    Array, ArrayRef, BinaryArray, BooleanArray, Float64Array, Int16Array, Int32Array, Int64Array,
-    ListArray, MapArray, RecordBatch, RecordBatchReader, StringArray, StructArray, UInt32Array,
-    UInt64Array, UnionArray,
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    hash::Hash,
+    sync::Arc,
 };
-use arrow_buffer::{OffsetBuffer, ScalarBuffer};
-use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef, UnionFields};
 
 use adbc_core::{
+    arrow::{
+        arrow_array::{
+            Array, ArrayRef, BinaryArray, BooleanArray, Float64Array, Int16Array, Int32Array,
+            Int64Array, ListArray, MapArray, RecordBatch, RecordBatchReader, StringArray,
+            StructArray, UInt32Array, UInt64Array, UnionArray,
+        },
+        arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef, UnionFields},
+    },
     error::{Error, Result, Status},
     ffi::constants,
     options::{
         InfoCode, ObjectDepth, OptionConnection, OptionDatabase, OptionStatement, OptionValue,
+        Statistics,
     },
     schemas, Connection, Database, Driver, Optionable, PartitionedResult, Statement,
 };
+use arrow_buffer::{OffsetBuffer, ScalarBuffer};
 
 #[derive(Debug)]
 pub struct SingleBatchReader {
@@ -762,7 +766,7 @@ impl Connection for DummyConnection {
         catalog: Option<&str>,
         db_schema: Option<&str>,
         table_name: &str,
-    ) -> Result<arrow_schema::Schema> {
+    ) -> Result<Schema> {
         let catalog = catalog.unwrap_or("default");
         let db_schema = db_schema.unwrap_or("default");
 

--- a/rust/driver/dummy/tests/driver_exporter_dummy.rs
+++ b/rust/driver/dummy/tests/driver_exporter_dummy.rs
@@ -19,22 +19,24 @@
 /// directly using the Rust API (native) and through the exported driver via the
 /// driver manager (exported). That allows us to test that data correctly round-trip
 /// between C and Rust.
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
-use arrow_array::{Array, Float64Array, Int64Array, RecordBatch, RecordBatchReader, StringArray};
-use arrow_schema::{DataType, Field, Schema};
-use arrow_select::concat::concat_batches;
-
-use adbc_core::options::{
-    AdbcVersion, InfoCode, IngestMode, IsolationLevel, ObjectDepth, OptionConnection,
-    OptionDatabase, OptionStatement,
+use adbc_core::{
+    arrow::{
+        arrow_array::{
+            Array, Float64Array, Int64Array, RecordBatch, RecordBatchReader, StringArray,
+        },
+        arrow_schema::{DataType, Field, Schema},
+    },
+    options::{
+        AdbcVersion, InfoCode, IngestMode, IsolationLevel, ObjectDepth, OptionConnection,
+        OptionDatabase, OptionStatement,
+    },
+    schemas, Connection, Database, Driver, Optionable, Statement,
 };
-use adbc_core::Statement;
-use adbc_core::{schemas, Connection, Database, Driver, Optionable};
 use adbc_driver_manager::{ManagedConnection, ManagedDatabase, ManagedDriver, ManagedStatement};
-
 use adbc_dummy::{DummyConnection, DummyDatabase, DummyDriver, DummyStatement, SingleBatchReader};
+use arrow_select::concat::concat_batches;
 
 const OPTION_STRING_LONG: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 const OPTION_BYTES_LONG: &[u8] = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";

--- a/rust/driver/snowflake/Cargo.toml
+++ b/rust/driver/snowflake/Cargo.toml
@@ -44,8 +44,6 @@ dotenv = ["env", "dep:dotenvy"]
 [dependencies]
 adbc_core.workspace = true
 adbc_driver_manager.workspace = true
-arrow-array.workspace = true
-arrow-schema.workspace = true
 dotenvy = { version = "0.15.7", default-features = false, optional = true }
 regex = { version = "1.11.2", default-features = false, optional = true }
 url = "2.5.7"

--- a/rust/driver/snowflake/README.md
+++ b/rust/driver/snowflake/README.md
@@ -31,9 +31,11 @@ driver, based on the
 ## Example
 
 ```rust,no_run
-use adbc_core::{Connection, Statement};
+use adbc_core::{
+    arrow::arrow_array::{cast::AsArray, types::Decimal128Type},
+    Connection, Statement
+};
 use adbc_snowflake::{connection, database, Driver};
-use arrow_array::{cast::AsArray, types::Decimal128Type};
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 

--- a/rust/driver/snowflake/src/connection.rs
+++ b/rust/driver/snowflake/src/connection.rs
@@ -22,13 +22,12 @@
 use std::collections::HashSet;
 
 use adbc_core::{
+    arrow::{arrow_array::RecordBatchReader, arrow_schema::Schema},
     error::Result,
     options::{InfoCode, OptionConnection, OptionValue},
     Optionable,
 };
 use adbc_driver_manager::ManagedConnection;
-use arrow_array::RecordBatchReader;
-use arrow_schema::Schema;
 
 use crate::Statement;
 

--- a/rust/driver/snowflake/src/database.rs
+++ b/rust/driver/snowflake/src/database.rs
@@ -22,16 +22,16 @@
 use std::{collections::HashSet, ffi::c_int, sync::Arc};
 
 use adbc_core::{
+    arrow::arrow_array::{
+        cast::AsArray,
+        types::{Int64Type, UInt32Type},
+        Array,
+    },
     error::{Error, Result, Status},
     options::{AdbcVersion, InfoCode, OptionConnection, OptionDatabase, OptionValue},
     Connection as _, Database as _, Optionable,
 };
 use adbc_driver_manager::ManagedDatabase;
-use arrow_array::{
-    cast::AsArray,
-    types::{Int64Type, UInt32Type},
-    Array,
-};
 
 use crate::Connection;
 

--- a/rust/driver/snowflake/src/statement.rs
+++ b/rust/driver/snowflake/src/statement.rs
@@ -20,13 +20,15 @@
 //!
 
 use adbc_core::{
+    arrow::{
+        arrow_array::{RecordBatch, RecordBatchReader},
+        arrow_schema::Schema,
+    },
     error::Result,
     options::{OptionStatement, OptionValue},
     Optionable, PartitionedResult,
 };
 use adbc_driver_manager::ManagedStatement;
-use arrow_array::{RecordBatch, RecordBatchReader};
-use arrow_schema::Schema;
 
 /// Snowflake ADBC Statement.
 pub struct Statement(pub(crate) ManagedStatement);

--- a/rust/driver/snowflake/tests/driver.rs
+++ b/rust/driver/snowflake/tests/driver.rs
@@ -37,12 +37,12 @@ mod tests {
     use std::{collections::HashSet, ops::Deref, sync::LazyLock};
 
     use adbc_core::{
+        arrow::arrow_array::{cast::AsArray, types::Decimal128Type},
         error::{Error, Result},
         options::AdbcVersion,
         Connection as _, Statement as _,
     };
     use adbc_snowflake::{connection, database, driver, Connection, Database, Driver, Statement};
-    use arrow_array::{cast::AsArray, types::Decimal128Type};
 
     const ADBC_VERSION: AdbcVersion = AdbcVersion::V110;
 

--- a/rust/driver_manager/Cargo.toml
+++ b/rust/driver_manager/Cargo.toml
@@ -36,8 +36,6 @@ driver_manager_test_manifest_user = ["driver_manager_test_lib"]
 
 [dependencies]
 adbc_core.workspace = true
-arrow-array.workspace = true
-arrow-schema.workspace = true
 libloading = "0.8"
 toml = { version = "0.9.5", default-features = false, features = [
     "parse",

--- a/rust/driver_manager/tests/common/mod.rs
+++ b/rust/driver_manager/tests/common/mod.rs
@@ -15,23 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashSet;
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{collections::HashSet, ops::Deref, sync::Arc};
 
-use adbc_core::error::Status;
-use adbc_core::options::{
-    InfoCode, IngestMode, ObjectDepth, OptionConnection, OptionDatabase, OptionStatement,
+use adbc_core::{
+    arrow::{
+        arrow_array::{
+            cast::as_string_array, Array, Float64Array, Int64Array, RecordBatch, RecordBatchReader,
+            StringArray,
+        },
+        arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef},
+    },
+    error::Status,
+    options::{
+        InfoCode, IngestMode, ObjectDepth, OptionConnection, OptionDatabase, OptionStatement,
+    },
+    schemas, Connection, Database, Driver, Optionable, Statement,
 };
-use adbc_core::schemas;
-use adbc_core::{Connection, Database, Driver, Optionable, Statement};
 use adbc_driver_manager::{ManagedConnection, ManagedDatabase, ManagedDriver, ManagedStatement};
-
-use arrow_array::{
-    cast::as_string_array, Array, Float64Array, Int64Array, RecordBatch, RecordBatchReader,
-    StringArray,
-};
-use arrow_schema::{ArrowError, DataType, Field, Schema, SchemaRef};
 use arrow_select::concat::concat_batches;
 
 pub struct SingleBatchReader {

--- a/rust/driver_manager/tests/driver_manager_sqlite.rs
+++ b/rust/driver_manager/tests/driver_manager_sqlite.rs
@@ -15,11 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use arrow_schema::{Field, Schema};
-
-use adbc_core::options::{AdbcVersion, OptionConnection, OptionDatabase};
-use adbc_core::{error::Status, Driver, Optionable};
-use adbc_core::{Connection, Database, Statement};
+use adbc_core::{
+    arrow::arrow_schema::{Field, Schema},
+    error::Status,
+    options::{AdbcVersion, OptionConnection, OptionDatabase},
+    Connection, Database, Driver, Optionable, Statement,
+};
 use adbc_driver_manager::{ManagedDatabase, ManagedDriver};
 
 mod common;


### PR DESCRIPTION
`adbc_core` defines public items that use types from both the `arrow-array` and `arrow-schema` crates. This PR adds a re-export of those crates (in an `arrow` mod) to the `adbc_core` crate. This means other crates no longer need to directly depend on the `arrow` crates for types from those crates used in `adbc_core`. Overall this should make it easier to use this crate.