### PR TITLE
fix(csharp/src/Apache.Arrow.Adbc): Expose extensions to package in NuGet

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/Extensions/ListArrayExtensions.cs
+++ b/csharp/src/Apache.Arrow.Adbc/Extensions/ListArrayExtensions.cs
@@ -21,7 +21,7 @@ using Apache.Arrow.Types;
 
 namespace Apache.Arrow.Adbc.Extensions
 {
-    internal static class ListArrayExtensions
+    public static class ListArrayExtensions
     {
         /// <summary>
         /// Builds a <see cref="ListArray"/> from a list of <see cref="IArrowArray"/> data for the given datatype <see cref="IArrowArray"/>.

--- a/csharp/src/Apache.Arrow.Adbc/Extensions/StandardSchemaExtensions.cs
+++ b/csharp/src/Apache.Arrow.Adbc/Extensions/StandardSchemaExtensions.cs
@@ -22,7 +22,7 @@ using Apache.Arrow.Types;
 
 namespace Apache.Arrow.Adbc.Extensions
 {
-    internal static class StandardSchemaExtensions
+    public static class StandardSchemaExtensions
     {
 
         /// <summary>


### PR DESCRIPTION
Exposes the ListArrayExtensions and StandardSchemaExtensions to prepare for the Foundry integration.