### PR TITLE
Fix a goroutine leak bug

### DIFF
--- a/go/adbc/driver/flightsql/flightsql_connection.go
+++ b/go/adbc/driver/flightsql/flightsql_connection.go
@@ -1131,6 +1131,7 @@ func (c *connectionImpl) Close() error {
 		}
 	}
 
+	c.clientCache.Purge()
 	err = c.cl.Close()
 	c.cl = nil
 	return adbcFromFlightStatus(err, "Close")

--- a/go/adbc/driver/flightsql/flightsql_database.go
+++ b/go/adbc/driver/flightsql/flightsql_database.go
@@ -494,6 +494,12 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 			if err != nil {
 				d.Logger.Debug("failed to close client", "error", err.Error())
 			}
+		}).PurgeVisitorFunc(func(_ interface{}, client interface{}) {
+			conn := client.(*flightsql.Client)
+			err := conn.Close()
+			if err != nil {
+				d.Logger.Debug("failed to close client", "error", err.Error())
+			}
 		}).Build()
 
 	var cnxnSupport support


### PR DESCRIPTION
**Fixed a Goroutine leak issue.**
When a connection is opened via databaseImpl, the cache clientCache is initialized to manage *flightsql.Client objects. These objects need to be properly released when the connection is closed; otherwise, a Goroutine leak occurs.

Specifically, each time a connection is opened through databaseImpl, 6 Goroutines are created. Under the existing logic, closing the connection releases 3 of these Goroutines, while the remaining 3 associated with the cached client are overlooked, resulting in a Goroutine leak.