### PR TITLE
fix(go/adbc/driver/bigquery): fix timestamp arrow type to use micro seconds

### DIFF
--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -809,7 +809,7 @@ func buildField(schema *bigquery.FieldSchema, level uint) (arrow.Field, error) {
 	case bigquery.BooleanFieldType:
 		field.Type = arrow.FixedWidthTypes.Boolean
 	case bigquery.TimestampFieldType:
-		field.Type = arrow.FixedWidthTypes.Timestamp_ms
+		field.Type = arrow.FixedWidthTypes.Timestamp_us
 	case bigquery.RecordFieldType:
 		// create an Arrow struct for BigQuery Record fields
 		nestedFields := make([]arrow.Field, len(schema.Schema))


### PR DESCRIPTION
This is also documented officially https://cloud.google.com/bigquery/docs/reference/storage#arrow_schema_details see `TIMESTAMP`