### PR TITLE
fix(r/adbcdrivermanager): support `replace` and `create_append` ingest mode in `write_adbc()`

### DIFF
--- a/r/adbcdrivermanager/R/helpers.R
+++ b/r/adbcdrivermanager/R/helpers.R
@@ -27,8 +27,9 @@
 #' @param tbl A data.frame, [nanoarrow_array][nanoarrow::as_nanoarrow_array],
 #'   or  [nanoarrow_array_stream][nanoarrow::as_nanoarrow_array_stream].
 #' @param target_table A target table name to which `tbl` should be written.
-#' @param mode One of "create", "append", or "default" (error if the schema
-#'   is not compatible or append otherwise).
+#' @param mode One of `"create"`, `"append"`, `"replace"`, `"create_append"` (error if the schema
+#'   is not compatible or append otherwise), or `"default"` (use the `adbc.ingest.mode`
+#'   argument of [adbc_statement_init()]). The default is `"default"`.
 #' @param query An SQL query
 #' @param bind A data.frame, nanoarrow_array, or nanoarrow_array_stream of
 #'   bind parameters or NULL to skip the bind/prepare step.
@@ -67,7 +68,7 @@ execute_adbc <- function(db_or_con, query, ..., bind = NULL) {
 #' @rdname read_adbc
 #' @export
 write_adbc <- function(tbl, db_or_con, target_table, ...,
-                       mode = c("default", "create", "append"),
+                       mode = c("default", "create", "append", "replace", "create_append"),
                        temporary = FALSE) {
   UseMethod("write_adbc", db_or_con)
 }
@@ -111,7 +112,7 @@ execute_adbc.default <- function(db_or_con, query, ..., bind = NULL, stream = NU
 
 #' @export
 write_adbc.default <- function(tbl, db_or_con, target_table, ...,
-                               mode = c("default", "create", "append"),
+                               mode = c("default", "create", "append", "replace", "create_append"),
                                temporary = FALSE) {
   assert_adbc(db_or_con, c("adbc_database", "adbc_connection"))
   mode <- match.arg(mode)

--- a/r/adbcdrivermanager/man/read_adbc.Rd
+++ b/r/adbcdrivermanager/man/read_adbc.Rd
@@ -15,7 +15,7 @@ write_adbc(
   db_or_con,
   target_table,
   ...,
-  mode = c("default", "create", "append"),
+  mode = c("default", "create", "append", "replace", "create_append"),
   temporary = FALSE
 )
 }
@@ -36,8 +36,9 @@ or  \link[nanoarrow:as_nanoarrow_array_stream]{nanoarrow_array_stream}.}
 
 \item{target_table}{A target table name to which \code{tbl} should be written.}
 
-\item{mode}{One of "create", "append", or "default" (error if the schema
-is not compatible or append otherwise).}
+\item{mode}{One of \code{"create"}, \code{"append"}, \code{"replace"}, \code{"create_append"} (error if the schema
+is not compatible or append otherwise), or \code{"default"} (use the \code{adbc.ingest.mode}
+argument of \code{\link[=adbc_statement_init]{adbc_statement_init()}}). The default is \code{"default"}.}
 
 \item{temporary}{Use TRUE to create a table as a temporary table.}
 }

--- a/r/adbcsqlite/tests/testthat/test-adbcsqlite-package.R
+++ b/r/adbcsqlite/tests/testthat/test-adbcsqlite-package.R
@@ -125,3 +125,22 @@ test_that("write_adbc() with temporary = TRUE works with sqlite databases", {
   adbcdrivermanager::adbc_connection_release(con)
   adbcdrivermanager::adbc_database_release(db)
 })
+
+test_that("write_adbc() supports mode replace/create_append", {
+  skip_if_not(packageVersion("adbcdrivermanager") >= "0.20.0.9000")
+
+  db <- adbc_database_init(adbcsqlite())
+  con <- adbc_connection_init(db)
+
+  df <- data.frame(x = as.double(1:10))
+
+  adbcdrivermanager::write_adbc(mtcars, con, "df")
+  adbcdrivermanager::write_adbc(df, con, "df", mode = "replace")
+
+  stream <- adbcdrivermanager::read_adbc(con, "SELECT * from df")
+  expect_identical(as.data.frame(stream), df)
+
+  adbcdrivermanager::write_adbc(df, con, "df", mode = "create_append")
+  stream <- adbcdrivermanager::read_adbc(con, "SELECT * from df")
+  expect_identical(as.data.frame(stream), rbind(df, df))
+})


### PR DESCRIPTION
Close #3475