### PR TITLE
feat(rust/core): derive Copy, Eq, PartialEq (#3716)

### DIFF
--- a/rust/core/src/options.rs
+++ b/rust/core/src/options.rs
@@ -219,7 +219,7 @@ impl TryFrom<u32> for InfoCode {
 }
 
 /// Depth parameter for [get_objects][crate::Connection::get_objects] method.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ObjectDepth {
     /// Catalogs, schemas, tables, and columns.
     All,
@@ -523,7 +523,7 @@ impl From<IsolationLevel> for OptionValue {
 }
 
 /// Ingestion mode value for key [OptionStatement::IngestMode].
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum IngestMode {
     /// Create the table and insert data; error if the table exists.
     Create,


### PR DESCRIPTION
### Description
This PR addresses a paper cut mentioned in issue #3716 - enums should derive Copy, Eq, and PartialEq.

Fixes #3716