### PR TITLE
feat(csharp/src/Drivers/BigQuery): implement AdbcStatement.Cancel on BigQuery - once for all semantic

### DIFF
--- a/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
@@ -695,7 +695,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
 
             public ReadRowsStream(IAsyncEnumerator<ReadRowsResponse> response, CancellationToken parentCancellationToken)
             {
-                this.parentCancellationToken = parentCancellationToken;   
+                this.parentCancellationToken = parentCancellationToken;
                 try
                 {
                     if (response.MoveNextAsync().Result && response.Current != null)

--- a/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
@@ -124,10 +124,10 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
 
                 TokenProtectedReadClientManger clientMgr = new TokenProtectedReadClientManger(Credential);
                 clientMgr.UpdateToken = () => Task.Run(() =>
-                    {
-                        this.bigQueryConnection.SetCredential();
-                        clientMgr.UpdateCredential(Credential);
-                    });
+                {
+                    this.bigQueryConnection.SetCredential();
+                    clientMgr.UpdateCredential(Credential);
+                });
 
                 // For multi-statement queries, StatementType == "SCRIPT"
                 if (results.TableReference == null || job.Statistics.Query.StatementType.Equals("SCRIPT", StringComparison.OrdinalIgnoreCase))
@@ -139,8 +139,8 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                     }
                     int statementIndex = 1;
                     if (Options?.TryGetValue(BigQueryParameters.StatementIndex, out string? statementIndexString) == true &&
-                            int.TryParse(statementIndexString, out int statementIndexInt) &&
-                            statementIndexInt > 0)
+                        int.TryParse(statementIndexString, out int statementIndexInt) &&
+                        statementIndexInt > 0)
                     {
                         statementIndex = statementIndexInt;
                     }

--- a/csharp/src/Drivers/BigQuery/RetryManager.cs
+++ b/csharp/src/Drivers/BigQuery/RetryManager.cs
@@ -49,7 +49,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                     T result = await action();
                     return result;
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     activity?.AddBigQueryTag("retry_attempt", retryCount);
                     activity?.AddException(ex);

--- a/csharp/test/Drivers/BigQuery/StatementTests.cs
+++ b/csharp/test/Drivers/BigQuery/StatementTests.cs
@@ -76,16 +76,17 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
                 AdbcConnection adbcConnection = GetAdbcConnection(environment.Name);
 
                 AdbcStatement statement = adbcConnection.CreateStatement();
+                // Generate unique column names so query will not be served from cache
                 string columnName1 = Guid.NewGuid().ToString("N");
                 string columnName2 = Guid.NewGuid().ToString("N");
                 statement.SqlQuery = $"SELECT GENERATE_ARRAY(`{columnName2}`, 10000) AS `{columnName1}` FROM UNNEST(GENERATE_ARRAY(0, 100000)) AS `{columnName2}`";
                 _outputHelper?.WriteLine($"Query: {statement.SqlQuery}");
 
                 // Execute the query/cancel multiple times to validate consistent behavior
-                const int iternations = 3;
-                for (int i = 0; i < iternations; i++)
+                const int iterations = 3;
+                for (int i = 0; i < iterations; i++)
                 {
-                    _outputHelper?.WriteLine($"Iteration {i + 1} of {iternations}");
+                    _outputHelper?.WriteLine($"Iteration {i + 1} of {iterations}");
 
                     // Expect this to take about 10 seconds without cancellation
                     Task<QueryResult> queryTask = Task.Run(statement.ExecuteQuery);
@@ -121,6 +122,5 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.BigQuery
 
             return _configuredConnections[environmentName!];
         }
-
     }
 }


### PR DESCRIPTION
Adds implementation of `AdbcStatement.Cancel` to the BigQuery driver.
- Add wrapper `ExecuteCancellableJobAsync` to wrap calls with async cancellable steps. The context will allow the executing code to set the current job to cancel explicitly.
- `BigQueryStatement.Cancel()` will call the `CancellationTokenSource.Cancel` to indicate a cancellation is requested.
- A single token source is used for Statement/Reader/Stream so that cancelling the statement will cancel all the associated and generated objects.
- The `RetryManager` has been updated to not catch `OperationCancellationException`.
- Test added to confirm expected behavior.