### PR TITLE
fix(c/driver_manager): incorrect buffer length check in AdbcDatabaseGetOption

### DIFF
--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -1652,7 +1652,7 @@ AdbcStatusCode AdbcDatabaseGetOption(struct AdbcDatabase* database, const char* 
     result = &it->second;
   }
 
-  if (*length <= result->size() + 1) {
+  if (*length >= result->size() + 1) {
     // Enough space
     std::memcpy(value, result->c_str(), result->size() + 1);
   }
@@ -1676,7 +1676,7 @@ AdbcStatusCode AdbcDatabaseGetOptionBytes(struct AdbcDatabase* database, const c
   }
   const std::string& result = it->second;
 
-  if (*length <= result.size()) {
+  if (*length >= result.size()) {
     // Enough space
     std::memcpy(value, result.c_str(), result.size());
   }

--- a/c/driver_manager/adbc_driver_manager_test.cc
+++ b/c/driver_manager/adbc_driver_manager_test.cc
@@ -368,7 +368,7 @@ TEST(AdbcDriverManagerInternal, DatabaseGetOptionValueBufferSize) {
       AdbcDatabaseGetOption(&database, "driver", buf_too_small, &len_too_small, &error),
       IsOkStatus(&error));
   EXPECT_EQ(len_too_small, 12u);
-  EXPECT_STREQ(buf_too_small, "test_driver");
+  EXPECT_STRNE(buf_too_small, "test_driver");
 
   // Just right
   char buf_just_right[12];

--- a/go/adbc/drivermgr/adbc_driver_manager.cc
+++ b/go/adbc/drivermgr/adbc_driver_manager.cc
@@ -1652,7 +1652,7 @@ AdbcStatusCode AdbcDatabaseGetOption(struct AdbcDatabase* database, const char* 
     result = &it->second;
   }
 
-  if (*length <= result->size() + 1) {
+  if (*length >= result->size() + 1) {
     // Enough space
     std::memcpy(value, result->c_str(), result->size() + 1);
   }
@@ -1676,7 +1676,7 @@ AdbcStatusCode AdbcDatabaseGetOptionBytes(struct AdbcDatabase* database, const c
   }
   const std::string& result = it->second;
 
-  if (*length <= result.size()) {
+  if (*length >= result.size()) {
     // Enough space
     std::memcpy(value, result.c_str(), result.size());
   }


### PR DESCRIPTION
This test covers the behavior of AdbcDatabaseGetOption with out different out buffer lengths and exposes what I think is a bug in

https://github.com/apache/arrow-adbc/blob/8ed6379bd2d8f7a7bc2b6950c9ad56ba95f71536/c/driver_manager/adbc_driver_manager.cc#L1655