### PR TITLE
fix(c/driver_manager): look for correct init symbol name

### DIFF
--- a/c/driver_manager/CMakeLists.txt
+++ b/c/driver_manager/CMakeLists.txt
@@ -84,6 +84,16 @@ if(ADBC_BUILD_TESTS)
     set(TEST_LINK_LIBS adbc_driver_manager_static)
   endif()
 
+  add_library(adbc_driver_entrypoint SHARED entrypoint.c)
+  target_include_directories(adbc_driver_entrypoint SYSTEM
+                             PRIVATE ${REPOSITORY_ROOT}/c/include/)
+  target_compile_definitions(adbc_driver_entrypoint PRIVATE ADBC_EXPORTING)
+
+  add_library(adbc_driver_no_entrypoint SHARED entrypoint.c)
+  target_include_directories(adbc_driver_no_entrypoint SYSTEM
+                             PRIVATE ${REPOSITORY_ROOT}/c/include/)
+  target_compile_definitions(adbc_driver_no_entrypoint PRIVATE ADBC_EXPORTING)
+
   add_test_case(driver_manager_test
                 PREFIX
                 adbc
@@ -96,6 +106,16 @@ if(ADBC_BUILD_TESTS)
                 adbc_validation
                 ${TEST_LINK_LIBS})
   target_compile_features(adbc-driver-manager-test PRIVATE cxx_std_17)
+  add_dependencies(adbc-driver-manager-test adbc_driver_entrypoint
+                   adbc_driver_no_entrypoint)
+
+  target_compile_definitions(adbc-driver-manager-test
+                             PRIVATE ADBC_DRIVER_MANAGER_ENTRYPOINT_TEST_LIB="${CMAKE_BINARY_DIR}/driver_manager/${CMAKE_SHARED_LIBRARY_PREFIX}adbc_driver_entrypoint${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  )
+
+  target_compile_definitions(adbc-driver-manager-test
+                             PRIVATE ADBC_DRIVER_MANAGER_NO_ENTRYPOINT_TEST_LIB="${CMAKE_BINARY_DIR}/driver_manager/${CMAKE_SHARED_LIBRARY_PREFIX}adbc_driver_no_entrypoint${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  )
 
   if(ADBC_DRIVER_SQLITE)
     target_compile_definitions(adbc-driver-manager-test

--- a/c/driver_manager/adbc_driver_manager_test.cc
+++ b/c/driver_manager/adbc_driver_manager_test.cc
@@ -171,6 +171,37 @@ TEST_F(DriverManager, MultiDriverTest) {
   error->release(&error.value);
 }
 
+TEST_F(DriverManager, NoDefaultEntrypoint) {
+#if !defined(ADBC_DRIVER_MANAGER_ENTRYPOINT_TEST_LIB)
+  GTEST_SKIP() << "ADBC_DRIVER_MANAGER_ENTRYPOINT_TEST_LIB is not defined";
+#else
+  adbc_validation::Handle<struct AdbcError> error;
+  adbc_validation::Handle<struct AdbcDriver> driver;
+  // Must fail with expected status
+  ASSERT_THAT(AdbcLoadDriver(ADBC_DRIVER_MANAGER_ENTRYPOINT_TEST_LIB, nullptr,
+                             ADBC_VERSION_1_1_0, &driver.value, &error.value),
+              IsStatus(ADBC_STATUS_IO, &error.value));
+
+#endif  // !defined(ADBC_DRIVER_MANAGER_ENTRYPOINT_TEST_LIB)
+}
+
+TEST_F(DriverManager, NoDefaultEntrypointFound) {
+#if !defined(ADBC_DRIVER_MANAGER_NO_ENTRYPOINT_TEST_LIB)
+  GTEST_SKIP() << "ADBC_DRIVER_MANAGER_NO_ENTRYPOINT_TEST_LIB is not defined";
+#else
+  adbc_validation::Handle<struct AdbcError> error;
+  adbc_validation::Handle<struct AdbcDriver> driver;
+  ASSERT_THAT(AdbcLoadDriver(ADBC_DRIVER_MANAGER_NO_ENTRYPOINT_TEST_LIB, nullptr,
+                             ADBC_VERSION_1_1_0, &driver.value, &error.value),
+              IsStatus(ADBC_STATUS_INTERNAL, &error.value));
+  // Both symbols should not be found, should be mentioned in error message
+  ASSERT_THAT(error->message,
+              ::testing::HasSubstr("(AdbcDriverNoEntrypointInit) failed"));
+  ASSERT_THAT(error->message, ::testing::HasSubstr("(AdbcDriverInit) failed"));
+
+#endif  // !defined(ADBC_DRIVER_MANAGER_NO_ENTRYPOINT_TEST_LIB)
+}
+
 class SqliteQuirks : public adbc_validation::DriverQuirks {
  public:
   AdbcStatusCode SetupDatabase(struct AdbcDatabase* database,

--- a/c/driver_manager/entrypoint.c
+++ b/c/driver_manager/entrypoint.c
@@ -1,0 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow-adbc/adbc.h"
+
+ADBC_EXPORT AdbcStatusCode AdbcDriverEntrypointInit(int version, void* raw_driver,
+                                                    struct AdbcError* error) {
+  return ADBC_STATUS_IO;
+}

--- a/c/validation/adbc_validation_util.h
+++ b/c/validation/adbc_validation_util.h
@@ -124,6 +124,19 @@ struct Releaser<struct AdbcDatabase> {
 };
 
 template <>
+struct Releaser<struct AdbcDriver> {
+  static void Release(struct AdbcDriver* value) {
+    if (value->release) {
+      struct AdbcError error = {};
+      auto status = value->release(value, &error);
+      if (status != ADBC_STATUS_OK) {
+        FAIL() << StatusCodeToString(status) << ": " << ToString(&error);
+      }
+    }
+  }
+};
+
+template <>
 struct Releaser<struct AdbcStatement> {
   static void Release(struct AdbcStatement* value) {
     if (value->private_data) {


### PR DESCRIPTION
- Add sanity assertions
- Actually test this end-to-end
- Populate lib_path properly so the right init symbol name gets calculated

IMO, the control flow now is very convoluted because it intermixes searching and loading, which led to this regression since it's hard to tell if the return value is actually fully initialized. I'm still not sure all code paths are correct. I may try to factor searching/loading out separately.

Closes #3680.