### PR TITLE
fix(c/driver_manager): rename `ADBC_CONFIG_PATH` to `ADBC_DRIVER_PATH`

### DIFF
--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -300,11 +300,11 @@ std::vector<std::filesystem::path> GetSearchPaths(const AdbcLoadFlags levels) {
   std::vector<std::filesystem::path> paths;
   if (levels & ADBC_LOAD_FLAG_SEARCH_ENV) {
 #ifdef _WIN32
-    static const wchar_t* env_var = L"ADBC_CONFIG_PATH";
+    static const wchar_t* env_var = L"ADBC_DRIVER_PATH";
 #else
-    static const char* env_var = "ADBC_CONFIG_PATH";
+    static const char* env_var = "ADBC_DRIVER_PATH";
 #endif  // _WIN32
-    // Check the ADBC_CONFIG_PATH environment variable
+    // Check the ADBC_DRIVER_PATH environment variable
     paths = GetEnvPaths(env_var);
   }
 
@@ -482,7 +482,7 @@ struct ManagedLibrary {
     }
 
     {
-      // First search the paths in the env var `ADBC_CONFIG_PATH`.
+      // First search the paths in the env var `ADBC_DRIVER_PATH`.
       // Then search the runtime application-defined additional search paths.
       auto search_paths = GetSearchPaths(load_options & ADBC_LOAD_FLAG_SEARCH_ENV);
       search_paths.insert(search_paths.end(), additional_search_paths.begin(),

--- a/c/driver_manager/adbc_driver_manager_test.cc
+++ b/c/driver_manager/adbc_driver_manager_test.cc
@@ -439,9 +439,9 @@ class DriverManifest : public ::testing::Test {
  protected:
   void SetConfigPath(const char* path) {
 #ifdef _WIN32
-    ASSERT_TRUE(SetEnvironmentVariable("ADBC_CONFIG_PATH", path));
+    ASSERT_TRUE(SetEnvironmentVariable("ADBC_DRIVER_PATH", path));
 #else
-    setenv("ADBC_CONFIG_PATH", path, 1);
+    setenv("ADBC_DRIVER_PATH", path, 1);
 #endif
   }
 

--- a/c/include/arrow-adbc/adbc_driver_manager.h
+++ b/c/include/arrow-adbc/adbc_driver_manager.h
@@ -81,7 +81,7 @@ AdbcStatusCode AdbcLoadDriver(const char* driver_name, const char* entrypoint,
 ///
 /// If the passed in driver_name does not have an extension and is not an absolute path:
 /// - The load_options parameter will control whether the driver manager will search the
-///   environment variable ADBC_CONFIG_PATH and (if built or installed with conda) the
+///   environment variable ADBC_DRIVER_PATH and (if built or installed with conda) the
 ///   conda environment, the user-level configuration, and/or the system-level
 ///   configuration for either a manifest file or a shared library.
 /// - For each path to be searched, it will first look for <path>/<driver_name>.toml. If
@@ -161,7 +161,7 @@ AdbcStatusCode AdbcDriverManagerDatabaseSetLoadFlags(struct AdbcDatabase* databa
 /// driver/entrypoint dynamically. This function lets you explicitly
 /// set a path list at runtime for additional paths to search when
 /// looking for a driver manifest. While users can add additional
-/// paths via the ADBC_CONFIG_PATH environment variable, this allows
+/// paths via the ADBC_DRIVER_PATH environment variable, this allows
 /// an application to specify search paths at runtime which are not tied
 /// to the load flags.
 ///

--- a/docs/source/format/driver_manifests.rst
+++ b/docs/source/format/driver_manifests.rst
@@ -352,7 +352,7 @@ to control which directories will be searched for manifests, with the behavior b
        The type :c:type:`AdbcLoadFlags` is a set of bitflags to control the directories to be searched. The flags are
 
        * :c:macro:`ADBC_LOAD_FLAG_SEARCH_ENV` - search the directory paths in the environment variable
-         ``ADBC_CONFIG_PATH`` and (when built or installed with conda) search in the conda environment
+         ``ADBC_DRIVER_PATH`` and (when built or installed with conda) search in the conda environment
        * :c:macro:`ADBC_LOAD_FLAG_SEARCH_USER` - search the user configuration directory
        * :c:macro:`ADBC_LOAD_FLAG_SEARCH_SYSTEM` - search the system configuration directory
        * :c:macro:`ADBC_LOAD_FLAG_ALLOW_RELATIVE_PATHS` - allow a relative path to be provided
@@ -366,7 +366,7 @@ to control which directories will be searched for manifests, with the behavior b
        The type ``GADBCLoadFlags`` is a set of bitflags to control the directories to be searched. The flags are
 
        * ``GADBC_LOAD_SEARCH_ENV`` - search the directory paths in the environment variable
-         ``ADBC_CONFIG_PATH`` and (when built or installed with conda) search in the conda environment
+         ``ADBC_DRIVER_PATH`` and (when built or installed with conda) search in the conda environment
        * ``GADBC_LOAD_FLAG_SEARCH_USER`` - search the user configuration directory
        * ``GADBC_LOAD_FLAG_SEARCH_SYSTEM`` - search the system configuration directory
        * ``GADBC_LOAD_FLAG_ALLOW_RELATIVE_PATHS`` - allow a relative path to be provided
@@ -383,7 +383,7 @@ to control which directories will be searched for manifests, with the behavior b
        or ``NewDatabaseWithContext``. The flags are defined in the ``drivermgr`` package as constants:
 
        * ``drivermgr.LoadFlagsSearchEnv`` - search the directory paths in the environment variable
-         ``ADBC_CONFIG_PATH``
+         ``ADBC_DRIVER_PATH``
        * ``drivermgr.LoadFlagsSearchUser`` - search the user configuration directory
        * ``drivermgr.LoadFlagsSearchSystem`` - search the system configuration directory
        * ``drivermgr.LoadFlagsAllowRelativePaths`` - allow a relative path to be used
@@ -407,7 +407,7 @@ to control which directories will be searched for manifests, with the behavior b
        The class ``ADBC::LoadFlags`` is a set of bitflags to control the directories to be searched. The flags are
 
        * ``ADBC::LoadFlags::SEARCH_ENV`` - search the directory paths in the environment variable
-         ``ADBC_CONFIG_PATH`` and (when built or installed with conda) search in the conda environment
+         ``ADBC_DRIVER_PATH`` and (when built or installed with conda) search in the conda environment
        * ``ADBC::LoadFlags::SEARCH_USER`` - search the user configuration directory
        * ``ADBC::LoadFlags::SEARCH_SYSTEM`` - search the system configuration directory
        * ``ADBC::LoadFlags::ALLOW_RELATIVE_PATHS`` - allow a relative path to be provided
@@ -424,7 +424,7 @@ to control which directories will be searched for manifests, with the behavior b
        the type ``adbc_core::driver_manager::LoadFlags``, which has the following constants:
 
        * ``LOAD_FLAG_SEARCH_ENV`` - search the directory paths in the environment variable
-         ``ADBC_CONFIG_PATH`` and (when built or installed with conda) search in the conda environment
+         ``ADBC_DRIVER_PATH`` and (when built or installed with conda) search in the conda environment
        * ``LOAD_FLAG_SEARCH_USER`` - search the user configuration directory
        * ``LOAD_FLAG_SEARCH_SYSTEM`` - search the system configuration directory
        * ``LOAD_FLAG_ALLOW_RELATIVE_PATHS`` - allow a relative path to be used
@@ -436,9 +436,9 @@ Unix-like Platforms
 For Unix-like platforms, (e.g. Linux, macOS), the driver manager will search the following directories based on the options provided, in
 the given order:
 
-#. If the ``LOAD_FLAG_SEARCH_ENV`` load option is set, then the paths in the environment variable ``ADBC_CONFIG_PATH`` will be searched
+#. If the ``LOAD_FLAG_SEARCH_ENV`` load option is set, then the paths in the environment variable ``ADBC_DRIVER_PATH`` will be searched
 
-  * ``ADBC_CONFIG_PATH`` is a colon-separated list of directories
+  * ``ADBC_DRIVER_PATH`` is a colon-separated list of directories
 
 #. If additional search paths have been specified, those will be searched
 
@@ -463,9 +463,9 @@ Windows
 Things are slightly different on Windows, where the driver manager will also search for driver information in the registry just as
 would happen for ODBC drivers. The search for a manifest on Windows would be the following:
 
-#. If the ``LOAD_FLAG_SEARCH_ENV`` load option is set, then the paths in the environment variable ``ADBC_CONFIG_PATH`` will be searched
+#. If the ``LOAD_FLAG_SEARCH_ENV`` load option is set, then the paths in the environment variable ``ADBC_DRIVER_PATH`` will be searched
 
-  * ``ADBC_CONFIG_PATH`` is a semicolon-separated list of directories
+  * ``ADBC_DRIVER_PATH`` is a semicolon-separated list of directories
 
 #. If additional search paths have been specified, those will be searched
 

--- a/glib/adbc-glib/database.h
+++ b/glib/adbc-glib/database.h
@@ -28,7 +28,7 @@ G_BEGIN_DECLS
 /**
  * GADBCLoadFlags:
  * @GADBC_LOAD_SEARCH_ENV: Search the directory paths in the environment
- * variable ADBC_CONFIG_PATH and (when built or installed with conda)
+ * variable ADBC_DRIVER_PATH and (when built or installed with conda)
  * search in the conda environment
  * @GADBC_LOAD_SEARCH_USER: Search the user configuration directory.
  * @GADBC_LOAD_SEARCH_SYSTEM: Search the system configuration directory.

--- a/go/adbc/drivermgr/adbc_driver_manager.cc
+++ b/go/adbc/drivermgr/adbc_driver_manager.cc
@@ -300,11 +300,11 @@ std::vector<std::filesystem::path> GetSearchPaths(const AdbcLoadFlags levels) {
   std::vector<std::filesystem::path> paths;
   if (levels & ADBC_LOAD_FLAG_SEARCH_ENV) {
 #ifdef _WIN32
-    static const wchar_t* env_var = L"ADBC_CONFIG_PATH";
+    static const wchar_t* env_var = L"ADBC_DRIVER_PATH";
 #else
-    static const char* env_var = "ADBC_CONFIG_PATH";
+    static const char* env_var = "ADBC_DRIVER_PATH";
 #endif
-    // Check the ADBC_CONFIG_PATH environment variable
+    // Check the ADBC_DRIVER_PATH environment variable
     paths = GetEnvPaths(env_var);
   }
 
@@ -482,7 +482,7 @@ struct ManagedLibrary {
     }
 
     {
-      // First search the paths in the env var `ADBC_CONFIG_PATH`.
+      // First search the paths in the env var `ADBC_DRIVER_PATH`.
       // Then search the runtime application-defined additional search paths.
       auto search_paths = GetSearchPaths(load_options & ADBC_LOAD_FLAG_SEARCH_ENV);
       search_paths.insert(search_paths.end(), additional_search_paths.begin(),

--- a/go/adbc/drivermgr/arrow-adbc/adbc_driver_manager.h
+++ b/go/adbc/drivermgr/arrow-adbc/adbc_driver_manager.h
@@ -81,7 +81,7 @@ AdbcStatusCode AdbcLoadDriver(const char* driver_name, const char* entrypoint,
 ///
 /// If the passed in driver_name does not have an extension and is not an absolute path:
 /// - The load_options parameter will control whether the driver manager will search the
-///   environment variable ADBC_CONFIG_PATH and (if built or installed with conda) the
+///   environment variable ADBC_DRIVER_PATH and (if built or installed with conda) the
 ///   conda environment, the user-level configuration, and/or the system-level
 ///   configuration for either a manifest file or a shared library.
 /// - For each path to be searched, it will first look for <path>/<driver_name>.toml. If
@@ -161,7 +161,7 @@ AdbcStatusCode AdbcDriverManagerDatabaseSetLoadFlags(struct AdbcDatabase* databa
 /// driver/entrypoint dynamically. This function lets you explicitly
 /// set a path list at runtime for additional paths to search when
 /// looking for a driver manifest. While users can add additional
-/// paths via the ADBC_CONFIG_PATH environment variable, this allows
+/// paths via the ADBC_DRIVER_PATH environment variable, this allows
 /// an application to specify search paths at runtime which are not tied
 /// to the load flags.
 ///

--- a/r/adbcdrivermanager/R/driver_void.R
+++ b/r/adbcdrivermanager/R/driver_void.R
@@ -108,12 +108,12 @@ adbc_driver_load <- function(x, entrypoint, version, driver, error,
 #'
 #' Options that indicate where to look for driver manifests. Manifests
 #' (.toml files) can be installed at the system level, the user level,
-#' in location(s) specified by the ADBC_CONFIG_PATH environment variable,
+#' in location(s) specified by the ADBC_DRIVER_PATH environment variable,
 #' and/or in a conda environment. See the ADBC documentation for details
 #' regarding the locations of the user and system paths on various platforms.
 #'
 #' @param search_env Search for manifest files in the directories specified in
-#'   the ADBC_CONFIG_PATH environment variable and (when installed with conda)
+#'   the ADBC_DRIVER_PATH environment variable and (when installed with conda)
 #'   in the conda environment.
 #' @param search_user Search for manifest files in the designated directory
 #'   for user ADBC driver installs.

--- a/r/adbcdrivermanager/man/adbc_load_flags.Rd
+++ b/r/adbcdrivermanager/man/adbc_load_flags.Rd
@@ -13,7 +13,7 @@ adbc_load_flags(
 }
 \arguments{
 \item{search_env}{Search for manifest files in the directories specified in
-the ADBC_CONFIG_PATH environment variable and (when installed with conda)
+the ADBC_DRIVER_PATH environment variable and (when installed with conda)
 in the conda environment.}
 
 \item{search_user}{Search for manifest files in the designated directory
@@ -31,7 +31,7 @@ An integer flag value for use in \code{adbc_driver()}
 \description{
 Options that indicate where to look for driver manifests. Manifests
 (.toml files) can be installed at the system level, the user level,
-in location(s) specified by the ADBC_CONFIG_PATH environment variable,
+in location(s) specified by the ADBC_DRIVER_PATH environment variable,
 and/or in a conda environment. See the ADBC documentation for details
 regarding the locations of the user and system paths on various platforms.
 }

--- a/rust/driver_manager/src/lib.rs
+++ b/rust/driver_manager/src/lib.rs
@@ -501,7 +501,7 @@ impl ManagedDriver {
             }
         }
 
-        // the logic we want is that we first search ADBC_CONFIG_PATH if set,
+        // the logic we want is that we first search ADBC_DRIVER_PATH if set,
         // then we search the additional search paths if they exist. Finally,
         // we will search CONDA_PREFIX if built with conda_build before moving on.
         if let Some(additional_search_paths) = additional_search_paths {
@@ -1815,7 +1815,7 @@ fn system_config_dir() -> Option<PathBuf> {
 fn get_search_paths(lvls: LoadFlags) -> Vec<PathBuf> {
     let mut result = Vec::new();
     if lvls & LOAD_FLAG_SEARCH_ENV != 0 {
-        if let Some(paths) = env::var_os("ADBC_CONFIG_PATH") {
+        if let Some(paths) = env::var_os("ADBC_DRIVER_PATH") {
             for p in env::split_paths(&paths) {
                 result.push(p);
             }
@@ -1985,7 +1985,7 @@ mod tests {
     #[cfg_attr(target_os = "windows", ignore)] // TODO: remove this line after fixing
     fn test_load_driver_env() {
         // ensure that we fail without the env var set
-        with_var_unset("ADBC_CONFIG_PATH", || {
+        with_var_unset("ADBC_DRIVER_PATH", || {
             let err = ManagedDriver::load_from_name(
                 "sqlite",
                 None,
@@ -2001,7 +2001,7 @@ mod tests {
             write_manifest_to_tempfile(PathBuf::from("sqlite.toml"), simple_manifest());
 
         with_var(
-            "ADBC_CONFIG_PATH",
+            "ADBC_DRIVER_PATH",
             Some(manifest_path.parent().unwrap().as_os_str()),
             || {
                 ManagedDriver::load_from_name(
@@ -2033,7 +2033,7 @@ mod tests {
         ])
         .unwrap();
 
-        with_var("ADBC_CONFIG_PATH", Some(&path_os_string), || {
+        with_var("ADBC_DRIVER_PATH", Some(&path_os_string), || {
             ManagedDriver::load_from_name(
                 "sqlite",
                 None,
@@ -2056,7 +2056,7 @@ mod tests {
         let (tmp_dir, manifest_path) = write_manifest_to_tempfile(p, simple_manifest());
 
         with_var(
-            "ADBC_CONFIG_PATH",
+            "ADBC_DRIVER_PATH",
             Some(manifest_path.parent().unwrap().as_os_str()),
             || {
                 ManagedDriver::load_from_name(
@@ -2083,7 +2083,7 @@ mod tests {
             write_manifest_to_tempfile(PathBuf::from("sqlite.toml"), simple_manifest());
 
         with_var(
-            "ADBC_CONFIG_PATH",
+            "ADBC_DRIVER_PATH",
             Some(manifest_path.parent().unwrap().as_os_str()),
             || {
                 let load_flags = LOAD_FLAG_DEFAULT & !LOAD_FLAG_SEARCH_ENV;


### PR DESCRIPTION
Closes #3378