### PR TITLE
ci: change CI DB for snowflake tests

### DIFF
--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -432,7 +432,7 @@ jobs:
           popd
       - name: Go Test
         env:
-          SNOWFLAKE_DATABASE: ADBC_TESTING
+          SNOWFLAKE_DATABASE: ARROW_OSS_DB
           SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
         run: |
           ./ci/scripts/go_test.sh "$(pwd)" "$(pwd)/build" "$HOME/local"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -180,7 +180,7 @@ jobs:
         # env:
         # ADBC_SNOWFLAKE_TESTS: 1
         # ADBC_SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
-        # ADBC_SNOWFLAKE_SQL_DB: ADBC_TESTING
+        # ADBC_SNOWFLAKE_SQL_DB: ARROW_OSS_DB
       - name: Doctests
         working-directory: rust
         # TODO: enable snowflake tests on windows

--- a/go/adbc/driver/snowflake/driver_test.go
+++ b/go/adbc/driver/snowflake/driver_test.go
@@ -1444,7 +1444,6 @@ func (suite *SnowflakeTests) TestStatementEmptyResultSet() {
 		"failed",
 		"suspended",
 		"uuid",
-		"budget",
 		"owner_role_type",
 	}
 


### PR DESCRIPTION
Switchover to ARROW_OSS_DB for the database name to use with CI