### PR TITLE
chore(go/adbc): fix deprecation warning

### DIFF
--- a/go/adbc/driver/snowflake/driver_test.go
+++ b/go/adbc/driver/snowflake/driver_test.go
@@ -2053,7 +2053,7 @@ func (suite *SnowflakeTests) TestSchemaWithLowPrecision() {
 
 	// Check actual data types in the record
 	suite.True(rdr.Next())
-	rec := rdr.Record()
+	rec := rdr.RecordBatch()
 
 	// Verify INTEGER_COL is actually Int64
 	col0 := rec.Column(0)


### PR DESCRIPTION
Caused by merging an old PR that hadn't been rebased.