### PR TITLE
fix(csharp/src/Drivers/Databricks): update error type for connection errors when possible

### DIFF
--- a/csharp/src/Drivers/Databricks/DatabricksDatabase.cs
+++ b/csharp/src/Drivers/Databricks/DatabricksDatabase.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Apache.Arrow.Adbc.Drivers.Apache;
 
 namespace Apache.Arrow.Adbc.Drivers.Databricks
 {
@@ -35,15 +36,30 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
 
         public override AdbcConnection Connect(IReadOnlyDictionary<string, string>? options)
         {
-            IReadOnlyDictionary<string, string> mergedProperties = options == null
-                ? properties
-                : options
-                    .Concat(properties.Where(x => !options.Keys.Contains(x.Key, StringComparer.OrdinalIgnoreCase)))
-                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
-            DatabricksConnection connection = new DatabricksConnection(mergedProperties);
-            connection.OpenAsync().Wait();
-            connection.ApplyServerSidePropertiesAsync().Wait();
-            return connection;
+            try
+            {
+                IReadOnlyDictionary<string, string> mergedProperties = options == null
+                    ? properties
+                    : options
+                        .Concat(properties.Where(x => !options.Keys.Contains(x.Key, StringComparer.OrdinalIgnoreCase)))
+                        .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+                DatabricksConnection connection = new DatabricksConnection(mergedProperties);
+                connection.OpenAsync().Wait();
+                connection.ApplyServerSidePropertiesAsync().Wait();
+                return connection;
+            }
+            catch (AggregateException ae)
+            {
+                // Unwrap AggregateException to AdbcException if possible
+                // to better conform to the ADBC standard
+                if (ApacheUtility.ContainsException(ae, out AdbcException? adbcException) && adbcException != null)
+                {
+                    // keep the entire chain, but throw the AdbcException
+                    throw new AdbcException(adbcException.Message, adbcException.Status, ae);
+                }
+
+                throw;
+            }
         }
     }
 }

--- a/csharp/test/Drivers/Databricks/E2E/DriverTests.cs
+++ b/csharp/test/Drivers/Databricks/E2E/DriverTests.cs
@@ -98,7 +98,7 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             }
 
             AdbcDatabase database = driver.Open(parameters);
-            AggregateException exception = Assert.ThrowsAny<AggregateException>(() => database.Connect(parameters));
+            AdbcException exception = Assert.ThrowsAny<AdbcException>(() => database.Connect(parameters));
             OutputHelper?.WriteLine(exception.Message);
         }
 
@@ -130,10 +130,9 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks
             }
 
             AdbcDatabase database = driver.Open(parameters);
-            AggregateException exception = Assert.ThrowsAny<AggregateException>(() => database.Connect(parameters));
-            Assert.True(ApacheUtility.ContainsException(exception, out AdbcException? adbcException), $"Expect AdbcException. Actual type: {exception.GetType().Name}");
-            Assert.Equal(AdbcStatusCode.Unauthorized, adbcException!.Status);
-            OutputHelper?.WriteLine(exception.Message);
+            AdbcException adbcException = Assert.ThrowsAny<AdbcException>(() => database.Connect(parameters));
+            Assert.Equal(AdbcStatusCode.Unauthorized, adbcException.Status);
+            OutputHelper?.WriteLine(adbcException.Message);
         }
 
         protected override IReadOnlyList<int> GetUpdateExpectedResults()


### PR DESCRIPTION
The driver currently throws an AggregateException when an error occurs during the `connection.OpenAsync().Wait();` call. This PR attempts to unwind the AggregateException and throw an AdbcException to conform to the ADBC spec. It keeps the AggregateException as the InnerException of the throw AdbcException to maintain the integrity of the stack.