### PR TITLE
fix(csharp/src/Drivers): correct the call to TraceActivityAsync

### DIFF
--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2Connection.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2Connection.cs
@@ -343,7 +343,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
 
         internal async Task OpenAsync()
         {
-            await this.TraceActivity(async activity =>
+            await this.TraceActivityAsync(async activity =>
             {
                 CancellationToken cancellationToken = ApacheUtility.GetCancellationToken(ConnectTimeoutMilliseconds, ApacheUtility.TimeUnit.Milliseconds);
                 try

--- a/csharp/src/Drivers/Apache/Hive2/HiveServer2Reader.cs
+++ b/csharp/src/Drivers/Apache/Hive2/HiveServer2Reader.cs
@@ -97,7 +97,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Hive2
 
         public override async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
         {
-            return await this.TraceActivity(async activity =>
+            return await this.TraceActivityAsync(async activity =>
             {
                 // All records have been exhausted
                 if (_hasNoMoreData)

--- a/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
+++ b/csharp/src/Drivers/BigQuery/BigQueryStatement.cs
@@ -88,7 +88,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
 
         private async Task<QueryResult> ExecuteQueryInternalAsync()
         {
-            return await this.TraceActivity(async activity =>
+            return await this.TraceActivityAsync(async activity =>
             {
                 QueryOptions queryOptions = ValidateOptions(activity);
 
@@ -262,7 +262,7 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
 
         private async Task<UpdateResult> ExecuteUpdateInternalAsync()
         {
-            return await this.TraceActivity(async activity =>
+            return await this.TraceActivityAsync(async activity =>
             {
                 GetQueryResultsOptions getQueryResultsOptions = new GetQueryResultsOptions();
 

--- a/csharp/src/Drivers/Databricks/Reader/DatabricksReader.cs
+++ b/csharp/src/Drivers/Databricks/Reader/DatabricksReader.cs
@@ -50,7 +50,7 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader
 
         public override async ValueTask<RecordBatch?> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
         {
-            return await this.TraceActivity(async activity =>
+            return await this.TraceActivityAsync(async activity =>
             {
                 ThrowIfDisposed();
 


### PR DESCRIPTION
This fix corrects the calls to `TraceActivity` when async to use `TraceActivityAsync`, instead.