### PR TITLE
fix(csharp/src/Drivers/BigQuery): improve selective handling of cancellation exception

### DIFF
--- a/csharp/src/Drivers/BigQuery/RetryManager.cs
+++ b/csharp/src/Drivers/BigQuery/RetryManager.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Apache.Arrow.Adbc.Drivers.BigQuery
@@ -32,7 +33,8 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
             Func<Task<T>> action,
             Activity? activity,
             int maxRetries = 5,
-            int initialDelayMilliseconds = 200)
+            int initialDelayMilliseconds = 200,
+            CancellationToken cancellationToken = default)
         {
             if (action == null)
             {
@@ -49,8 +51,10 @@ namespace Apache.Arrow.Adbc.Drivers.BigQuery
                     T result = await action();
                     return result;
                 }
-                catch (Exception ex) when (!BigQueryUtils.ContainsException(ex, out OperationCanceledException? _))
+                catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
                 {
+                    // Note: OperationCanceledException could be thrown from the call,
+                    // but we only want to break out when the cancellation was requested from the caller.
                     activity?.AddBigQueryTag("retry_attempt", retryCount);
                     activity?.AddException(ex);
 


### PR DESCRIPTION
After adding cancellation functionality to BigQuery statements, there is a report that `task was cancelled` messages are now appearing.

This is likely due to the change where the retry code stops processing when it gets a `OperationCancelledExecption`.

This change now only exits early if the cancellation was requested on the passed cancellation token.