### PR TITLE
chore(rust/core): fix package description

### DIFF
--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 authors.workspace = true
 categories.workspace = true
-description = "Public abstract API, driver manager and driver exporter"
+description = "Public abstract API of ADBC"
 documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
Since we've split functionality driver manager and driver exporter into separate packages (#3106), we also need to update the package description.