### PR TITLE
ci: cut down on Dependabot spam a bit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,10 @@ updates:
     commit-message:
       prefix: "chore(go/adbc): "
     groups:
+      "golang.org/x":
+        applies-to: version-updates
+        patterns:
+          - "golang.org/x/*"
       opentelemetry:
         applies-to: version-updates
         patterns:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,6 +28,8 @@ on:
       - "python/**"
       - ".github/workflows/integration.yml"
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - "c/**"
       - "ci/**"

--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -31,6 +31,8 @@ on:
       - "ruby/**"
       - ".github/workflows/native-unix.yml"
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - "c/**"
       - "ci/**"

--- a/.github/workflows/native-windows.yml
+++ b/.github/workflows/native-windows.yml
@@ -30,6 +30,8 @@ on:
       - "ruby/**"
       - ".github/workflows/native-windows.yml"
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - "c/**"
       - "ci/**"


### PR DESCRIPTION
Don't run all the pipelines twice, and group together some more dependency updates (even if they aren't strictly related).