### PR TITLE
feat(csharp): make DriverName virtual in SparkConnection to enable driver-specific identification

### DIFF
--- a/csharp/src/Drivers/Apache/Spark/SparkConnection.cs
+++ b/csharp/src/Drivers/Apache/Spark/SparkConnection.cs
@@ -28,7 +28,7 @@ namespace Apache.Arrow.Adbc.Drivers.Apache.Spark
     internal abstract class SparkConnection : HiveServer2Connection
     {
         protected const string ProductVersionDefault = "1.0.0";
-        protected const string DriverName = "ADBC Spark Driver";
+        protected virtual string DriverName => "ADBC Spark Driver";
         private const string ArrowVersion = "1.0.0";
         private readonly Lazy<string> _productVersion;
 


### PR DESCRIPTION
 ## Summary                                                                                                                                                                 
  Converts `DriverName` from a constant to a virtual property in `SparkConnection`, enabling derived drivers (Databricks) to properly identify themselves in GetInfo API responses and User-Agent headers.                                                                                                                              
Associated PR: [https://github.com/adbc-drivers/databricks/pull/127](https://github.com/adbc-drivers/databricks/pull/127)