### PR TITLE
ci: macos-13 is deprecated

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet: ['8.0.x']
-        os: [ubuntu-latest, windows-2022, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-2022, macos-latest]
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -68,10 +68,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-13", "macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-latest"]
         include:
-          - os: macos-13
-            goarch: x64
           - os: macos-latest
             goarch: arm64
           - os: ubuntu-latest
@@ -156,7 +154,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-13", "macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-latest"]
     env:
       # Required for macOS
       # https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
@@ -322,7 +320,7 @@ jobs:
       matrix:
         # N.B. no macos-latest here since conda-forge does not package
         # arrow-c-glib for M1
-        os: ["macos-13", "ubuntu-latest"]
+        os: ["ubuntu-latest"]
     env:
       # Required for macOS
       # https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
@@ -395,7 +393,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-13", "macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -448,10 +446,8 @@ jobs:
       - drivers-build-conda
     strategy:
       matrix:
-        os: ["macos-13", "macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-latest"]
         include:
-          - os: macos-13
-            goarch: x64
           - os: macos-latest
             goarch: arm64
           - os: ubuntu-latest
@@ -543,7 +539,7 @@ jobs:
       - drivers-build-conda
     strategy:
       matrix:
-        os: ["macos-13", "macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-latest"]
         python: ["3.9", "3.13"]
     env:
       # Required for macOS

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-13", "macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -100,7 +100,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-13"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
 
     steps:
       - uses: actions/download-artifact@v5
@@ -743,10 +743,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-13", "macos-latest"]
+        os: ["macos-latest"]
         include:
-          - os: macos-13
-            arch: amd64
           - os: macos-latest
             arch: arm64v8
     env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,6 @@ jobs:
       matrix:
         # See: https://github.com/apache/arrow-adbc/pull/1803#issuecomment-2117669300
         os:
-          - macos-13
           - macos-latest
           - ubuntu-latest
           - windows-latest
@@ -146,11 +145,6 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           echo "DYLD_LIBRARY_PATH=/opt/homebrew/opt/sqlite/lib:${{ github.workspace }}/local/lib:$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
-          echo "ADBC_DRIVER_MANAGER_TEST_LIB=${{ github.workspace }}/local/lib/libadbc_driver_sqlite.dylib" >> "$GITHUB_ENV"
-      - name: Set dynamic linker path
-        if: matrix.os == 'macos-13'
-        run: |
-          echo "DYLD_LIBRARY_PATH=/usr/local/opt/sqlite/lib:${{ github.workspace }}/local/lib:$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
           echo "ADBC_DRIVER_MANAGER_TEST_LIB=${{ github.workspace }}/local/lib/libadbc_driver_sqlite.dylib" >> "$GITHUB_ENV"
       - name: Set dynamic linker path
         if: runner.os == 'Windows'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["macos-13", "macos-latest", "ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-latest"]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -80,7 +80,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-13", "macos-latest", "ubuntu-latest", "windows-latest"]
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

removed all references to `maco-13` except one
https://github.com/apache/arrow-adbc/blob/66461304b423b8deea75f4575a169a6cb4d76cf4/.github/workflows/packaging.yml#L559-L564