### PR TITLE
ci(r): ensure installing the required version of Go on windows

### DIFF
--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -39,6 +39,10 @@ on:
       SNOWFLAKE_URI:
         required: false
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   r-check:
     runs-on: ${{ inputs.os }}-latest
@@ -74,7 +78,6 @@ jobs:
           pushd "r/${{ inputs.pkg }}"
           Rscript bootstrap.R
           popd
-        shell: bash
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
         with:


### PR DESCRIPTION
It seems that the problem was that powershell was used instead of bash on Windows, so the Go version was not set in the environment variables and causing the error.