### PR TITLE
feat(go/adbc/driver/snowflake): Add option to disable vectorized scanner

### DIFF
--- a/go/adbc/driver/snowflake/bulk_ingestion.go
+++ b/go/adbc/driver/snowflake/bulk_ingestion.go
@@ -179,7 +179,12 @@ func (st *statement) ingestRecord(ctx context.Context) (nrows int64, err error) 
 	})
 
 	// Create a temporary stage, we can't start uploading until it has been created
-	createTemporaryStageStmt := fmt.Sprintf(createTemporaryStageTmpl, "")
+	var createTemporaryStageStmt string
+	if st.ingestOptions.vectorizedScanner {
+		createTemporaryStageStmt = fmt.Sprintf(createTemporaryStageTmpl, vectorizedScannerOption)
+	} else {
+		createTemporaryStageStmt = fmt.Sprintf(createTemporaryStageTmpl, "")
+	}
 	_, err = st.cnxn.cn.ExecContext(ctx, createTemporaryStageStmt, nil)
 	if err != nil {
 		return

--- a/go/adbc/driver/snowflake/statement.go
+++ b/go/adbc/driver/snowflake/statement.go
@@ -46,7 +46,7 @@ const (
 	OptionStatementIngestTargetFileSize    = "adbc.snowflake.statement.ingest_target_file_size"
 	OptionStatementIngestCompressionCodec  = "adbc.snowflake.statement.ingest_compression_codec" // TODO(GH-1473): Implement option
 	OptionStatementIngestCompressionLevel  = "adbc.snowflake.statement.ingest_compression_level" // TODO(GH-1473): Implement option
-	OptionStatementVectorizedScanner       = "adbc.snowflake.statement.use_vectorized_scanner"
+	OptionStatementVectorizedScanner       = "adbc.snowflake.statement.ingest_use_vectorized_scanner"
 )
 
 type statement struct {


### PR DESCRIPTION
The vectorized scanner seems to be causing performance issues under some circumstances. Add an option to disable it.