### PR TITLE
fix(csharp/test/Drivers/Databricks): Fix SendAsync_WithExternalToken_BlocksUntilTokenExchangeCompletes

### DIFF
--- a/csharp/test/Drivers/Databricks/Unit/Auth/MandatoryTokenExchangeDelegatingHandlerTests.cs
+++ b/csharp/test/Drivers/Databricks/Unit/Auth/MandatoryTokenExchangeDelegatingHandlerTests.cs
@@ -16,6 +16,7 @@
 */
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -167,9 +168,10 @@ namespace Apache.Arrow.Adbc.Tests.Drivers.Databricks.Unit.Auth
             var httpClient = new HttpClient(handler);
 
             // First request should block until token exchange completes, then use exchanged token
-            var startTime = DateTime.UtcNow;
+            var stopwatch = Stopwatch.StartNew();
             var response = await httpClient.SendAsync(request);
-            var requestDuration = DateTime.UtcNow - startTime;
+            stopwatch.Stop();
+            var requestDuration = stopwatch.Elapsed;
 
             Assert.Equal(expectedResponse, response);
             Assert.True(requestDuration >= tokenExchangeDelay,


### PR DESCRIPTION
Fix flaky test SendAsync_WithExternalToken_BlocksUntilTokenExchangeCompletes by using the more-accurate `Stopwatch` instead of `DateTime.UtcNow`. The latter was regularly causing test failures with messages like "Request took 488.5696ms, which is shorter than the token exchange delay of 500ms. Expected blocking behavior." due to the lack of precision.