### PR TITLE
feat(go/adbc/driver/bigquery): Add option to link failed jobs 

### DIFF
--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -110,6 +110,10 @@ const (
 	// OptionStringImpersonateLifetime instructs the driver to impersonate for the
 	// given duration (e.g. "3600s").
 	OptionStringImpersonateLifetime = "adbc.bigquery.sql.impersonate.lifetime"
+
+	// OptionBoolQueryLinkFailedJob instructs the driver to construct a link to the
+	// query job if it fails to run.
+	OptionBoolQueryLinkFailedJob = "adbc.bigquery.sql.query.link_failed_job"
 )
 
 var (


### PR DESCRIPTION
Added an option to wrap query errors on Bigquery with a link to the failing query job. This is configurable via "adbc.bigquery.sql.query.link_failed_job".