### PR TITLE
ci(rust): suppress unused features error for unstable `non_exhaustive_omitted_patterns_lint` only used in `arrow_ffi`

### DIFF
--- a/rust/ffi/src/options.rs
+++ b/rust/ffi/src/options.rs
@@ -45,6 +45,7 @@ pub(crate) fn get_opt_name(value: &OptionValue) -> &str {
         OptionValue::String(_) => "String",
         OptionValue::Bytes(_) => "Bytes",
         OptionValue::Int(_) => "Int",
+        OptionValue::Double(_) => "Double",
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
It seems that the latest nightly toolchain has tightened detection of unused features.
Currently, unstable `non_exhaustive_omitted_patterns` is only used in `adbc_ffi` (#3245), so it seems necessary `allow(unused_features)` for the other workspace members.

This change fixes the Rust CI failure seen in recent PRs.