### PR TITLE
docs: Fix macro name for exporting ADBC driver in README

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -49,6 +49,6 @@ To write an ADBC driver in Rust you have to:
 
 1. Create a new library crate with `crate-type = ["lib", "cdylib"]`.
 1. Implement the abstract API which consists of the traits `Driver`, `Database`, `Connection` and `Statement`.
-1. Export your driver to C with the macro `adbc_core::export_driver!`.
+1. Export your driver to C with the macro `adbc_ffi::export_driver!`.
 
 The resulting object file can then be loaded by other languages through their own driver manager.


### PR DESCRIPTION
The driver exporter has been moved from `adbc_core` to `adbc_ffi` in https://github.com/apache/arrow-adbc/pull/3381; however, the README remains unchanged. I found this discrepancy when upgrading the `adbc_core` dependency of [SedonaDB](https://github.com/apache/sedona-db). This out-dated information also appears in https://crates.io/crates/adbc_core and made me frustrated, so I decided to submit a PR containing this very tiny fix.