### PR TITLE
fix(rust/driver_manager): don't dlclose drivers

### DIFF
--- a/rust/driver_manager/Cargo.toml
+++ b/rust/driver_manager/Cargo.toml
@@ -39,7 +39,7 @@ adbc_core.workspace = true
 adbc_ffi.workspace = true
 arrow-array.workspace = true
 arrow-schema.workspace = true
-libloading = "0.8"
+libloading = "0.8.8"
 toml = { version = "0.9.10", default-features = false, features = [
     "parse",
     "display",


### PR DESCRIPTION
According to https://github.com/golang/go/issues/11100#issuecomment-932638093, the `-Wl,-z,nodelete` does not work on macos. This causes dlclose to be called when the shared library is dropped, which results in unexpected behaviour ( I've observed the program hangs because Go cannot kill the goroutines and so waits for them to close )

On linux, since the `-Wl,-z,nodelete` is respected, we do not see this issue.

This PR fixes the problem by ensuring that we explicitly open the library with `RTLD_NODELETE` flag which ensures that `dlclose` is not called during unload


Fixes #3840 