### PR TITLE
fix(dev/release): fix wheel verification failure on macOS due to SIP

### DIFF
--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -182,6 +182,7 @@ import $component.dbapi
         # set env var so that we don't skip tests if we somehow accidentally installed pyarrow
         # GH-3679: Don't prefix with 'env' command because env on macOS is
         # "restricted" and strips DYLD_LIBRARY_PATH
-        ADBC_NO_SKIP_TESTS=1 python -m pytest -vvx --import-mode append "${test_files[@]}"
+        export ADBC_NO_SKIP_TESTS=1
+        python -m pytest -vvx --import-mode append "${test_files[@]}"
     done
 }


### PR DESCRIPTION
Prior to this change, wheel verification would fail on macOS because `DYLD_LIBRARY_PATH` wasn't been passed down to pytest in `ci/scripts/python_util.sh`. Here, `DYLD_LIBRARY_PATH` is used in the tests to specify the location of driver to test so when it's not set, the test fails to find the driver. Presumably this doesn't fail elsewhere because we invoke the tests differently elsewhere.

This ultimately due to System Integrity Protection (SIP) on macOS and that `env` is `/usr/bin/env` which is a "restricted" binary. Restricted means environment variables like `DYLD_LIBRARY_PATH` get stripped from child processes.

This is a simple test that shows how this fails:

```console
$ echo $DYLD_LIBRARY_PATH
XXX

~/tmp/arrow-adbc-tmpdir/venv-wheel-3.10-arm64/bin
$ ./python -c "import os; print(os.environ['DYLD_LIBRARY_PATH'])"
XXX

~/tmp/arrow-adbc-tmpdir/venv-wheel-3.10-arm64/bin
$ env FOO=bar ./python -c "import os; print(os.environ['DYLD_LIBRARY_PATH'])"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/bryce/.local/share/uv/python/cpython-3.10.19-macos-aarch64-none/lib/python3.10/os.py", line 680, in __getitem__
    raise KeyError(key) from None
KeyError: 'DYLD_LIBRARY_PATH'
```