### PR TITLE
docs: update docs site footer for new ASF logo

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ sys.path.append(str(Path("./ext").resolve()))
 
 project = "ADBC"
 copyright = """2022–2025 The Apache Software Foundation.  Apache Arrow, Arrow,
-Apache, the Apache feather logo, and the Apache Arrow project logo are either
+Apache, the Apache logo, and the Apache Arrow project logo are either
 registered trademarks or trademarks of The Apache Software Foundation in the
 United States and other countries."""
 author = "the Apache Arrow Developers"


### PR DESCRIPTION
Replace "Apache feather logo" with "Apache logo" just like in https://github.com/apache/arrow/pull/47647.