### PR TITLE
refactor(glib): update PostgreSQL isolation level test to use supported values

### DIFF
--- a/glib/test/test-connection.rb
+++ b/glib/test/test-connection.rb
@@ -521,7 +521,7 @@ class ConnectionTest < Test::Unit::TestCase
     open_connection do |connection|
       connection.isolation_level = :serializable
       execute_sql(connection, "SELECT current_setting('transaction_isolation')") do |table,|
-        assert_equal("serializable", table["current_setting"][0].as_s)
+        assert_equal("serializable", table["current_setting"][0])
       end
     end
   end


### PR DESCRIPTION
PostgreSQL driver now supports isolation levels (https://github.com/apache/arrow-adbc/pull/3760), so test should verify functionality rather than expect NotImplemented errors.