### PR TITLE
fix(rust/driver_manager): remove optional property for windows deps

### DIFF
--- a/rust/driver_manager/Cargo.toml
+++ b/rust/driver_manager/Cargo.toml
@@ -50,8 +50,8 @@ windows-sys = { version = ">= 0.59.0", features = [
     "Win32_UI_Shell",
     "Win32_Globalization",
     "Win32_System_Com",
-], optional = true }
-windows-registry = { version = ">= 0.5.3", optional = true }
+] }
+windows-registry = { version = ">= 0.5.3" }
 
 [dev-dependencies]
 arrow-select.workspace = true


### PR DESCRIPTION
Hi there! When using the `adbc_driver_manager` crate on Windows, it's impossible to build the project because the `adbc_driver_manager` dependency fails to compile. Windows crates are marked as optional and are not included in any of the crate's features. To make it work, the `optional` flag needs to be removed.