### PR TITLE
feat(csharp/Benchmarks): Add custom columns for CloudFetch benchmark metrics

### DIFF
--- a/csharp/Benchmarks/CloudFetchBenchmarkRunner.cs
+++ b/csharp/Benchmarks/CloudFetchBenchmarkRunner.cs
@@ -37,9 +37,11 @@ namespace Apache.Arrow.Adbc.Benchmarks
             // Enable TLS 1.2/1.3 for .NET Framework 4.7.2 (required for modern HTTPS endpoints)
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | (SecurityProtocolType)3072; // 3072 = Tls13
 #endif
-            // Configure to include the peak memory column and hide confusing error column
+            // Configure to include custom metric columns and hide confusing error column
             var config = DefaultConfig.Instance
                 .AddColumn(new PeakMemoryColumn())
+                .AddColumn(new TotalRowsColumn())
+                .AddColumn(new TotalBatchesColumn())
                 .HideColumns("Error", "StdDev");  // Hide statistical columns that are confusing with few iterations
 
             // Run only the real E2E CloudFetch benchmark


### PR DESCRIPTION
## Summary
Add custom BenchmarkDotNet columns to display Peak Memory, Total Rows, and Total Batches in the summary table instead of requiring users to check console output.

## Changes
- Add `BenchmarkMetrics` class to store peak memory, total rows, and total batches
- Store metrics in temp file (`cloudfetch_benchmark_metrics.json`) for cross-process access
- Update `PeakMemoryColumn` to read from temp file instead of static dictionary
- Add `TotalRowsColumn` to display total rows processed
- Add `TotalBatchesColumn` to display total batches processed  
- Register all three custom columns in `CloudFetchBenchmarkRunner`
- Update README with .NET Framework 4.7.2 instructions for Power BI testing
- Update README with new metrics column documentation and examples

## Problem Solved
This fixes the "See previous console output" issue where custom columns couldn't access metrics because BenchmarkDotNet runs iterations in separate processes. The temp file approach ensures metrics are available when generating the final summary table.

## Before
```
| Peak Memory (MB)            |
|----------------------------:|
| See previous console output |
```

## After
```
| Peak Memory (MB) | Total Rows | Total Batches |
|-----------------:|-----------:|--------------:|
| 256.48           | 1,441,548  | 145           |
```

## Testing
- Built successfully on macOS with net8.0
- All three custom columns now display actual values in summary table
- Metrics written to temp file during execution
- README updated with net472 instructions for Windows/Power BI testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)