### PR TITLE
fix(csharp/src/Drivers/BigQuery): Include try/catch for InvalidOperationException in ReadRowsStream

### DIFF
--- a/csharp/src/Drivers/BigQuery/RetryManager.cs
+++ b/csharp/src/Drivers/BigQuery/RetryManager.cs
@@ -62,11 +62,11 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                             if (tokenProtectedResource?.TokenRequiresUpdate(ex) == true)
                             {
                                 activity?.AddBigQueryTag("update_token.status", "Expired");
-                                throw new AdbcException($"Cannot update access token after {maxRetries} tries. Last exception: {ex.Message}", AdbcStatusCode.Unauthenticated, ex);
+                                throw new AdbcException($"Cannot update access token after {maxRetries} tries. Last exception: {ex.GetType().Name}: {ex.Message}", AdbcStatusCode.Unauthenticated, ex);
                             }
                         }
 
-                        throw new AdbcException($"Cannot execute {action.Method.Name} after {maxRetries} tries. Last exception: {ex.Message}", AdbcStatusCode.UnknownError, ex);
+                        throw new AdbcException($"Cannot execute {action.Method.Name} after {maxRetries} tries. Last exception: {ex.GetType().Name}: {ex.Message}", AdbcStatusCode.UnknownError, ex);
                     }
 
                     if ((tokenProtectedResource?.UpdateToken != null))


### PR DESCRIPTION
The previous update was still not catching the issue. Found some older grpc classes with the similar message (`No current element is available.`) and pattern including https://github.com/grpc/grpc/blob/2d4f3c56001cd1e1f85734b2f7c5ce5f2797c38a/src/csharp/Grpc.Core/Internal/ServerRequestStream.cs#L38, so added a try/catch around the attempt to add an additional check.