### PR TITLE
chore(r): remove the `-D_LIBCPP_DISABLE_AVAILABILITY` cpp flag for new macos toolchains

### DIFF
--- a/r/adbcdrivermanager/src/Makevars
+++ b/r/adbcdrivermanager/src/Makevars
@@ -17,7 +17,7 @@
 
 CXX_STD = CXX17
 CONDA_BUILD ?= "0"
-PKG_CPPFLAGS=-I../src/c/include -I../src/c -I../src/c/vendor -DADBC_EXPORT="" -D_LIBCPP_DISABLE_AVAILABILITY -DADBC_CONDA_BUILD=$(CONDA_BUILD)
+PKG_CPPFLAGS=-I../src/c/include -I../src/c -I../src/c/vendor -DADBC_EXPORT="" -DADBC_CONDA_BUILD=$(CONDA_BUILD)
 
 OBJECTS = driver_test.o \
     error.o \

--- a/r/adbcsqlite/src/Makevars.in
+++ b/r/adbcsqlite/src/Makevars.in
@@ -16,7 +16,7 @@
 # under the License.
 
 CXX_STD = CXX17
-PKG_CPPFLAGS=-I../src/c -I../src/c/include -I../src/c/vendor/ -I../src/c/vendor/fmt/include @cppflags@ -DADBC_EXPORT="" -DFMT_HEADER_ONLY=1 -D_LIBCPP_DISABLE_AVAILABILITY
+PKG_CPPFLAGS=-I../src/c -I../src/c/include -I../src/c/vendor/ -I../src/c/vendor/fmt/include @cppflags@ -DADBC_EXPORT="" -DFMT_HEADER_ONLY=1
 PKG_LIBS=@libs@
 
 OBJECTS = init.o \


### PR DESCRIPTION
Fix #4025

In the R world, this flag seems no longer needed (added in #1672, #3034).