### PR TITLE
fix(go/adbc/sqldriver): properly close resources

### DIFF
--- a/go/adbc/sqldriver/driver.go
+++ b/go/adbc/sqldriver/driver.go
@@ -647,9 +647,9 @@ func (r *rows) Close() error {
 	r.rdr.Release()
 	r.rdr = nil
 
-	r.stmt.Close()
+	err := r.stmt.Close()
 	r.stmt = nil
-	return nil
+	return err
 }
 
 func (r *rows) Next(dest []driver.Value) error {


### PR DESCRIPTION
fixes #3728

This was a combination of two issues that are fixed in this PR:

1. `sqldriver.Connector` needs to implement the `io.Closer` interface so that `sql.DB.Close` will call it and call `Close` on the `adbc.Database` object.
2. `rows.Close` needs to also close the associated `stmt`. In the case of at least one driver (the duckdb driver in associated issue) not closing the `stmt` led to the handle to the duckdb database not being dropped despite calling `Close` on the database.