### PR TITLE
fix(java/driver/flight-sql): use FlightSqlClientWithCallOptions for prepared statement operations to ensure CallOptions get set

### DIFF
--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlClientWithCallOptions.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlClientWithCallOptions.java
@@ -58,6 +58,10 @@ public class FlightSqlClientWithCallOptions implements AutoCloseable {
     return client.execute(query, transaction, combine(options));
   }
 
+  public FlightInfo executePrepared(PreparedStatement statement, CallOption... options) {
+    return statement.execute(combine(options));
+  }
+
   public FlightInfo executeSubstrait(SubstraitPlan plan, CallOption... options) {
     return client.executeSubstrait(plan, combine(options));
   }
@@ -92,6 +96,10 @@ public class FlightSqlClientWithCallOptions implements AutoCloseable {
 
   public long executeUpdate(String query, Transaction transaction, CallOption... options) {
     return client.executeUpdate(query, transaction, combine(options));
+  }
+
+  public long executePreparedUpdate(PreparedStatement statement, CallOption... options) {
+    return statement.executeUpdate(combine(options));
   }
 
   public long executeSubstraitUpdate(SubstraitPlan plan, CallOption... options) {

--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlStatement.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlStatement.java
@@ -168,7 +168,7 @@ public class FlightSqlStatement implements AdbcStatement {
     try {
       try {
         statement.setParameters(new NonOwningRoot(bindParams));
-        statement.executeUpdate();
+        client.executePreparedUpdate(statement);
       } finally {
         statement.close();
       }
@@ -218,7 +218,7 @@ public class FlightSqlStatement implements AdbcStatement {
       throw AdbcException.invalidState("[Flight SQL] Must setSqlQuery() before execute");
     }
     final String query = sqlQuery;
-    return execute(FlightSqlClient.PreparedStatement::execute, (client) -> client.execute(query));
+    return execute(client::executePrepared, (client) -> client.execute(query));
   }
 
   @Override
@@ -277,7 +277,7 @@ public class FlightSqlStatement implements AdbcStatement {
             (preparedStatement) -> {
               // XXX(ARROW-17199): why does this throw SQLException?
               try {
-                return preparedStatement.executeUpdate();
+                return client.executePreparedUpdate(preparedStatement);
               } catch (FlightRuntimeException e) {
                 throw FlightSqlDriverUtil.fromFlightException(e);
               }


### PR DESCRIPTION
Use FlightSqlClientWithCallOptions for prepared statement operations to ensure CallOptions get set

Fixes #3582 