### PR TITLE
feat(go/adbc/driver/bigquery): Support setting quota project for connection

### DIFF
--- a/go/adbc/driver/bigquery/bigquery_database.go
+++ b/go/adbc/driver/bigquery/bigquery_database.go
@@ -44,9 +44,10 @@ type databaseImpl struct {
 	// projectID is the catalog
 	projectID string
 	// datasetID is the schema
-	datasetID string
-	tableID   string
-	location  string
+	datasetID    string
+	tableID      string
+	location     string
+	quotaProject string
 }
 
 func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
@@ -67,6 +68,7 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 		location:                   d.location,
 		resultRecordBufferSize:     defaultQueryResultBufferSize,
 		prefetchConcurrency:        defaultQueryPrefetchConcurrency,
+		quotaProject:               d.quotaProject,
 	}
 
 	err := conn.newClient(ctx)
@@ -96,6 +98,8 @@ func (d *databaseImpl) GetOption(key string) (string, error) {
 		return d.clientSecret, nil
 	case OptionStringAuthRefreshToken:
 		return d.refreshToken, nil
+	case OptionStringAuthQuotaProject:
+		return d.quotaProject, nil
 	case OptionStringLocation:
 		return d.location, nil
 	case OptionStringProjectID:
@@ -158,6 +162,8 @@ func (d *databaseImpl) SetOption(key string, value string) error {
 		d.clientSecret = value
 	case OptionStringAuthRefreshToken:
 		d.refreshToken = value
+	case OptionStringAuthQuotaProject:
+		d.quotaProject = value
 	case OptionStringImpersonateTargetPrincipal:
 		d.impersonateTargetPrincipal = value
 	case OptionStringImpersonateDelegates:

--- a/go/adbc/driver/bigquery/connection.go
+++ b/go/adbc/driver/bigquery/connection.go
@@ -51,6 +51,7 @@ type connectionImpl struct {
 	clientID     string
 	clientSecret string
 	refreshToken string
+	quotaProject string
 
 	impersonateTargetPrincipal string
 	impersonateDelegates       []string
@@ -468,6 +469,8 @@ func (c *connectionImpl) GetOption(key string) (string, error) {
 		return c.clientSecret, nil
 	case OptionStringAuthRefreshToken:
 		return c.refreshToken, nil
+	case OptionStringAuthQuotaProject:
+		return c.quotaProject, nil
 	case OptionStringProjectID:
 		return c.catalog, nil
 	case OptionStringDatasetID:
@@ -500,6 +503,8 @@ func (c *connectionImpl) SetOption(key string, value string) error {
 		c.clientSecret = value
 	case OptionStringAuthRefreshToken:
 		c.refreshToken = value
+	case OptionStringAuthQuotaProject:
+		c.quotaProject = value
 	case OptionStringImpersonateTargetPrincipal:
 		c.impersonateTargetPrincipal = value
 	case OptionStringImpersonateDelegates:
@@ -589,6 +594,11 @@ func (c *connectionImpl) newClient(ctx context.Context) error {
 			Code: adbc.StatusInvalidArgument,
 			Msg:  fmt.Sprintf("Unknown auth type: %s", c.authType),
 		}
+	}
+
+	// Set quota project id if configured
+	if c.quotaProject != "" {
+		authOptions = append(authOptions, option.WithQuotaProject(c.quotaProject))
 	}
 
 	// Then, apply impersonation if configured (as a credential transformation layer)

--- a/go/adbc/driver/bigquery/driver.go
+++ b/go/adbc/driver/bigquery/driver.go
@@ -46,6 +46,7 @@ const (
 	OptionStringAuthClientID              = "adbc.bigquery.sql.auth.client_id"
 	OptionStringAuthClientSecret          = "adbc.bigquery.sql.auth.client_secret"
 	OptionStringAuthRefreshToken          = "adbc.bigquery.sql.auth.refresh_token"
+	OptionStringAuthQuotaProject          = "adbc.bigquery.sql.auth.quota_project"
 
 	// OptionStringQueryParameterMode specifies if the query uses positional syntax ("?")
 	// or the named syntax ("@p"). It is illegal to mix positional and named syntax.


### PR DESCRIPTION
Adds an option to the Bigquery driver for configuring the quota project ("adbc.bigquery.sql.auth.quota_project") (see [Cloud Docs](https://docs.cloud.google.com/docs/quotas/quota-project)), so users can specify a different project to bill for query execution.

This was previously only [configurable via environment variable](https://docs.cloud.google.com/docs/quotas/set-quota-project#set-project-variable).