### PR TITLE
docs: fix path case in references in bigquery.rst

### DIFF
--- a/docs/source/driver/bigquery.rst
+++ b/docs/source/driver/bigquery.rst
@@ -20,7 +20,7 @@ BigQuery Support
 ================
 
 .. adbc_driver_status:: ../../../c/driver/bigquery/README.md
-.. adbc_driver_status:: ../../../csharp/src/Drivers/BigQuery/README.md
+.. adbc_driver_status:: ../../../csharp/src/Drivers/BigQuery/readme.md
 
 There are two official BigQuery drivers in development:
 
@@ -33,7 +33,7 @@ C# BigQuery Driver
 Installation
 ~~~~~~~~~~~~
 
-.. adbc_driver_installation:: ../../../csharp/src/Drivers/BigQuery/README.md
+.. adbc_driver_installation:: ../../../csharp/src/Drivers/BigQuery/readme.md
 
 More Information
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Merging https://github.com/apache/arrow-adbc/pull/3452 caused the docs build to fail in https://github.com/apache/arrow-adbc/actions/runs/17883091089/job/50853293450. I expect this is due to case sensitivity so I think this change should fix the issue.