### PR TITLE
build(python): bump image used to build wheels

### DIFF
--- a/ci/docker/python-wheel-manylinux-relocate.dockerfile
+++ b/ci/docker/python-wheel-manylinux-relocate.dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt update \
   && apt install -y \


### PR DESCRIPTION
cibuildwheel appears to expect a newer docker-compose, so switch the image to Debian 13 (Trixie). This will not affect the wheels themselves which are still built under the manylinux2014 image.

Closes #3977.