### PR TITLE
feat(java/driver/jni): add executeSchema

### DIFF
--- a/java/driver/jni-validation-sqlite/src/test/java/org/apache/arrow/adbc/driver/jni/JniSqliteStatementTest.java
+++ b/java/driver/jni-validation-sqlite/src/test/java/org/apache/arrow/adbc/driver/jni/JniSqliteStatementTest.java
@@ -40,15 +40,15 @@ class JniSqliteStatementTest extends AbstractStatementTest {
   public void bulkIngestCreateConflict() {}
 
   @Override
-  @Disabled("Not yet implemented in JNI driver")
+  @Disabled("SQLite driver does not support ExecuteSchema")
   public void executeSchema() {}
 
   @Override
-  @Disabled("Not yet implemented in JNI driver")
+  @Disabled("SQLite driver does not support ExecuteSchema")
   public void executeSchemaPrepared() {}
 
   @Override
-  @Disabled("Not yet implemented in JNI driver")
+  @Disabled("SQLite driver does not support ExecuteSchema")
   public void executeSchemaParams() {}
 
   @Override

--- a/java/driver/jni/src/main/cpp/jni_wrapper.cc
+++ b/java/driver/jni/src/main/cpp/jni_wrapper.cc
@@ -97,7 +97,8 @@ void RaiseAdbcException(AdbcStatusCode code, const AdbcError& error) {
   assert(code != ADBC_STATUS_OK);
   throw AdbcException{
       .code = code,
-      .message = std::string(error.message),
+      .message =
+          error.message ? std::string(error.message) : std::string("(unknown error)"),
   };
 }
 
@@ -437,6 +438,22 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementPrepare(
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementExecuteSchema(
+    JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
+  try {
+    struct AdbcError error = ADBC_ERROR_INIT;
+    auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
+    struct ArrowSchema schema = {};
+    CHECK_ADBC_ERROR(AdbcStatementExecuteSchema(ptr, &schema, &error), error);
+
+    return MakeNativeSchemaResult(env, &schema);
+  } catch (const AdbcException& e) {
+    e.ThrowJavaException(env);
+  }
+  return nullptr;
 }
 
 JNIEXPORT void JNICALL

--- a/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/JniStatement.java
+++ b/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/JniStatement.java
@@ -27,6 +27,7 @@ import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
 
 public class JniStatement implements AdbcStatement {
   private final BufferAllocator allocator;
@@ -77,6 +78,12 @@ public class JniStatement implements AdbcStatement {
     exportBind();
     long rowsAffected = JniLoader.INSTANCE.statementExecuteUpdate(handle);
     return new UpdateResult(rowsAffected);
+  }
+
+  @Override
+  public Schema executeSchema() throws AdbcException {
+    exportBind();
+    return JniLoader.INSTANCE.statementExecuteSchema(handle).importSchema(allocator);
   }
 
   @Override

--- a/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLoader.java
+++ b/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLoader.java
@@ -119,6 +119,11 @@ public enum JniLoader {
     NativeAdbc.statementSetOption(statement.getStatementHandle(), key, value);
   }
 
+  public NativeSchemaResult statementExecuteSchema(NativeStatementHandle statement)
+      throws AdbcException {
+    return NativeAdbc.statementExecuteSchema(statement.getStatementHandle());
+  }
+
   public NativeQueryResult connectionGetObjects(
       NativeConnectionHandle connection,
       int depth,

--- a/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/NativeAdbc.java
+++ b/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/NativeAdbc.java
@@ -52,6 +52,8 @@ class NativeAdbc {
 
   static native void statementSetOption(long handle, String key, String value) throws AdbcException;
 
+  static native NativeSchemaResult statementExecuteSchema(long handle) throws AdbcException;
+
   static native NativeQueryResult connectionGetObjects(
       long handle,
       int depth,


### PR DESCRIPTION
- adds executeSchema to jni driver
- sqlite validation suite can't test it as sqlite driver doesn't support executeSchema yet, but the change is pretty straightforward