### PR TITLE
fix(csharp/test/Drivers): Fix databricks tests

### DIFF
--- a/csharp/test/Drivers/Apache/Common/ClientTests.cs
+++ b/csharp/test/Drivers/Apache/Common/ClientTests.cs
@@ -45,7 +45,10 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Common
         {
             Skip.IfNot(Utils.CanExecuteTestConfig(TestConfigVariable));
         }
-
+        internal virtual string formatTableName()
+        {
+            return TestConfiguration.Metadata.Table;
+        }
         /// <summary>
         /// Validates if the client execute updates.
         /// </summary>
@@ -73,7 +76,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Common
         {
             using (Adbc.Client.AdbcConnection adbcConnection = GetAdbcConnection())
             {
-                Tests.ClientTests.CanClientGetSchema(adbcConnection, TestConfiguration, $"SELECT * FROM {TestConfiguration.Metadata.Table}");
+                Tests.ClientTests.CanClientGetSchema(adbcConnection, TestConfiguration, $"SELECT * FROM {formatTableName()}");
             }
         }
 
@@ -102,7 +105,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Common
                 Tests.ClientTests.CanClientExecuteQuery(
                     adbcConnection,
                     TestConfiguration,
-                    customQuery: $"SELECT * FROM {TestConfiguration.Metadata.Table} WHERE FALSE",
+                    customQuery: $"SELECT * FROM {formatTableName()} WHERE FALSE",
                     expectedResultsCount: 0);
             }
         }

--- a/csharp/test/Drivers/Apache/Common/DriverTests.cs
+++ b/csharp/test/Drivers/Apache/Common/DriverTests.cs
@@ -604,10 +604,15 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Apache.Common
             using AdbcConnection adbcConnection = NewConnection();
             using AdbcStatement statement = adbcConnection.CreateStatement();
 
-            statement.SqlQuery = $"SELECT * from {TestConfiguration.Metadata.Table} WHERE FALSE";
+            statement.SqlQuery = $"SELECT * from {formatTableName()} WHERE FALSE";
             QueryResult queryResult = await statement.ExecuteQueryAsync();
 
             await Tests.DriverTests.CanExecuteQueryAsync(queryResult, 0);
+        }
+
+        internal virtual string formatTableName()
+        {
+            return TestConfiguration.Metadata.Table;
         }
     }
 }

--- a/csharp/test/Drivers/Databricks/E2E/ClientTests.cs
+++ b/csharp/test/Drivers/Databricks/E2E/ClientTests.cs
@@ -52,5 +52,10 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
                     affectedRows,  // DELETE
                   ];
         }
+
+        internal override string formatTableName()
+        {
+            return $"{TestConfiguration.Metadata.Catalog}.{TestConfiguration.Metadata.Schema}.{TestConfiguration.Metadata.Table}";
+        }
     }
 }

--- a/csharp/test/Drivers/Databricks/E2E/CloudFetch/CloudFetchResultFetcherTest.cs
+++ b/csharp/test/Drivers/Databricks/E2E/CloudFetch/CloudFetchResultFetcherTest.cs
@@ -467,7 +467,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.CloudFetch
             Assert.True(timedOut, "Fetch operation should have timed out due to QueryTimeoutSeconds setting");
 
             // Wait a bit for the fetcher to complete its error handling
-            //await Task.Delay(100);
+            await Task.Delay(100);
 
             // Verify the fetcher state
             Assert.True(_resultFetcher.IsCompleted);

--- a/csharp/test/Drivers/Databricks/E2E/DriverTests.cs
+++ b/csharp/test/Drivers/Databricks/E2E/DriverTests.cs
@@ -182,5 +182,10 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
                     return false;
             }
         }
+
+        internal override string formatTableName()
+        {
+            return $"{TestConfiguration.Metadata.Catalog}.{TestConfiguration.Metadata.Schema}.{TestConfiguration.Metadata.Table}";
+        }
     }
 }


### PR DESCRIPTION
- Added virtual formatTableName() method to Apache common test classes
- Databricks tests override to return fully qualified names: {catalog}.{schema}.{table}
- Apache drivers continue using table names as-is
- Fixed CloudFetch test stability issue
