### PR TITLE
feat(format): add table_definition to GetObjects

### DIFF
--- a/c/driver_manager/adbc_version_100_compatibility_test.cc
+++ b/c/driver_manager/adbc_version_100_compatibility_test.cc
@@ -57,9 +57,11 @@ class AdbcVersion : public ::testing::Test {
 TEST_F(AdbcVersion, StructSize) {
   ASSERT_EQ(sizeof(AdbcErrorVersion100), ADBC_ERROR_1_0_0_SIZE);
   ASSERT_EQ(sizeof(AdbcError), ADBC_ERROR_1_1_0_SIZE);
+  ASSERT_EQ(sizeof(AdbcError), ADBC_ERROR_1_2_0_SIZE);
 
   ASSERT_EQ(sizeof(AdbcDriverVersion100), ADBC_DRIVER_1_0_0_SIZE);
-  ASSERT_EQ(sizeof(AdbcDriver), ADBC_DRIVER_1_1_0_SIZE);
+  ASSERT_EQ(offsetof(struct AdbcDriver, StatementExecuteMulti), ADBC_DRIVER_1_1_0_SIZE);
+  ASSERT_EQ(sizeof(AdbcDriver), ADBC_DRIVER_1_2_0_SIZE);
 }
 
 // Initialize a version 1.0.0 driver with the version 1.1.0 driver struct.

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -683,6 +683,10 @@ const struct AdbcError* AdbcErrorFromArrayStream(struct ArrowArrayStream* stream
 /// \see ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA
 #define ADBC_INFO_FEATURE_ERROR_METADATA 250
 
+/// \defgroup adbc-catalog-metadata ADBC Catalog Metadata Constants
+/// Constants for catalog metadata.
+/// @{
+
 /// \brief Return metadata on catalogs, schemas, tables, and columns.
 ///
 /// \see AdbcConnectionGetObjects
@@ -707,6 +711,88 @@ const struct AdbcError* AdbcErrorFromArrayStream(struct ArrowArrayStream* stream
 ///
 /// \see AdbcConnectionGetObjects
 #define ADBC_OBJECT_DEPTH_COLUMNS ADBC_OBJECT_DEPTH_ALL
+
+/// \brief This foreign key does not allow update of the corresponding primary
+///   key.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyNoAction`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_ACTION_NO_ACTION 3
+
+/// \brief This foreign key will be updated/deleted with corresponding primary
+///   key.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyCascade`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_ACTION_CASCADE 0
+
+/// \brief This foreign key will be set to NULL if its corresponding primary
+///   key is updated or deleted.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeySetNull`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_ACTION_SET_NULL 2
+
+/// \brief This foreign key will be set to its default if its corresponding
+///   primary key is updated or deleted.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeySetDefault`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_ACTION_SET_DEFAULT 4
+
+/// \brief Similar to ADBC_CONSTRAINT_ACTION_NO_ACTION but may be interpreted
+///   differently by the vendor (e.g., raise an error immediately instead of
+///   allowing the check to be deferred).
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyRestrict`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_ACTION_RESTRICT 1
+
+/// \brief This constraint is deferrable, and is initially deferred.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyInitiallyDeferred`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_DEFERRABLE_DEFERRED 5
+
+/// \brief This constraint is deferrable, but is initially immediate.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyInitiallyImmediate`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_DEFERRABLE_IMMEDIATE 6
+
+/// \brief This constraint may not be deferred.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyNotDeferrable`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_NOT_DEFERRABLE 7
+
+/// \brief This foreign key allows any of the foreign key columns to be NULL;
+///   if so, no match is required in the referenced table.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_MATCH_SIMPLE 0
+
+/// \brief This foreign key only allows foreign key columns to be NULL if all
+///   of them are NULL; if so, no match is required in the referenced table.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_MATCH_FULL 1
+
+/// \brief This foreign key allows any of the foreign key columns to be NULL;
+///   if so, non-NULL columns must still match.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_MATCH_PARTIAL 2
+
+/// @}
 
 /// \defgroup adbc-table-statistics ADBC Statistic Types
 /// Standard statistic names for AdbcConnectionGetStatistics.
@@ -1950,20 +2036,58 @@ AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
 /// | constraint_type          | utf8 not null           | (1)      |
 /// | constraint_column_names  | list<utf8> not null     | (2)      |
 /// | constraint_column_usage  | list<USAGE_SCHEMA>      | (3)      |
+/// | constraint_expression    | utf8                    | (4)      |
+/// | constraint_update_rule   | int16                   | (5)      |
+/// | constraint_delete_rule   | int16                   | (5)      |
+/// | constraint_enforced      | bool                    | (6)      |
+/// | constraint_deferrability | int16                   | (7)      |
+/// | constraint_match_type    | int16                   | (8)      |
 ///
-/// 1. One of 'CHECK', 'FOREIGN KEY', 'PRIMARY KEY', or 'UNIQUE'.
+/// 1. One of 'CHECK', 'FOREIGN KEY', 'PRIMARY KEY', or 'UNIQUE', or a
+///    vendor-specific type.
 /// 2. The columns on the current table that are constrained, in
 ///    order.
 /// 3. For FOREIGN KEY only, the referenced table and columns.
+/// 4. [Since version 1.2.0] The vendor-specific definition of the constraint
+///    (e.g. the SQL expression to be checked).  This field is optional.
+/// 5. [Since version 1.2.0] The action to be taken when the primary key is
+///    updated or deleted.  The value is one of the ADBC_CONSTRAINT_ACTION_
+///    constants. This field is optional.
+/// 6. [Since version 1.2.0] Whether the constraint is currently enabled.
+///    This field is optional.
+/// 7. [Since version 1.2.0] Whether the constraint can be deferred, and if
+///    so, whether it starts deferred.  The value is one of the
+///    ADBC_CONSTRAINT_DEFERRABLE_ constants or
+///    ADBC_CONSTRAINT_NOT_DEFERRABLE.  This field is optional.
+/// 8. [Since version 1.2.0] How the foreign key constraint should be matched.
+///    The value is one of the ADBC_CONSTRAINT_MATCH_ constants.  This field
+///    is optional.
 ///
 /// USAGE_SCHEMA is a Struct with fields:
 ///
-/// | Field Name               | Field Type              |
-/// |--------------------------|-------------------------|
-/// | fk_catalog               | utf8                    |
-/// | fk_db_schema             | utf8                    |
-/// | fk_table                 | utf8 not null           |
-/// | fk_column_name           | utf8 not null           |
+/// | Field Name               | Field Type              | Comments |
+/// |--------------------------|-------------------------|----------|
+/// | fk_catalog               | utf8                    |          |
+/// | fk_db_schema             | utf8                    |          |
+/// | fk_table                 | utf8 not null           |          |
+/// | fk_column_name           | utf8 not null           |          |
+/// | fk_key_seq               | int32                   | (1)      |
+/// | fk_pk_name               | utf8                    | (2)      |
+///
+/// 1. [Since version 1.2.0] The ordinal position of the column within the
+///    foreign key.  If present, the driver should sort the rows on this
+///    column.  This field is optional.
+/// 2. [Since version 1.2.0] The name of the referenced primary key.  This
+///    field is optional.
+///
+/// Starting in version 1.2.0, optional fields were introduced to the schema.
+/// Optional fields may not be present in the returned schema/data and
+/// applications should check for their presence before using them.  Drivers
+/// may choose to include optional fields (with null values) even if not
+/// supported, but are not required to.  If an optional field is present, all
+/// optional fields defined before it in the schema must be present (but the
+/// values may still be null if the driver does not actually support that
+/// field).
 ///
 /// This AdbcConnection must outlive the returned ArrowArrayStream.
 ///

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -1991,12 +1991,16 @@ AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
 ///
 /// TABLE_SCHEMA is a Struct with fields:
 ///
-/// | Field Name               | Field Type              |
-/// |--------------------------|-------------------------|
-/// | table_name               | utf8 not null           |
-/// | table_type               | utf8 not null           |
-/// | table_columns            | list<COLUMN_SCHEMA>     |
-/// | table_constraints        | list<CONSTRAINT_SCHEMA> |
+/// | Field Name               | Field Type              | Comments |
+/// |--------------------------|-------------------------|----------|
+/// | table_name               | utf8 not null           |          |
+/// | table_type               | utf8 not null           |          |
+/// | table_columns            | list<COLUMN_SCHEMA>     |          |
+/// | table_constraints        | list<CONSTRAINT_SCHEMA> |          |
+/// | table_definition         | utf8                    | (1)      |
+///
+/// 1. [Since version 1.2.0] The table or view definition (e.g. a SQL DDL
+///    statement).  This field is optional.
 ///
 /// COLUMN_SCHEMA is a Struct with fields:
 ///

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -1977,17 +1977,25 @@ AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
 ///
 /// The result is an Arrow dataset with the following schema:
 ///
-/// | Field Name               | Field Type              |
-/// |--------------------------|-------------------------|
-/// | catalog_name             | utf8                    |
-/// | catalog_db_schemas       | list<DB_SCHEMA_SCHEMA>  |
+/// | Field Name               | Field Type              | Comments |
+/// |--------------------------|-------------------------|----------|
+/// | catalog_name             | utf8                    |          |
+/// | catalog_db_schemas       | list<DB_SCHEMA_SCHEMA>  |          |
+/// | remarks                  | utf8                    | (1)      |
+///
+/// 1. [Since version 1.2.0] A description of the catalog.  This field is
+///    optional.
 ///
 /// DB_SCHEMA_SCHEMA is a Struct with fields:
 ///
-/// | Field Name               | Field Type              |
-/// |--------------------------|-------------------------|
-/// | db_schema_name           | utf8                    |
-/// | db_schema_tables         | list<TABLE_SCHEMA>      |
+/// | Field Name               | Field Type              | Comments |
+/// |--------------------------|-------------------------|----------|
+/// | db_schema_name           | utf8                    |          |
+/// | db_schema_tables         | list<TABLE_SCHEMA>      |          |
+/// | remarks                  | utf8                    | (1)      |
+///
+/// 1. [Since version 1.2.0] A description of the schema.  This field is
+///    optional.
 ///
 /// TABLE_SCHEMA is a Struct with fields:
 ///
@@ -1998,9 +2006,12 @@ AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
 /// | table_columns            | list<COLUMN_SCHEMA>     |          |
 /// | table_constraints        | list<CONSTRAINT_SCHEMA> |          |
 /// | table_definition         | utf8                    | (1)      |
+/// | remarks                  | utf8                    | (2)      |
 ///
 /// 1. [Since version 1.2.0] The table or view definition (e.g. a SQL DDL
 ///    statement).  This field is optional.
+/// 2. [Since version 1.2.0] A description of the table.  This field is
+///    optional.
 ///
 /// COLUMN_SCHEMA is a Struct with fields:
 ///
@@ -2025,12 +2036,14 @@ AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
 /// | xdbc_scope_table         | utf8                    | (3)      |
 /// | xdbc_is_autoincrement    | bool                    | (3)      |
 /// | xdbc_is_generatedcolumn  | bool                    | (3)      |
+/// | xdbc_source_data_type    | int16                   | (3, 4)   |
 ///
 /// 1. The column's ordinal position in the table (starting from 1).
 /// 2. Database-specific description of the column.
 /// 3. Optional value.  Should be null if not supported by the driver.
 ///    xdbc_ values are meant to provide JDBC/ODBC-compatible metadata
 ///    in an agnostic manner.
+/// 4. [Since version 1.2.0] This field is optional.
 ///
 /// CONSTRAINT_SCHEMA is a Struct with fields:
 ///
@@ -2092,6 +2105,13 @@ AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
 /// optional fields defined before it in the schema must be present (but the
 /// values may still be null if the driver does not actually support that
 /// field).
+///
+/// Starting in version 1.2.0, driver-specific fields were introduced to the
+/// schema.  Drivers may add custom fields at the end of any schema above to
+/// reflect vendor-specific metadata.  Applications must access these using an
+/// offset from the end of the schema and cannot assume that the index of the
+/// field will remain stable.  Drivers should prefix field names with the
+/// vendor/driver name to differentiate them (e.g. 'POSTGRESQL:owner').
 ///
 /// This AdbcConnection must outlive the returned ArrowArrayStream.
 ///

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -545,6 +545,137 @@ const struct AdbcError* AdbcErrorFromArrayStream(struct ArrowArrayStream* stream
 /// \see ADBC_VERSION_1_2_0
 #define ADBC_INFO_DRIVER_ADBC_VERSION 103
 
+/// \brief Whether the driver supports bulk ingest (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_FEATURE_INGEST 200
+
+/// \brief Supported bulk ingest modes (type: string list).
+///
+/// Values are the mode constants themselves.
+///
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_FEATURE_INGEST_MODES 201
+
+/// \brief Whether the driver supports ingesting into a temporary table (type:
+///   bool).
+///
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_INGEST_OPTION_TEMPORARY
+#define ADBC_INFO_FEATURE_INGEST_TEMPORARY 202
+
+/// \brief Whether the driver supports specifying the catalog of the table to
+///   ingest into (type: bool).
+///
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_INGEST_OPTION_TARGET_CATALOG
+#define ADBC_INFO_FEATURE_INGEST_TARGET_CATALOG 203
+
+/// \brief Whether the driver supports specifying the catalog of the table to
+///   ingest into (type: bool).
+///
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_INGEST_OPTION_TARGET_CATALOG
+#define ADBC_INFO_FEATURE_INGEST_TARGET_SCHEMA 204
+
+/// \brief Whether the driver supports getting catalog metadata (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcConnectionGetObjects
+#define ADBC_INFO_FEATURE_OBJECTS 220
+
+/// \brief Whether the driver supports getting table schemas (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcConnectionGetObjects
+#define ADBC_INFO_FEATURE_TABLE_SCHEMA 221
+
+/// \brief Whether the driver supports getting table types (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcConnectionGetObjects
+#define ADBC_INFO_FEATURE_TABLE_TYPES 222
+
+/// \brief Whether the driver supports transactions (true), or if autocommit
+///   is always enabled (false) (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_CONNECTION_OPTION_AUTOCOMMIT
+#define ADBC_INFO_FEATURE_TRANSACTIONS 240
+
+/// \brief Whether the driver supports setting the isolation level of
+///   transactions (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_CONNECTION_OPTION_ISOLATION_LEVEL
+#define ADBC_INFO_FEATURE_TRANSACTION_ISOLATION_LEVEL 241
+
+/// \brief Whether the driver supports getting statistics (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcConnectionGetStatistics
+#define ADBC_INFO_FEATURE_STATISTICS 242
+
+/// \brief Whether the driver supports getting/setting the current catalog
+///   (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_CONNECTION_OPTION_CURRENT_CATALOG
+#define ADBC_INFO_FEATURE_CURRENT_CATALOG 243
+
+/// \brief Whether the driver supports getting/setting the current schema
+///   (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_CONNECTION_OPTION_CURRENT_CATALOG
+#define ADBC_INFO_FEATURE_CURRENT_DB_SCHEMA 244
+
+/// \brief Whether the driver supports binding data (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcStatementBind
+/// \see AdbcStatementBindStream
+#define ADBC_INFO_FEATURE_BIND 245
+
+/// \brief Whether the driver supports partitioned execution (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcConnectionReadPartition
+/// \see AdbcStatementExecutePartitions
+#define ADBC_INFO_FEATURE_EXECUTE_PARTITIONS 246
+
+/// \brief Whether the driver supports multiple result sets (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcStatementExecuteMulti
+#define ADBC_INFO_FEATURE_EXECUTE_MULTI 247
+
+/// \brief Whether the driver supports getting result set schemas (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcStatementExecuteSchema
+/// \see AdbcStatementExecuteSchemaMulti
+#define ADBC_INFO_FEATURE_EXECUTE_SCHEMA 248
+
+/// \brief Whether the driver supports getting parameter schemas (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcStatementGetParameterSchema
+#define ADBC_INFO_FEATURE_PARAMETER_SCHEMA 249
+
+/// \brief Whether the driver supports getting error metadata (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcErrorGetDetailCount
+/// \see AdbcErrorGetDetail
+/// \see AdbcErrorFromArrayStream
+/// \see ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA
+#define ADBC_INFO_FEATURE_ERROR_METADATA 250
+
 /// \brief Return metadata on catalogs, schemas, tables, and columns.
 ///
 /// \see AdbcConnectionGetObjects

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -380,6 +380,13 @@ struct ADBC_EXPORT AdbcErrorDetail {
   size_t value_length;
 };
 
+/// \brief Get the vendor code for an error (since the vendor code field was
+///   repurposed), or 0 if not available/not set.
+///
+/// \since ADBC API revision 1.2.0
+ADBC_EXPORT
+int AdbcErrorGetVendorCode(const struct AdbcError* error);
+
 /// \brief Get the number of metadata values available in an error.
 ///
 /// \since ADBC API revision 1.1.0
@@ -1401,6 +1408,8 @@ struct ADBC_EXPORT AdbcDriver {
   /// in the spec after that version.
   ///
   /// @{
+
+  int (*AdbcErrorGetVendorCode)(const struct AdbcError*);
 
   AdbcStatusCode (*MultiResultSetNext)(struct AdbcMultiResultSet*,
                                        struct ArrowArrayStream*, int64_t*,

--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -989,8 +989,6 @@ struct AdbcPartitions {
 
 /// @}
 
-/// @}
-
 /// \defgroup adbc-statement-multi Multiple Result Set Execution
 /// Some databases support executing a statement that returns multiple
 /// result sets.  This section defines the API for working with such
@@ -1091,6 +1089,23 @@ AdbcStatusCode AdbcMultiResultSetNextPartitions(struct AdbcMultiResultSet* resul
                                                 int64_t* rows_affected,
                                                 struct AdbcError* error);
 /// @}
+
+/// \brief A warning handler function.
+///
+/// The handler must not block and must not call any ADBC functions (besides
+/// releasing the warning).  The warning does not need to be released before
+/// returning, but the warning pointer itself may not be valid after the
+/// handler returns.
+///
+/// There are no requirements on ordering or concurrency of calls to the
+/// handler; the driver may call the handler at any time from any thread,
+/// including calling the handler concurrently.
+///
+/// \param[in] warning The warning information.  The application is
+///   responsible for releasing the warning, but the warning pointer itself
+///   may not be valid after the handler returns.
+/// \param[in] user_data The user_data pointer.
+typedef void (*AdbcWarningHandler)(const struct AdbcError* warning, void* user_data);
 
 /// \defgroup adbc-driver Driver Initialization
 ///
@@ -1264,6 +1279,11 @@ struct ADBC_EXPORT AdbcDriver {
                                                  struct AdbcPartitions*, int64_t*,
                                                  struct AdbcError*);
   AdbcStatusCode (*MultiResultSetRelease)(struct AdbcMultiResultSet*, struct AdbcError*);
+
+  AdbcStatusCode (*ConnectionSetWarningHandler)(struct AdbcConnection*,
+                                                AdbcWarningHandler handler,
+                                                void* user_data, struct AdbcError*);
+
   AdbcStatusCode (*StatementExecuteSchemaMulti)(struct AdbcStatement*,
                                                 struct AdbcMultiResultSet*,
                                                 struct AdbcError*);
@@ -1611,6 +1631,30 @@ AdbcStatusCode AdbcConnectionInit(struct AdbcConnection* connection,
 ADBC_EXPORT
 AdbcStatusCode AdbcConnectionRelease(struct AdbcConnection* connection,
                                      struct AdbcError* error);
+
+/// \brief Set a warning handler.
+///
+/// May be set before or after AdbcConnectionInit.
+///
+/// Drivers should not repeat warnings unnecessarily.  For example, if a
+/// warning is issued for a lossy conversion to Arrow data, ideally it would
+/// be reported at most twice: once for the first occurrence, and/or a second
+/// time at the end of the result set summarizing how many values were
+/// affected.
+///
+/// \since ADBC API revision 1.2.0
+/// \param[in] database The database.
+/// \param[in] handler The warning handler to use; NULL removes the handler.
+/// \param[in] user_data A user data pointer to be passed to the handler.
+///   Must live at least until the connection is released or the warning
+///   handler is replaced.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if warning handlers are not supported
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionSetWarningHandler(struct AdbcConnection* connection,
+                                               AdbcWarningHandler handler,
+                                               void* user_data, struct AdbcError* error);
 
 /// \brief Cancel the in-progress operation on a connection.
 ///

--- a/go/adbc/drivermgr/arrow-adbc/adbc.h
+++ b/go/adbc/drivermgr/arrow-adbc/adbc.h
@@ -683,6 +683,10 @@ const struct AdbcError* AdbcErrorFromArrayStream(struct ArrowArrayStream* stream
 /// \see ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA
 #define ADBC_INFO_FEATURE_ERROR_METADATA 250
 
+/// \defgroup adbc-catalog-metadata ADBC Catalog Metadata Constants
+/// Constants for catalog metadata.
+/// @{
+
 /// \brief Return metadata on catalogs, schemas, tables, and columns.
 ///
 /// \see AdbcConnectionGetObjects
@@ -707,6 +711,88 @@ const struct AdbcError* AdbcErrorFromArrayStream(struct ArrowArrayStream* stream
 ///
 /// \see AdbcConnectionGetObjects
 #define ADBC_OBJECT_DEPTH_COLUMNS ADBC_OBJECT_DEPTH_ALL
+
+/// \brief This foreign key does not allow update of the corresponding primary
+///   key.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyNoAction`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_ACTION_NO_ACTION 3
+
+/// \brief This foreign key will be updated/deleted with corresponding primary
+///   key.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyCascade`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_ACTION_CASCADE 0
+
+/// \brief This foreign key will be set to NULL if its corresponding primary
+///   key is updated or deleted.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeySetNull`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_ACTION_SET_NULL 2
+
+/// \brief This foreign key will be set to its default if its corresponding
+///   primary key is updated or deleted.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeySetDefault`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_ACTION_SET_DEFAULT 4
+
+/// \brief Similar to ADBC_CONSTRAINT_ACTION_NO_ACTION but may be interpreted
+///   differently by the vendor (e.g., raise an error immediately instead of
+///   allowing the check to be deferred).
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyRestrict`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_ACTION_RESTRICT 1
+
+/// \brief This constraint is deferrable, and is initially deferred.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyInitiallyDeferred`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_DEFERRABLE_DEFERRED 5
+
+/// \brief This constraint is deferrable, but is initially immediate.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyInitiallyImmediate`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_DEFERRABLE_IMMEDIATE 6
+
+/// \brief This constraint may not be deferred.
+///
+/// \note Value corresponds to JDBC `DatabaseMetaData#importedKeyNotDeferrable`.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_NOT_DEFERRABLE 7
+
+/// \brief This foreign key allows any of the foreign key columns to be NULL;
+///   if so, no match is required in the referenced table.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_MATCH_SIMPLE 0
+
+/// \brief This foreign key only allows foreign key columns to be NULL if all
+///   of them are NULL; if so, no match is required in the referenced table.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_MATCH_FULL 1
+
+/// \brief This foreign key allows any of the foreign key columns to be NULL;
+///   if so, non-NULL columns must still match.
+///
+/// \see AdbcConnectionGetObjects
+#define ADBC_CONSTRAINT_MATCH_PARTIAL 2
+
+/// @}
 
 /// \defgroup adbc-table-statistics ADBC Statistic Types
 /// Standard statistic names for AdbcConnectionGetStatistics.
@@ -1950,20 +2036,58 @@ AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
 /// | constraint_type          | utf8 not null           | (1)      |
 /// | constraint_column_names  | list<utf8> not null     | (2)      |
 /// | constraint_column_usage  | list<USAGE_SCHEMA>      | (3)      |
+/// | constraint_expression    | utf8                    | (4)      |
+/// | constraint_update_rule   | int16                   | (5)      |
+/// | constraint_delete_rule   | int16                   | (5)      |
+/// | constraint_enforced      | bool                    | (6)      |
+/// | constraint_deferrability | int16                   | (7)      |
+/// | constraint_match_type    | int16                   | (8)      |
 ///
-/// 1. One of 'CHECK', 'FOREIGN KEY', 'PRIMARY KEY', or 'UNIQUE'.
+/// 1. One of 'CHECK', 'FOREIGN KEY', 'PRIMARY KEY', or 'UNIQUE', or a
+///    vendor-specific type.
 /// 2. The columns on the current table that are constrained, in
 ///    order.
 /// 3. For FOREIGN KEY only, the referenced table and columns.
+/// 4. [Since version 1.2.0] The vendor-specific definition of the constraint
+///    (e.g. the SQL expression to be checked).  This field is optional.
+/// 5. [Since version 1.2.0] The action to be taken when the primary key is
+///    updated or deleted.  The value is one of the ADBC_CONSTRAINT_ACTION_
+///    constants. This field is optional.
+/// 6. [Since version 1.2.0] Whether the constraint is currently enabled.
+///    This field is optional.
+/// 7. [Since version 1.2.0] Whether the constraint can be deferred, and if
+///    so, whether it starts deferred.  The value is one of the
+///    ADBC_CONSTRAINT_DEFERRABLE_ constants or
+///    ADBC_CONSTRAINT_NOT_DEFERRABLE.  This field is optional.
+/// 8. [Since version 1.2.0] How the foreign key constraint should be matched.
+///    The value is one of the ADBC_CONSTRAINT_MATCH_ constants.  This field
+///    is optional.
 ///
 /// USAGE_SCHEMA is a Struct with fields:
 ///
-/// | Field Name               | Field Type              |
-/// |--------------------------|-------------------------|
-/// | fk_catalog               | utf8                    |
-/// | fk_db_schema             | utf8                    |
-/// | fk_table                 | utf8 not null           |
-/// | fk_column_name           | utf8 not null           |
+/// | Field Name               | Field Type              | Comments |
+/// |--------------------------|-------------------------|----------|
+/// | fk_catalog               | utf8                    |          |
+/// | fk_db_schema             | utf8                    |          |
+/// | fk_table                 | utf8 not null           |          |
+/// | fk_column_name           | utf8 not null           |          |
+/// | fk_key_seq               | int32                   | (1)      |
+/// | fk_pk_name               | utf8                    | (2)      |
+///
+/// 1. [Since version 1.2.0] The ordinal position of the column within the
+///    foreign key.  If present, the driver should sort the rows on this
+///    column.  This field is optional.
+/// 2. [Since version 1.2.0] The name of the referenced primary key.  This
+///    field is optional.
+///
+/// Starting in version 1.2.0, optional fields were introduced to the schema.
+/// Optional fields may not be present in the returned schema/data and
+/// applications should check for their presence before using them.  Drivers
+/// may choose to include optional fields (with null values) even if not
+/// supported, but are not required to.  If an optional field is present, all
+/// optional fields defined before it in the schema must be present (but the
+/// values may still be null if the driver does not actually support that
+/// field).
 ///
 /// This AdbcConnection must outlive the returned ArrowArrayStream.
 ///

--- a/go/adbc/drivermgr/arrow-adbc/adbc.h
+++ b/go/adbc/drivermgr/arrow-adbc/adbc.h
@@ -545,6 +545,137 @@ const struct AdbcError* AdbcErrorFromArrayStream(struct ArrowArrayStream* stream
 /// \see ADBC_VERSION_1_2_0
 #define ADBC_INFO_DRIVER_ADBC_VERSION 103
 
+/// \brief Whether the driver supports bulk ingest (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_FEATURE_INGEST 200
+
+/// \brief Supported bulk ingest modes (type: string list).
+///
+/// Values are the mode constants themselves.
+///
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+#define ADBC_INFO_FEATURE_INGEST_MODES 201
+
+/// \brief Whether the driver supports ingesting into a temporary table (type:
+///   bool).
+///
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_INGEST_OPTION_TEMPORARY
+#define ADBC_INFO_FEATURE_INGEST_TEMPORARY 202
+
+/// \brief Whether the driver supports specifying the catalog of the table to
+///   ingest into (type: bool).
+///
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_INGEST_OPTION_TARGET_CATALOG
+#define ADBC_INFO_FEATURE_INGEST_TARGET_CATALOG 203
+
+/// \brief Whether the driver supports specifying the catalog of the table to
+///   ingest into (type: bool).
+///
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_INGEST_OPTION_TARGET_CATALOG
+#define ADBC_INFO_FEATURE_INGEST_TARGET_SCHEMA 204
+
+/// \brief Whether the driver supports getting catalog metadata (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcConnectionGetObjects
+#define ADBC_INFO_FEATURE_OBJECTS 220
+
+/// \brief Whether the driver supports getting table schemas (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcConnectionGetObjects
+#define ADBC_INFO_FEATURE_TABLE_SCHEMA 221
+
+/// \brief Whether the driver supports getting table types (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcConnectionGetObjects
+#define ADBC_INFO_FEATURE_TABLE_TYPES 222
+
+/// \brief Whether the driver supports transactions (true), or if autocommit
+///   is always enabled (false) (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_CONNECTION_OPTION_AUTOCOMMIT
+#define ADBC_INFO_FEATURE_TRANSACTIONS 240
+
+/// \brief Whether the driver supports setting the isolation level of
+///   transactions (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_CONNECTION_OPTION_ISOLATION_LEVEL
+#define ADBC_INFO_FEATURE_TRANSACTION_ISOLATION_LEVEL 241
+
+/// \brief Whether the driver supports getting statistics (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcConnectionGetStatistics
+#define ADBC_INFO_FEATURE_STATISTICS 242
+
+/// \brief Whether the driver supports getting/setting the current catalog
+///   (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_CONNECTION_OPTION_CURRENT_CATALOG
+#define ADBC_INFO_FEATURE_CURRENT_CATALOG 243
+
+/// \brief Whether the driver supports getting/setting the current schema
+///   (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see ADBC_CONNECTION_OPTION_CURRENT_CATALOG
+#define ADBC_INFO_FEATURE_CURRENT_DB_SCHEMA 244
+
+/// \brief Whether the driver supports binding data (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcStatementBind
+/// \see AdbcStatementBindStream
+#define ADBC_INFO_FEATURE_BIND 245
+
+/// \brief Whether the driver supports partitioned execution (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcConnectionReadPartition
+/// \see AdbcStatementExecutePartitions
+#define ADBC_INFO_FEATURE_EXECUTE_PARTITIONS 246
+
+/// \brief Whether the driver supports multiple result sets (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcStatementExecuteMulti
+#define ADBC_INFO_FEATURE_EXECUTE_MULTI 247
+
+/// \brief Whether the driver supports getting result set schemas (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcStatementExecuteSchema
+/// \see AdbcStatementExecuteSchemaMulti
+#define ADBC_INFO_FEATURE_EXECUTE_SCHEMA 248
+
+/// \brief Whether the driver supports getting parameter schemas (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcStatementGetParameterSchema
+#define ADBC_INFO_FEATURE_PARAMETER_SCHEMA 249
+
+/// \brief Whether the driver supports getting error metadata (type: bool).
+/// \since ADBC API revision 1.2.0
+/// \see AdbcConnectionGetInfo
+/// \see AdbcErrorGetDetailCount
+/// \see AdbcErrorGetDetail
+/// \see AdbcErrorFromArrayStream
+/// \see ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA
+#define ADBC_INFO_FEATURE_ERROR_METADATA 250
+
 /// \brief Return metadata on catalogs, schemas, tables, and columns.
 ///
 /// \see AdbcConnectionGetObjects

--- a/go/adbc/drivermgr/arrow-adbc/adbc.h
+++ b/go/adbc/drivermgr/arrow-adbc/adbc.h
@@ -380,6 +380,13 @@ struct ADBC_EXPORT AdbcErrorDetail {
   size_t value_length;
 };
 
+/// \brief Get the vendor code for an error (since the vendor code field was
+///   repurposed), or 0 if not available/not set.
+///
+/// \since ADBC API revision 1.2.0
+ADBC_EXPORT
+int AdbcErrorGetVendorCode(const struct AdbcError* error);
+
 /// \brief Get the number of metadata values available in an error.
 ///
 /// \since ADBC API revision 1.1.0
@@ -1401,6 +1408,8 @@ struct ADBC_EXPORT AdbcDriver {
   /// in the spec after that version.
   ///
   /// @{
+
+  int (*AdbcErrorGetVendorCode)(const struct AdbcError*);
 
   AdbcStatusCode (*MultiResultSetNext)(struct AdbcMultiResultSet*,
                                        struct ArrowArrayStream*, int64_t*,

--- a/go/adbc/drivermgr/arrow-adbc/adbc.h
+++ b/go/adbc/drivermgr/arrow-adbc/adbc.h
@@ -989,8 +989,6 @@ struct AdbcPartitions {
 
 /// @}
 
-/// @}
-
 /// \defgroup adbc-statement-multi Multiple Result Set Execution
 /// Some databases support executing a statement that returns multiple
 /// result sets.  This section defines the API for working with such
@@ -1091,6 +1089,23 @@ AdbcStatusCode AdbcMultiResultSetNextPartitions(struct AdbcMultiResultSet* resul
                                                 int64_t* rows_affected,
                                                 struct AdbcError* error);
 /// @}
+
+/// \brief A warning handler function.
+///
+/// The handler must not block and must not call any ADBC functions (besides
+/// releasing the warning).  The warning does not need to be released before
+/// returning, but the warning pointer itself may not be valid after the
+/// handler returns.
+///
+/// There are no requirements on ordering or concurrency of calls to the
+/// handler; the driver may call the handler at any time from any thread,
+/// including calling the handler concurrently.
+///
+/// \param[in] warning The warning information.  The application is
+///   responsible for releasing the warning, but the warning pointer itself
+///   may not be valid after the handler returns.
+/// \param[in] user_data The user_data pointer.
+typedef void (*AdbcWarningHandler)(const struct AdbcError* warning, void* user_data);
 
 /// \defgroup adbc-driver Driver Initialization
 ///
@@ -1264,6 +1279,11 @@ struct ADBC_EXPORT AdbcDriver {
                                                  struct AdbcPartitions*, int64_t*,
                                                  struct AdbcError*);
   AdbcStatusCode (*MultiResultSetRelease)(struct AdbcMultiResultSet*, struct AdbcError*);
+
+  AdbcStatusCode (*ConnectionSetWarningHandler)(struct AdbcConnection*,
+                                                AdbcWarningHandler handler,
+                                                void* user_data, struct AdbcError*);
+
   AdbcStatusCode (*StatementExecuteSchemaMulti)(struct AdbcStatement*,
                                                 struct AdbcMultiResultSet*,
                                                 struct AdbcError*);
@@ -1611,6 +1631,30 @@ AdbcStatusCode AdbcConnectionInit(struct AdbcConnection* connection,
 ADBC_EXPORT
 AdbcStatusCode AdbcConnectionRelease(struct AdbcConnection* connection,
                                      struct AdbcError* error);
+
+/// \brief Set a warning handler.
+///
+/// May be set before or after AdbcConnectionInit.
+///
+/// Drivers should not repeat warnings unnecessarily.  For example, if a
+/// warning is issued for a lossy conversion to Arrow data, ideally it would
+/// be reported at most twice: once for the first occurrence, and/or a second
+/// time at the end of the result set summarizing how many values were
+/// affected.
+///
+/// \since ADBC API revision 1.2.0
+/// \param[in] database The database.
+/// \param[in] handler The warning handler to use; NULL removes the handler.
+/// \param[in] user_data A user data pointer to be passed to the handler.
+///   Must live at least until the connection is released or the warning
+///   handler is replaced.
+/// \param[out] error An optional location to return an error
+///   message if necessary.
+/// \return ADBC_STATUS_NOT_IMPLEMENTED if warning handlers are not supported
+ADBC_EXPORT
+AdbcStatusCode AdbcConnectionSetWarningHandler(struct AdbcConnection* connection,
+                                               AdbcWarningHandler handler,
+                                               void* user_data, struct AdbcError* error);
 
 /// \brief Cancel the in-progress operation on a connection.
 ///

--- a/r/adbcdrivermanager/src/radbc.cc
+++ b/r/adbcdrivermanager/src/radbc.cc
@@ -105,7 +105,8 @@ extern "C" SEXP RAdbcAllocateDriver(void) {
   R_RegisterCFinalizer(driver_xptr, &finalize_driver_xptr);
 
   // Make sure we error when the ADBC spec is updated
-  static_assert(sizeof(AdbcDriver) == ADBC_DRIVER_1_1_0_SIZE);
+  static_assert(offsetof(struct AdbcDriver, StatementExecuteMulti) ==
+                ADBC_DRIVER_1_1_0_SIZE);
   SEXP version_sexp = PROTECT(Rf_ScalarInteger(ADBC_VERSION_1_1_0));
 
   const char* names[] = {"driver", "version", ""};


### PR DESCRIPTION
Add some more properties to GetObjects. Also, allow drivers to add custom fields for database-specific metadata.

Closes #3984.
Closes #3995.