### PR TITLE
feat(c/include/arrow-adbc): Add AdbcStatementRequestSchema

### DIFF
--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -3363,7 +3363,6 @@ AdbcStatusCode AdbcLoadDriverFromInitFunc(AdbcDriverInitFunc init_func, int vers
     FILL_DEFAULT(driver, StatementSetOption);
     FILL_DEFAULT(driver, StatementSetSqlQuery);
     FILL_DEFAULT(driver, StatementSetSubstraitPlan);
-    FILL_DEFAULT(driver, StatementRequestSchema);
   }
   if (version >= ADBC_VERSION_1_1_0) {
     auto* driver = reinterpret_cast<struct AdbcDriver*>(raw_driver);
@@ -3399,6 +3398,10 @@ AdbcStatusCode AdbcLoadDriverFromInitFunc(AdbcDriverInitFunc init_func, int vers
     FILL_DEFAULT(driver, StatementSetOptionBytes);
     FILL_DEFAULT(driver, StatementSetOptionDouble);
     FILL_DEFAULT(driver, StatementSetOptionInt);
+  }
+  if (version >= ADBC_VERSION_1_2_0) {
+    auto* driver = reinterpret_cast<struct AdbcDriver*>(raw_driver);
+    FILL_DEFAULT(driver, StatementRequestSchema);
   }
 
   return ADBC_STATUS_OK;

--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -1764,6 +1764,12 @@ AdbcStatusCode StatementSetSubstraitPlan(struct AdbcStatement*, const uint8_t*, 
   return ADBC_STATUS_NOT_IMPLEMENTED;
 }
 
+AdbcStatusCode StatementRequestSchema(struct AdbcStatement*, struct ArrowSchema*,
+                                      struct AdbcError* error) {
+  SetError(error, "AdbcStatementRequestSchema not implemented");
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
 /// Temporary state while the database is being configured.
 struct TempDatabase {
   std::unordered_map<std::string, std::string> options;
@@ -3159,6 +3165,17 @@ AdbcStatusCode AdbcStatementSetSubstraitPlan(struct AdbcStatement* statement,
                                                               error);
 }
 
+AdbcStatusCode AdbcStatementRequestSchema(struct AdbcStatement* statement,
+                                          struct ArrowSchema* schema,
+                                          struct AdbcError* error) {
+  if (!statement->private_driver) {
+    SetError(error, "AdbcStatementRequestSchema: must call AdbcStatementNew first");
+    return ADBC_STATUS_INVALID_STATE;
+  }
+  INIT_ERROR(error, statement);
+  return statement->private_driver->StatementRequestSchema(statement, schema, error);
+}
+
 const char* AdbcStatusCodeMessage(AdbcStatusCode code) {
 #define CASE(CONSTANT)         \
   case ADBC_STATUS_##CONSTANT: \
@@ -3346,6 +3363,7 @@ AdbcStatusCode AdbcLoadDriverFromInitFunc(AdbcDriverInitFunc init_func, int vers
     FILL_DEFAULT(driver, StatementSetOption);
     FILL_DEFAULT(driver, StatementSetSqlQuery);
     FILL_DEFAULT(driver, StatementSetSubstraitPlan);
+    FILL_DEFAULT(driver, StatementRequestSchema);
   }
   if (version >= ADBC_VERSION_1_1_0) {
     auto* driver = reinterpret_cast<struct AdbcDriver*>(raw_driver);

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -2304,10 +2304,7 @@ AdbcStatusCode AdbcStatementExecuteSchema(struct AdbcStatement* statement,
 /// consistent schema when executing queries against a database
 /// with row-based types (e.g., SQLite) or a database whose types
 /// are implemented with row-based parameters where Arrow prefers
-/// type-level parameters (e.g., NUMERIC for PostgreSQL). Callers
-/// may also use a transformation of the schema provided by
-/// AdbcStatementExecuteSchema to request specific Arrow type
-/// variants such as string views or list views.
+/// type-level parameters (e.g., NUMERIC for PostgreSQL).
 ///
 /// The provided schema is a request and not a guarantee (i.e.,
 /// callers must use the schema provided by the output stream to

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -1255,10 +1255,6 @@ struct ADBC_EXPORT AdbcDriver {
   AdbcStatusCode (*StatementSetOptionInt)(struct AdbcStatement*, const char*, int64_t,
                                           struct AdbcError*);
 
-  // ADBC 1.2
-  AdbcStatusCode (*StatementRequestSchema)(struct AdbcStatement*, struct ArrowSchema*,
-                                           struct AdbcError*);
-
   /// @}
 
   /// \defgroup adbc-1.2.0 ADBC API Revision 1.2.0
@@ -1293,6 +1289,9 @@ struct ADBC_EXPORT AdbcDriver {
                                                 struct AdbcError*);
   AdbcStatusCode (*StatementExecuteMulti)(struct AdbcStatement*,
                                           struct AdbcMultiResultSet*, struct AdbcError*);
+
+  AdbcStatusCode (*StatementRequestSchema)(struct AdbcStatement*, struct ArrowSchema*,
+                                           struct AdbcError*);
 
   /// @}
 };

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -2293,6 +2293,31 @@ AdbcStatusCode AdbcStatementExecuteSchema(struct AdbcStatement* statement,
                                           struct ArrowSchema* schema,
                                           struct AdbcError* error);
 
+/// \brief Request the schema of the next statement execution
+///
+/// Allows the caller to request a specific schema based on prior
+/// information or user input. This may be used to ensure a
+/// consistent schema when executing queries against a database
+/// with row-based types (e.g., SQLite) or a database whose types
+/// are implemented with row-based parameters where Arrow prefers
+/// type-level parameters (e.g., NUMERIC for PostgreSQL). Callers
+/// may also use a transformation of the schema provided by
+/// AdbcStatementExecuteSchema to request specific Arrow type
+/// variants such as string views or list views.
+///
+/// \since ADBC API revision 1.2.0
+///
+/// \param[in] statement The statement to execute.
+/// \param[in] schema The requested schema.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+///
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the driver does not support this.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementRequestSchema(struct AdbcStatement* statement,
+                                          struct ArrowSchema* schema,
+                                          struct AdbcError* error);
+
 /// \brief Turn this statement into a prepared statement to be
 ///   executed multiple times.
 ///

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -1255,6 +1255,10 @@ struct ADBC_EXPORT AdbcDriver {
   AdbcStatusCode (*StatementSetOptionInt)(struct AdbcStatement*, const char*, int64_t,
                                           struct AdbcError*);
 
+  // ADBC 1.2
+  AdbcStatusCode (*StatementRequestSchema)(struct AdbcStatement*, struct ArrowSchema*,
+                                           struct AdbcError*);
+
   /// @}
 
   /// \defgroup adbc-1.2.0 ADBC API Revision 1.2.0
@@ -2304,6 +2308,14 @@ AdbcStatusCode AdbcStatementExecuteSchema(struct AdbcStatement* statement,
 /// may also use a transformation of the schema provided by
 /// AdbcStatementExecuteSchema to request specific Arrow type
 /// variants such as string views or list views.
+///
+/// The provided schema is a request and not a guarantee (i.e.,
+/// callers must use the schema provided by the output stream to
+/// interpret the result).
+///
+/// Calling AdbcStatementRequestSchema() must not affect the result
+/// of AdbcStatementExecuteSchema (which always infers its result
+/// from the input query).
 ///
 /// \since ADBC API revision 1.2.0
 ///

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -2303,7 +2303,11 @@ AdbcStatusCode AdbcStatementExecuteSchema(struct AdbcStatement* statement,
 /// consistent schema when executing queries against a database
 /// with row-based types (e.g., SQLite) or a database whose types
 /// are implemented with row-based parameters where Arrow prefers
-/// type-level parameters (e.g., NUMERIC for PostgreSQL).
+/// type-level parameters (e.g., NUMERIC for PostgreSQL). The
+/// schema request is intended to modify only the types or
+/// widen the nullability of types in the original schema;
+/// column reordering or changing the number of returned columns
+/// is not a goal of this feature.
 ///
 /// The provided schema is a request and not a guarantee (i.e.,
 /// callers must use the schema provided by the output stream to

--- a/go/adbc/drivermgr/adbc_driver_manager.cc
+++ b/go/adbc/drivermgr/adbc_driver_manager.cc
@@ -1764,6 +1764,12 @@ AdbcStatusCode StatementSetSubstraitPlan(struct AdbcStatement*, const uint8_t*, 
   return ADBC_STATUS_NOT_IMPLEMENTED;
 }
 
+AdbcStatusCode StatementRequestSchema(struct AdbcStatement*, struct ArrowSchema*,
+                                      struct AdbcError* error) {
+  SetError(error, "AdbcStatementRequestSchema not implemented");
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
 /// Temporary state while the database is being configured.
 struct TempDatabase {
   std::unordered_map<std::string, std::string> options;
@@ -3159,6 +3165,17 @@ AdbcStatusCode AdbcStatementSetSubstraitPlan(struct AdbcStatement* statement,
                                                               error);
 }
 
+AdbcStatusCode AdbcStatementRequestSchema(struct AdbcStatement* statement,
+                                          struct ArrowSchema* schema,
+                                          struct AdbcError* error) {
+  if (!statement->private_driver) {
+    SetError(error, "AdbcStatementRequestSchema: must call AdbcStatementNew first");
+    return ADBC_STATUS_INVALID_STATE;
+  }
+  INIT_ERROR(error, statement);
+  return statement->private_driver->StatementRequestSchema(statement, schema, error);
+}
+
 const char* AdbcStatusCodeMessage(AdbcStatusCode code) {
 #define CASE(CONSTANT)         \
   case ADBC_STATUS_##CONSTANT: \
@@ -3381,6 +3398,10 @@ AdbcStatusCode AdbcLoadDriverFromInitFunc(AdbcDriverInitFunc init_func, int vers
     FILL_DEFAULT(driver, StatementSetOptionBytes);
     FILL_DEFAULT(driver, StatementSetOptionDouble);
     FILL_DEFAULT(driver, StatementSetOptionInt);
+  }
+  if (version >= ADBC_VERSION_1_2_0) {
+    auto* driver = reinterpret_cast<struct AdbcDriver*>(raw_driver);
+    FILL_DEFAULT(driver, StatementRequestSchema);
   }
 
   return ADBC_STATUS_OK;

--- a/go/adbc/drivermgr/arrow-adbc/adbc.h
+++ b/go/adbc/drivermgr/arrow-adbc/adbc.h
@@ -1255,6 +1255,10 @@ struct ADBC_EXPORT AdbcDriver {
   AdbcStatusCode (*StatementSetOptionInt)(struct AdbcStatement*, const char*, int64_t,
                                           struct AdbcError*);
 
+  // ADBC 1.2
+  AdbcStatusCode (*StatementRequestSchema)(struct AdbcStatement*, struct ArrowSchema*,
+                                           struct AdbcError*);
+
   /// @}
 
   /// \defgroup adbc-1.2.0 ADBC API Revision 1.2.0
@@ -2290,6 +2294,36 @@ AdbcStatusCode AdbcStatementExecuteMulti(struct AdbcStatement* statement,
 /// \return ADBC_STATUS_NOT_IMPLEMENTED if the driver does not support this.
 ADBC_EXPORT
 AdbcStatusCode AdbcStatementExecuteSchema(struct AdbcStatement* statement,
+                                          struct ArrowSchema* schema,
+                                          struct AdbcError* error);
+
+/// \brief Request the schema of the next statement execution
+///
+/// Allows the caller to request a specific schema based on prior
+/// information or user input. This may be used to ensure a
+/// consistent schema when executing queries against a database
+/// with row-based types (e.g., SQLite) or a database whose types
+/// are implemented with row-based parameters where Arrow prefers
+/// type-level parameters (e.g., NUMERIC for PostgreSQL).
+///
+/// The provided schema is a request and not a guarantee (i.e.,
+/// callers must use the schema provided by the output stream to
+/// interpret the result).
+///
+/// Calling AdbcStatementRequestSchema() must not affect the result
+/// of AdbcStatementExecuteSchema (which always infers its result
+/// from the input query).
+///
+/// \since ADBC API revision 1.2.0
+///
+/// \param[in] statement The statement to execute.
+/// \param[in] schema The requested schema.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+///
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if the driver does not support this.
+ADBC_EXPORT
+AdbcStatusCode AdbcStatementRequestSchema(struct AdbcStatement* statement,
                                           struct ArrowSchema* schema,
                                           struct AdbcError* error);
 

--- a/go/adbc/drivermgr/arrow-adbc/adbc.h
+++ b/go/adbc/drivermgr/arrow-adbc/adbc.h
@@ -1255,10 +1255,6 @@ struct ADBC_EXPORT AdbcDriver {
   AdbcStatusCode (*StatementSetOptionInt)(struct AdbcStatement*, const char*, int64_t,
                                           struct AdbcError*);
 
-  // ADBC 1.2
-  AdbcStatusCode (*StatementRequestSchema)(struct AdbcStatement*, struct ArrowSchema*,
-                                           struct AdbcError*);
-
   /// @}
 
   /// \defgroup adbc-1.2.0 ADBC API Revision 1.2.0
@@ -1293,6 +1289,9 @@ struct ADBC_EXPORT AdbcDriver {
                                                 struct AdbcError*);
   AdbcStatusCode (*StatementExecuteMulti)(struct AdbcStatement*,
                                           struct AdbcMultiResultSet*, struct AdbcError*);
+
+  AdbcStatusCode (*StatementRequestSchema)(struct AdbcStatement*, struct ArrowSchema*,
+                                           struct AdbcError*);
 
   /// @}
 };

--- a/go/adbc/drivermgr/arrow-adbc/adbc.h
+++ b/go/adbc/drivermgr/arrow-adbc/adbc.h
@@ -2303,7 +2303,11 @@ AdbcStatusCode AdbcStatementExecuteSchema(struct AdbcStatement* statement,
 /// consistent schema when executing queries against a database
 /// with row-based types (e.g., SQLite) or a database whose types
 /// are implemented with row-based parameters where Arrow prefers
-/// type-level parameters (e.g., NUMERIC for PostgreSQL).
+/// type-level parameters (e.g., NUMERIC for PostgreSQL). The
+/// schema request is intended to modify only the types or
+/// widen the nullability of types in the original schema;
+/// column reordering or changing the number of returned columns
+/// is not a goal of this feature.
 ///
 /// The provided schema is a request and not a guarantee (i.e.,
 /// callers must use the schema provided by the output stream to


### PR DESCRIPTION
This PR proposes a 1.2 spec addition `AdbcStatementRequestSchema()`. There are a few decisions here and while I put specific language in I think any version of these is still helpful:

- I wrote this up as this best-effort (like the PyCapsule `requested_schema`). I think this is better for negotiation (e.g., the caller calls execute schema, requests a schema with all strings/binary/list columns as views, and the driver produces string/binary views but not list views because it doesn't implement those). A strict version is also useful and might generate better errors.
- Maybe `struct ArrowSchema*` should be `const ArrowSchema*`. I'm not sure this matters (mostly the C struct will be populated specifically for this call and they are easy to copy).
- No opinions on `RequestSchema` as the name if there's a better one

The capability to do this is built in to the Postgres driver already for some types (the COPY reader was designed to always accept an arbitrary ArrowSchema, which we currently just infer before constructing the reader).

Other 1.2 spec additions in https://github.com/apache/arrow-adbc/pull/3607 (which also contains the infrastructure for a new ADBC minor version).

Closes #1514 .