### PR TITLE
fix(rust/driver_manager): try to fix flaky test

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "libloading",
  "path-slash",
  "regex",
+ "serial_test",
  "temp-env",
  "tempfile",
  "toml",
@@ -2211,6 +2212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2249,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -2336,6 +2352,32 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/rust/driver_manager/Cargo.toml
+++ b/rust/driver_manager/Cargo.toml
@@ -57,5 +57,6 @@ windows-registry = { version = ">= 0.5.3" }
 
 [dev-dependencies]
 arrow-select.workspace = true
+serial_test = "3.4.0"
 temp-env = "0.3"
 tempfile = "3.26"

--- a/rust/driver_manager/src/search.rs
+++ b/rust/driver_manager/src/search.rs
@@ -875,7 +875,6 @@ pub(crate) fn find_filesystem_profile(
         .iter()
         .find_map(|path| {
             let full_path = path.join(actual_path.as_path());
-            println!("Checking for profile at: {}", full_path.display());
             if full_path.is_file() {
                 Some(full_path)
             } else {
@@ -911,10 +910,6 @@ fn get_profile_search_paths(additional_path_list: Option<Vec<PathBuf>>) -> Vec<P
 
     // Add ADBC_PROFILE_PATH environment variable paths
     if let Some(paths) = env::var_os("ADBC_PROFILE_PATH") {
-        println!(
-            "Adding ADBC_PROFILE_PATH directories to search path: {:?}",
-            paths
-        );
         result.extend(env::split_paths(&paths));
     }
 
@@ -940,7 +935,6 @@ fn get_profile_search_paths(additional_path_list: Option<Vec<PathBuf>>) -> Vec<P
         result.push(profiles_dir.join(PROFILE_DIR_NAME));
     }
 
-    println!("Final profile search paths: {:?}", result.iter().map(|p| p.display()).collect::<Vec<_>>());
     result
 }
 

--- a/rust/driver_manager/tests/connection_profile.rs
+++ b/rust/driver_manager/tests/connection_profile.rs
@@ -23,6 +23,7 @@ use adbc_driver_manager::profile::{
     ConnectionProfile, ConnectionProfileProvider, FilesystemProfileProvider,
 };
 use adbc_driver_manager::ManagedDatabase;
+use serial_test::serial;
 
 mod common;
 
@@ -432,6 +433,7 @@ fn test_profile_display() {
 }
 
 #[test]
+#[serial]
 fn test_profile_hierarchical_path_via_env_var() {
     use std::env;
 
@@ -448,8 +450,7 @@ fn test_profile_hierarchical_path_via_env_var() {
     // Create a profile in the nested directory
     let profile_path = postgres_dir.join("production.toml");
     std::fs::write(&profile_path, simple_profile()).expect("Failed to write profile");
-    println!("Creating profile at {}", profile_path.display());
-    
+
     // Verify the file was created
     assert!(
         profile_path.is_file(),
@@ -497,6 +498,7 @@ fn test_profile_hierarchical_path_via_env_var() {
 }
 
 #[test]
+#[serial]
 fn test_profile_hierarchical_path_with_extension_via_env_var() {
     use std::env;
 
@@ -512,7 +514,6 @@ fn test_profile_hierarchical_path_with_extension_via_env_var() {
 
     // Create a profile in the nested directory
     let profile_path = dev_dir.join("database.toml");
-    println!("Creating profile at {}", profile_path.display());
     std::fs::write(&profile_path, simple_profile()).expect("Failed to write profile");
 
     // Set ADBC_PROFILE_PATH to the parent directory


### PR DESCRIPTION
For some reason the hierarchical path profile test is flaky, let's try to fix that