### PR TITLE
build(docs): pin Sphinx < 9 for numpydoc

### DIFF
--- a/ci/conda_env_docs.txt
+++ b/ci/conda_env_docs.txt
@@ -23,7 +23,8 @@ nodejs
 numpydoc
 polars
 pytest
-sphinx>=8.2
+# https://github.com/apache/arrow-adbc/issues/3976
+sphinx>=8.2,<9
 sphinx-autobuild
 sphinx-copybutton
 sphinx-design


### PR DESCRIPTION
https://github.com/numpy/numpydoc/issues/671

Closes #3976.