### PR TITLE
feat(go/adbc/driver/snowflake): Enable PAT auth

### DIFF
--- a/go/adbc/driver/snowflake/driver.go
+++ b/go/adbc/driver/snowflake/driver.go
@@ -127,6 +127,8 @@ const (
 	OptionValueAuthJwt = "auth_jwt"
 	// use a username and password with mfa
 	OptionValueAuthUserPassMFA = "auth_mfa"
+	// use a programmatic access token
+	OptionValueAuthPat = "auth_pat"
 
 	// Use default behavior for nanoseconds.
 	OptionValueNanoseconds = "nanoseconds"

--- a/go/adbc/driver/snowflake/snowflake_database.go
+++ b/go/adbc/driver/snowflake/snowflake_database.go
@@ -47,6 +47,7 @@ var (
 		OptionValueAuthOkta:            gosnowflake.AuthTypeOkta,
 		OptionValueAuthJwt:             gosnowflake.AuthTypeJwt,
 		OptionValueAuthUserPassMFA:     gosnowflake.AuthTypeUsernamePasswordMFA,
+		OptionValueAuthPat:             gosnowflake.AuthTypePat,
 	}
 )
 

--- a/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
+++ b/python/adbc_driver_snowflake/adbc_driver_snowflake/__init__.py
@@ -103,6 +103,23 @@ class DatabaseOptions(enum.Enum):
     #: set using 'true' or 'false'.
     USE_HIGH_PRECISION = "adbc.snowflake.sql.client_option.use_high_precision"
 
+class ValueAuth(enum.Enum):
+    """Values for the AUTH_TYPE option to the Snowflake driver."""
+
+    #: General username/password auth
+    SNOWFLAKE = "auth_snowflake"
+    #: Use OAuth authentication for the connection
+    OAUTH = "auth_oauth"
+    #: Use an external browser to access a FED and perform SSO auth
+    EXTERNAL_BROWSER = "auth_ext_browser"
+    #: Use Okta authentication for the connection
+    OKTA = "auth_okta"
+    #: Use JWT authentication for the connection
+    JWT = "auth_jwt"
+    #: Use a username and password with MFA
+    MFA = "auth_mfa"
+    #: Use a programmatic access token
+    PAT = "auth_pat"
 
 class StatementOptions(enum.Enum):
     """Statement options specific to the Snowflake driver."""


### PR DESCRIPTION
Enable using PAT authentication for connecting with the Snowflake ADBC driver.