### PR TITLE
ci: add a nightly build job for musl linux (alpine)

### DIFF
--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -25,6 +25,7 @@ on:
       - ".github/workflows/nightly-verify.yml"
       - "ci/docker/cpp-clang-latest.dockerfile"
       - "ci/docker/cpp-gcc-latest.dockerfile"
+      - "ci/docker/cpp-musl.alpine.dockerfile"
       - "dev/release/verify-release-candidate.sh"
       - "dev/release/verify-release-candidate.ps1"
   schedule:
@@ -229,6 +230,11 @@ jobs:
         run: |
           pushd arrow-adbc
           docker compose run --rm cpp-static-test
+
+      - name: cpp-musl
+        run: |
+          pushd arrow-adbc
+          docker compose run --rm cpp-musl
 
       - name: python-debug
         run: |

--- a/ci/docker/cpp-musl.alpine.dockerfile
+++ b/ci/docker/cpp-musl.alpine.dockerfile
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM alpine:3
+
+RUN apk add --no-cache \
+    build-base \
+    cmake \
+    ninja \
+    bash \
+    git \
+    ca-certificates \
+    musl-dev \
+    libstdc++ \
+    linux-headers \
+    sqlite-dev

--- a/compose.yaml
+++ b/compose.yaml
@@ -73,6 +73,23 @@ services:
     command: "bash -c 'git config --global --add safe.directory /adbc && /adbc/ci/scripts/cpp_static_test.sh /adbc /adbc/build/static-test/build /adbc/build/static-test/local'"
 
 
+  ############################### C/C++: musl (Alpine) ##########################
+
+  cpp-musl:
+    image: ${REPO}:${ARCH}-cpp-musl-adbc
+    build:
+      context: .
+      dockerfile: ci/docker/cpp-musl.alpine.dockerfile
+    volumes:
+      - .:/adbc:delegated
+    environment:
+      ADBC_CMAKE_ARGS: "-DADBC_BUILD_WARNING_LEVEL=CHECKIN -DSIZEOF_TIME_T=8"
+      ADBC_USE_ASAN: "0"
+      ADBC_USE_UBSAN: "0"
+    command: "bash -c 'git config --global --add safe.directory /adbc && \
+      env ADBC_USE_ASAN=0 ADBC_USE_UBSAN=0 BUILD_ALL=0 BUILD_DRIVER_MANAGER=1 BUILD_DRIVER_POSTGRESQL=0 BUILD_DRIVER_SQLITE=1 BUILD_DRIVER_FLIGHTSQL=0 BUILD_DRIVER_SNOWFLAKE=0 BUILD_DRIVER_BIGQUERY=0 /adbc/ci/scripts/cpp_build.sh /adbc /adbc/build/musl && \
+      env ADBC_USE_ASAN=0 ADBC_USE_UBSAN=0 BUILD_ALL=0 BUILD_DRIVER_MANAGER=0 BUILD_DRIVER_POSTGRESQL=0 BUILD_DRIVER_SQLITE=1 BUILD_DRIVER_FLIGHTSQL=0 BUILD_DRIVER_SNOWFLAKE=0 BUILD_DRIVER_BIGQUERY=0 /adbc/ci/scripts/cpp_test.sh /adbc/build/musl'"
+
   ############################ Documentation ###################################
 
   docs:


### PR DESCRIPTION
Close #3107

I've prioritized testing the driver manager and added a minimal build, which we hope will catch musl-specific bugs like #3105.