### PR TITLE
chore(rust/driver/datafusion): bump dependent arrow to 57.3.0

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ca404ea6191e06bf30956394173337fa9c35f445bd447fe6c21ab944e1a23c"
+checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36356383099be0151dacc4245309895f16ba7917d79bdb71a7148659c9206c56"
+checksum = "c697ddca96183182f35b3a18e50b9110b11e916d7b7799cbfd4d34662f2c56c2"
 dependencies = [
  "bytes",
  "half",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf87f4ff5fc13290aa47e499a8b669a82c5977c6a1fedce22c7f542c1fd5a597"
+checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb63203e8e0e54b288d0d8043ca8fa1013820822a27692ef1b78a977d879f2c"
+checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
 dependencies = [
  "bitflags",
  "serde_core",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "57.2.0"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96d8a1c180b44ecf2e66c9a2f2bbcb8b1b6f14e165ce46ac8bde211a363411b"
+checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
  "ahash",
  "arrow-array",

--- a/rust/driver/datafusion/Cargo.toml
+++ b/rust/driver/datafusion/Cargo.toml
@@ -33,16 +33,16 @@ categories.workspace = true
 [dependencies]
 adbc_core.workspace = true
 adbc_ffi = { workspace = true, optional = true }
-arrow-array = "57.2.0"
-arrow-buffer = "57.2.0"
-arrow-schema = "57.2.0"
+arrow-array = "57.3.0"
+arrow-buffer = "57.3.0"
+arrow-schema = "57.3.0"
 datafusion = { version = "52.1.0", default-features = false }
 datafusion-substrait = { version = "52.1.0", default-features = false }
 tokio = { version = "1.49", features = ["rt-multi-thread"] }
 prost = "0.14.3"
 
 [dev-dependencies]
-arrow-select = "57.2.0"
+arrow-select = "57.3.0"
 
 [lib]
 crate-type = ["lib", "cdylib"]


### PR DESCRIPTION
Supersede #3953