### PR TITLE
test(glib,ruby): pin power_assert

### DIFF
--- a/glib/Gemfile
+++ b/glib/Gemfile
@@ -37,4 +37,6 @@ IO.pipe do |input, output|
   end
 end
 gem "red-arrow", red_arrow_version
+# 3.0.0 has a breaking change
+gem "power_assert", "<3.0.0"
 gem "test-unit"

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -23,4 +23,6 @@ gemspec
 
 gem "bundler"
 gem "rake"
+# 3.0.0 has a breaking change
+gem "power_assert", "<3.0.0"
 gem "test-unit"


### PR DESCRIPTION
There was a new release with an apparent breaking change 12 hours ago.

```
2025-11-03T02:19:16.5571756Z /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:16:in `method': undefined method `start' for class `#<Class:PowerAssert>' (NameError)
2025-11-03T02:19:16.5573444Z 	from /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:16:in `<module:BacktraceFilter>'
2025-11-03T02:19:16.5575112Z 	from /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:9:in `<module:Util>'
2025-11-03T02:19:16.5576301Z 	from /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:8:in `<module:Unit>'
2025-11-03T02:19:16.5577489Z 	from /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:7:in `<module:Test>'
2025-11-03T02:19:16.5578900Z 	from /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/util/backtracefilter.rb:6:in `<top (required)>'
2025-11-03T02:19:16.5580076Z 	from /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/assertions.rb:7:in `require_relative'
2025-11-03T02:19:16.5581187Z 	from /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/assertions.rb:7:in `<top (required)>'
2025-11-03T02:19:16.5582277Z 	from /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/testcase.rb:12:in `require_relative'
2025-11-03T02:19:16.5583344Z 	from /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/testcase.rb:12:in `<top (required)>'
2025-11-03T02:19:16.5584447Z 	from /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/autorunner.rb:7:in `require_relative'
2025-11-03T02:19:16.5585769Z 	from /adbc/glib/vendor/bundle/ruby/3.0.0/gems/test-unit-3.7.0/lib/test/unit/autorunner.rb:7:in `<top (required)>'
2025-11-03T02:19:16.5586508Z 	from /adbc/glib/test/run.rb:44:in `require'
2025-11-03T02:19:16.5586903Z 	from /adbc/glib/test/run.rb:44:in `<main>'
2025-11-03T02:19:17.2628569Z Failed to verify release candidate. See /tmp/arrow-adbc-HEAD.pbgze for details.
```