### PR TITLE
feat(csharp/src/Drivers/Databricks): consolidate LZ4 decompression logic and improve resource disposal

### DIFF
--- a/csharp/src/Drivers/Databricks/Lz4Utilities.cs
+++ b/csharp/src/Drivers/Databricks/Lz4Utilities.cs
@@ -76,6 +76,21 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks
         }
 
         /// <summary>
+        /// Asynchronously decompresses LZ4 compressed data into memory.
+        /// Returns the buffer and length as a tuple for efficient wrapping in a MemoryStream.
+        /// </summary>
+        /// <param name="compressedData">The compressed data bytes.</param>
+        /// <param name="cancellationToken">Cancellation token for the async operation.</param>
+        /// <returns>A tuple containing the decompressed buffer and its valid length.</returns>
+        /// <exception cref="AdbcException">Thrown when decompression fails.</exception>
+        public static Task<(byte[] buffer, int length)> DecompressLz4Async(
+            byte[] compressedData,
+            CancellationToken cancellationToken = default)
+        {
+            return DecompressLz4Async(compressedData, DefaultBufferSize, cancellationToken);
+        }
+
+        /// <summary>
         /// Asynchronously decompresses LZ4 compressed data into memory with a specified buffer size.
         /// Returns the buffer and length as a tuple for efficient wrapping in a MemoryStream.
         /// </summary>

--- a/csharp/src/Drivers/Databricks/Reader/CloudFetch/CloudFetchDownloader.cs
+++ b/csharp/src/Drivers/Databricks/Reader/CloudFetch/CloudFetchDownloader.cs
@@ -496,7 +496,6 @@ namespace Apache.Arrow.Adbc.Drivers.Databricks.Reader.CloudFetch
                         // Use shared Lz4Utilities for decompression (consolidates logic with non-CloudFetch path)
                         var (buffer, length) = await Lz4Utilities.DecompressLz4Async(
                             fileData,
-                            81920,
                             cancellationToken).ConfigureAwait(false);
 
                         // Create the dataStream from the decompressed buffer


### PR DESCRIPTION
## Summary
This PR consolidates LZ4 decompression code paths and ensures proper resource cleanup across both CloudFetch and non-CloudFetch readers in the Databricks C# driver.

## Changes
- **Lz4Utilities.cs**
  - Add configurable buffer size parameter to `DecompressLz4()`
  - Add async variant `DecompressLz4Async()` for CloudFetch pipeline
  - Add proper `using` statements for MemoryStream disposal
  - Add default buffer size constant (80KB)

- **CloudFetchDownloader.cs**
  - Update to use shared `Lz4Utilities.DecompressLz4Async()`
  - Reduce code duplication (~12 lines consolidated)
  - Improve telemetry with compression ratio calculation

## Benefits
- **Code Quality**: Both code paths now share the same decompression implementation, reducing duplication
- **Resource Management**: Explicit MemoryStream disposal improves memory hygiene (though GC would handle cleanup)
- **Maintainability**: Single source of truth for LZ4 decompression logic
- **Consistency**: Same error handling and telemetry patterns across both paths

## Technical Details
- Default buffer size remains 80KB (81920 bytes) - no behavioral changes
- Async version returns `(byte[] buffer, int length)` tuple for efficient MemoryStream wrapping in CloudFetch
- Buffer validity preserved after MemoryStream disposal via reference counting
- Maintains cancellation token support in async path
- No performance impact - purely refactoring and cleanup

## Testing
- Existing unit tests pass
- No functional changes to decompression logic
- Telemetry output remains consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)