### PR TITLE
fix(csharp/test/Drivers/Databricks): Disable UseDescTableExtended by default

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksConnection.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksConnection.cs
@@ -74,7 +74,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         private long _maxBytesPerFetchRequest = DefaultMaxBytesPerFetchRequest;
         private const bool DefaultRetryOnUnavailable = true;
         private const int DefaultTemporarilyUnavailableRetryTimeout = 900;
-        private bool _useDescTableExtended = true;
+        private bool _useDescTableExtended = false;
 
         // Trace propagation configuration
         private bool _tracePropagationEnabled = true;


### PR DESCRIPTION
## Motivation

Disable `UseDescTableExtended` (use `DESC TABLE AS JOIN` to get metadata) by default in the Databricks Driver, so it will not call `DESC TABLE AS JSON` to get the meta data in Power BI by default. But customer can turn it on by setting `UseDescTableExtended=1` as the connection property in Power BI or setting `adbc.databricks.use_desc_table_extended=true` as ADBC connection properties.

## Change
- Set `DatabricksConnection:_useDescTableExtended` default value as `false`

## Test
- Unit test and E2E test