### PR TITLE
refactor(python/adbc_driver_manager): add return type annotations

### DIFF
--- a/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
@@ -47,7 +47,7 @@ import time
 import typing
 import warnings
 import weakref
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, NoReturn, Optional, Tuple, Union
 
 try:
     import pyarrow
@@ -684,7 +684,7 @@ class Cursor(_Closeable):
         if adbc_stmt_kwargs:
             self._stmt.set_options(**adbc_stmt_kwargs)
 
-    def _clear(self):
+    def _clear(self) -> None:
         if self._results is not None:
             self._results.close()
             self._results = None
@@ -728,11 +728,11 @@ class Cursor(_Closeable):
             return self._results.rownumber
         return None
 
-    def callproc(self, procname, parameters):
+    def callproc(self, procname, parameters) -> NoReturn:
         """Call a stored procedure (not supported)."""
         raise NotSupportedError("Cursor.callproc")
 
-    def close(self):
+    def close(self) -> None:
         """Close the cursor and free resources."""
         if self._closed:
             return
@@ -919,22 +919,22 @@ class Cursor(_Closeable):
             )
         return self._results.fetchall()
 
-    def next(self):
+    def next(self) -> tuple:
         """Fetch the next row, or raise StopIteration."""
         row = self.fetchone()
         if row is None:
             raise StopIteration
         return row
 
-    def nextset(self):
+    def nextset(self) -> NoReturn:
         """Move to the next available result set (not supported)."""
         raise NotSupportedError("Cursor.nextset")
 
-    def setinputsizes(self, sizes):
+    def setinputsizes(self, sizes) -> None:
         """Preallocate memory for the parameters (no-op)."""
         pass
 
-    def setoutputsize(self, size, column=None):
+    def setoutputsize(self, size, column=None) -> None:
         """Preallocate memory for the result set (no-op)."""
         pass
 
@@ -943,10 +943,10 @@ class Cursor(_Closeable):
             self.close()
             _warn_unclosed("adbc_driver_manager.dbapi.Cursor")
 
-    def __iter__(self):
+    def __iter__(self) -> "Self":
         return self
 
-    def __next__(self):
+    def __next__(self) -> tuple:
         return self.next()
 
     # ------------------------------------------------------------
@@ -1453,7 +1453,7 @@ _PYTEST_ENV_VAR = "PYTEST_CURRENT_TEST"
 _ADBC_ENV_VAR = "_ADBC_DRIVER_MANAGER_WARN_UNCLOSED_RESOURCE"
 
 
-def _warn_unclosed(name):
+def _warn_unclosed(name) -> None:
     if _PYTEST_ENV_VAR in os.environ or os.environ.get(_ADBC_ENV_VAR) == "1":
         warnings.warn(
             f"A {name} was not explicitly close()d, which may leak "
@@ -1464,7 +1464,7 @@ def _warn_unclosed(name):
         )
 
 
-def _is_arrow_data(data):
+def _is_arrow_data(data) -> bool:
     # No need to check for PyArrow types explicitly since they support the
     # dunder methods
     return (
@@ -1475,7 +1475,7 @@ def _is_arrow_data(data):
     )
 
 
-def _requires_pyarrow():
+def _requires_pyarrow() -> None:
     if not _has_pyarrow:
         raise ProgrammingError(
             "This API requires PyArrow to be installed",

--- a/python/adbc_driver_manager/tests/panictest.py
+++ b/python/adbc_driver_manager/tests/panictest.py
@@ -22,7 +22,7 @@ import argparse
 import adbc_driver_manager
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("driver_path")
     args = parser.parse_args()

--- a/python/adbc_driver_manager/tests/test_blocking.py
+++ b/python/adbc_driver_manager/tests/test_blocking.py
@@ -27,6 +27,7 @@ import signal
 import sys
 import threading
 import time
+import typing
 
 import pytest
 
@@ -39,7 +40,7 @@ from adbc_driver_manager import _lib
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="Disabled on Windows")
 
 
-def _send_sigint():
+def _send_sigint() -> None:
     # Windows behavior is different
     # https://stackoverflow.com/questions/35772001
     if os.name == "nt":
@@ -48,7 +49,7 @@ def _send_sigint():
         os.kill(os.getpid(), signal.SIGINT)
 
 
-def _blocking(event):
+def _blocking(event) -> None:
     _send_sigint()
     event.wait()
 
@@ -58,7 +59,7 @@ def is_freethreaded() -> bool:
     return hasattr(sys, "_is_gil_enabled") and not getattr(sys, "_is_gil_enabled")()
 
 
-def test_sigint_fires():
+def test_sigint_fires() -> None:
     # Run the thing that fires SIGINT itself as the "blocking" call
     event = threading.Event()
 
@@ -68,7 +69,7 @@ def test_sigint_fires():
     _lib._blocking_call(_blocking, (event,), {}, _cancel)
 
 
-def test_handler_restored():
+def test_handler_restored() -> None:
     event = threading.Event()
     _lib._blocking_call(_blocking, (event,), {}, event.set)
 
@@ -80,7 +81,7 @@ def test_handler_restored():
         time.sleep(60)
 
 
-def test_args_return():
+def test_args_return() -> None:
     def _blocking(a, *, b):
         return a, b
 
@@ -92,7 +93,7 @@ def test_args_return():
     ) == (1, 2)
 
 
-def test_blocking_raise():
+def test_blocking_raise() -> None:
     def _blocking():
         raise ValueError("expected error")
 
@@ -112,7 +113,7 @@ def test_cancel_raise(is_freethreaded: bool) -> None:
         if is_freethreaded:
             time.sleep(5)
 
-    def _cancel():
+    def _cancel() -> typing.NoReturn:
         event.set()
         raise ValueError("expected error")
 
@@ -123,14 +124,14 @@ def test_cancel_raise(is_freethreaded: bool) -> None:
 def test_both_raise(is_freethreaded: bool) -> None:
     event = threading.Event()
 
-    def _blocking(event):
+    def _blocking(event) -> typing.NoReturn:
         _send_sigint()
         event.wait()
         if is_freethreaded:
             time.sleep(5)
         raise ValueError("expected error 1")
 
-    def _cancel():
+    def _cancel() -> typing.NoReturn:
         event.set()
         raise ValueError("expected error 2")
 
@@ -141,11 +142,11 @@ def test_both_raise(is_freethreaded: bool) -> None:
         raise excinfo.value.__cause__
 
 
-def test_nested():
+def test_nested() -> None:
     # To be clear, don't ever do this.
     event = threading.Event()
 
-    def _wrap_blocking():
+    def _wrap_blocking() -> None:
         _lib._blocking_call(_blocking, (event,), {}, event.set)
 
     _lib._blocking_call(_wrap_blocking, (), {}, lambda: None)

--- a/python/adbc_driver_manager/tests/test_dbapi.py
+++ b/python/adbc_driver_manager/tests/test_dbapi.py
@@ -26,7 +26,7 @@ from pandas.testing import assert_frame_equal
 from adbc_driver_manager import dbapi
 
 
-def test_type_objects():
+def test_type_objects() -> None:
     assert dbapi.NUMBER == pyarrow.int64()
     assert pyarrow.int64() == dbapi.NUMBER
 
@@ -39,7 +39,7 @@ def test_type_objects():
 
 
 @pytest.mark.sqlite
-def test_attrs(sqlite):
+def test_attrs(sqlite) -> None:
     assert sqlite.Warning == dbapi.Warning
     assert sqlite.Error == dbapi.Error
     assert sqlite.InterfaceError == dbapi.InterfaceError
@@ -59,7 +59,7 @@ def test_attrs(sqlite):
 
 
 @pytest.mark.sqlite
-def test_info(sqlite):
+def test_info(sqlite) -> None:
     info = sqlite.adbc_get_info()
     assert set(info.keys()) == {
         "driver_adbc_version",
@@ -74,7 +74,7 @@ def test_info(sqlite):
 
 
 @pytest.mark.sqlite
-def test_get_underlying(sqlite):
+def test_get_underlying(sqlite) -> None:
     assert sqlite.adbc_database
     assert sqlite.adbc_connection
     with sqlite.cursor() as cur:
@@ -82,7 +82,7 @@ def test_get_underlying(sqlite):
 
 
 @pytest.mark.sqlite
-def test_clone(sqlite):
+def test_clone(sqlite) -> None:
     with sqlite.adbc_clone() as sqlite2:
         with sqlite2.cursor() as cur:
             cur.execute("CREATE TABLE temporary (ints)")
@@ -95,7 +95,7 @@ def test_clone(sqlite):
 
 
 @pytest.mark.sqlite
-def test_get_objects(sqlite):
+def test_get_objects(sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.execute("CREATE TABLE temporary (ints)")
         cur.execute("INSERT INTO temporary VALUES (1)")
@@ -117,7 +117,7 @@ def test_get_objects(sqlite):
 
 
 @pytest.mark.sqlite
-def test_get_table_schema(sqlite):
+def test_get_table_schema(sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.execute("CREATE TABLE temporary (ints)")
         cur.execute("INSERT INTO temporary VALUES (1)")
@@ -127,12 +127,12 @@ def test_get_table_schema(sqlite):
 
 
 @pytest.mark.sqlite
-def test_get_table_types(sqlite):
+def test_get_table_types(sqlite) -> None:
     assert sqlite.adbc_get_table_types() == ["table", "view"]
 
 
 class ArrayWrapper:
-    def __init__(self, array):
+    def __init__(self, array) -> None:
         self.array = array
 
     def __arrow_c_array__(self, requested_schema=None):
@@ -140,7 +140,7 @@ class ArrayWrapper:
 
 
 class StreamWrapper:
-    def __init__(self, stream):
+    def __init__(self, stream) -> None:
         self.stream = stream
 
     def __arrow_c_stream__(self, requested_schema=None):
@@ -167,7 +167,7 @@ class StreamWrapper:
     ],
 )
 @pytest.mark.sqlite
-def test_ingest(data, sqlite):
+def test_ingest(data, sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.adbc_ingest("bulk_ingest", data())
 
@@ -191,14 +191,14 @@ def test_ingest(data, sqlite):
 
 
 @pytest.mark.sqlite
-def test_partitions(sqlite):
+def test_partitions(sqlite) -> None:
     with pytest.raises(dbapi.NotSupportedError):
         with sqlite.cursor() as cur:
             cur.adbc_execute_partitions("SELECT 1")
 
 
 @pytest.mark.sqlite
-def test_query_fetch_py(sqlite):
+def test_query_fetch_py(sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.execute("SELECT 1, 'foo' AS foo, 2.0")
         assert cur.description == [
@@ -224,7 +224,7 @@ def test_query_fetch_py(sqlite):
 
 
 @pytest.mark.sqlite
-def test_query_fetch_arrow(sqlite):
+def test_query_fetch_arrow(sqlite) -> None:
     with sqlite.cursor() as cur:
         with pytest.raises(sqlite.ProgrammingError):
             cur.fetch_arrow()
@@ -245,7 +245,7 @@ def test_query_fetch_arrow(sqlite):
 
 
 @pytest.mark.sqlite
-def test_query_fetch_arrow_3543(sqlite):
+def test_query_fetch_arrow_3543(sqlite) -> None:
     # Regression test for https://github.com/apache/arrow-adbc/issues/3543
     with sqlite.cursor() as cur:
         cur.execute("SELECT 1, 'foo' AS foo, 2.0")
@@ -269,7 +269,7 @@ def test_query_fetch_arrow_3543(sqlite):
 
 
 @pytest.mark.sqlite
-def test_query_fetch_arrow_table(sqlite):
+def test_query_fetch_arrow_table(sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.execute("SELECT 1, 'foo' AS foo, 2.0")
         assert cur.fetch_arrow_table() == pyarrow.table(
@@ -282,7 +282,7 @@ def test_query_fetch_arrow_table(sqlite):
 
 
 @pytest.mark.sqlite
-def test_query_fetch_df(sqlite):
+def test_query_fetch_df(sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.execute("SELECT 1, 'foo' AS foo, 2.0")
         assert_frame_equal(
@@ -308,14 +308,14 @@ def test_query_fetch_df(sqlite):
         StreamWrapper(pyarrow.table([[1.0], [2]], names=["float", "int"])),
     ],
 )
-def test_execute_parameters(sqlite, parameters):
+def test_execute_parameters(sqlite, parameters) -> None:
     with sqlite.cursor() as cur:
         cur.execute("SELECT ? + 1, ?", parameters)
         assert cur.fetchall() == [(2.0, 2)]
 
 
 @pytest.mark.sqlite
-def test_execute_parameters_name(sqlite):
+def test_execute_parameters_name(sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.execute("SELECT @a + 1, @b", {"@b": 2, "@a": 1})
         assert cur.fetchall() == [(2, 2)]
@@ -334,7 +334,7 @@ def test_execute_parameters_name(sqlite):
 
 
 @pytest.mark.sqlite
-def test_executemany_parameters_name(sqlite):
+def test_executemany_parameters_name(sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.execute("CREATE TABLE executemany_params (a, b)")
 
@@ -365,7 +365,7 @@ def test_executemany_parameters_name(sqlite):
         ((x, y) for x, y in ((1, "a"), (3, None))),
     ],
 )
-def test_executemany_parameters(sqlite, parameters):
+def test_executemany_parameters(sqlite, parameters) -> None:
     with sqlite.cursor() as cur:
         cur.execute("DROP TABLE IF EXISTS executemany")
         cur.execute("CREATE TABLE executemany (int, str)")
@@ -383,7 +383,7 @@ def test_executemany_parameters(sqlite, parameters):
         pyarrow.table([[]], schema=pyarrow.schema([("v", pyarrow.int64())])),
     ],
 )
-def test_executemany_empty(sqlite, parameters):
+def test_executemany_empty(sqlite, parameters) -> None:
     # Regression test for https://github.com/apache/arrow-adbc/issues/3319
     with sqlite.cursor() as cur:
         # With an empty sequence, it should be the same as not executing the
@@ -396,7 +396,7 @@ def test_executemany_empty(sqlite, parameters):
 
 
 @pytest.mark.sqlite
-def test_executemany_none(sqlite):
+def test_executemany_none(sqlite) -> None:
     # Regression test for https://github.com/apache/arrow-adbc/issues/3319
     with sqlite.cursor() as cur:
         # With None, it should be the same as executing the query once.
@@ -407,14 +407,14 @@ def test_executemany_none(sqlite):
 
 
 @pytest.mark.sqlite
-def test_query_substrait(sqlite):
+def test_query_substrait(sqlite) -> None:
     with sqlite.cursor() as cur:
         with pytest.raises(dbapi.NotSupportedError):
             cur.execute(b"Substrait plan")
 
 
 @pytest.mark.sqlite
-def test_executemany(sqlite):
+def test_executemany(sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.execute("CREATE TABLE foo (a, b)")
         cur.executemany(
@@ -437,7 +437,7 @@ def test_executemany(sqlite):
 
 
 @pytest.mark.sqlite
-def test_fetch_record_batch(sqlite):
+def test_fetch_record_batch(sqlite) -> None:
     dataset = [
         [1, 2],
         [3, 4],
@@ -457,7 +457,7 @@ def test_fetch_record_batch(sqlite):
 
 
 @pytest.mark.sqlite
-def test_fetch_empty(sqlite):
+def test_fetch_empty(sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.execute("CREATE TABLE foo (bar)")
         cur.execute("SELECT * FROM foo")
@@ -474,7 +474,7 @@ def test_reader(sqlite, tmp_path) -> None:
 
 
 @pytest.mark.sqlite
-def test_prepare(sqlite):
+def test_prepare(sqlite) -> None:
     with sqlite.cursor() as cur:
         schema = cur.adbc_prepare("SELECT 1")
         assert schema == pyarrow.schema([])
@@ -487,7 +487,7 @@ def test_prepare(sqlite):
 
 
 @pytest.mark.sqlite
-def test_close_warning(sqlite):
+def test_close_warning(sqlite) -> None:
     with pytest.warns(
         ResourceWarning,
         match=r"A adbc_driver_manager.dbapi.Cursor was not explicitly close\(\)d",
@@ -503,7 +503,7 @@ def test_close_warning(sqlite):
         del conn
 
 
-def _execute_schema(cursor):
+def _execute_schema(cursor) -> None:
     try:
         cursor.adbc_execute_schema("select 1")
     except dbapi.NotSupportedError:
@@ -548,7 +548,7 @@ def test_release(sqlite, op) -> None:
             assert not handle.is_valid
 
 
-def test_driver_path():
+def test_driver_path() -> None:
     with pytest.raises(
         dbapi.ProgrammingError,
         match="(dlopen|LoadLibraryExW).*failed:",
@@ -558,7 +558,7 @@ def test_driver_path():
 
 
 @pytest.mark.sqlite
-def test_dbapi_extensions(sqlite):
+def test_dbapi_extensions(sqlite) -> None:
     with sqlite.execute("SELECT ?", (1,)) as cur:
         assert cur.fetchone() == (1,)
         assert cur.fetchone() is None
@@ -571,7 +571,7 @@ def test_dbapi_extensions(sqlite):
 
 
 @pytest.mark.sqlite
-def test_close_connection_with_open_cursor():
+def test_close_connection_with_open_cursor() -> None:
     """
     Regression test for https://github.com/apache/arrow-adbc/issues/3713
 
@@ -596,7 +596,7 @@ def test_close_connection_with_open_cursor():
 
 
 @pytest.mark.sqlite
-def test_close_connection_with_multiple_open_cursors():
+def test_close_connection_with_multiple_open_cursors() -> None:
     """
     Test that closing a connection closes all open cursors.
 
@@ -621,7 +621,7 @@ def test_close_connection_with_multiple_open_cursors():
 
 
 @pytest.mark.sqlite
-def test_close_connection_cursor_already_closed():
+def test_close_connection_cursor_already_closed() -> None:
     """
     Test that closing a connection works even if some cursors are already closed.
 
@@ -646,7 +646,7 @@ def test_close_connection_cursor_already_closed():
 
 
 @pytest.mark.sqlite
-def test_close_connection_via_context_manager_with_open_cursors():
+def test_close_connection_via_context_manager_with_open_cursors() -> None:
     """
     Test that exiting a connection context manager closes open cursors.
 
@@ -671,7 +671,7 @@ def test_close_connection_via_context_manager_with_open_cursors():
 
 
 @pytest.mark.sqlite
-def test_close_connection_suppresses_cursor_close_error():
+def test_close_connection_suppresses_cursor_close_error() -> None:
     """
     Test that closing a connection suppresses exceptions from cursor.close().
 

--- a/python/adbc_driver_manager/tests/test_dbapi_polars_nopyarrow.py
+++ b/python/adbc_driver_manager/tests/test_dbapi_polars_nopyarrow.py
@@ -147,7 +147,7 @@ def test_query_executemany_parameters(sqlite: dbapi.Connection, parameters) -> N
         )
 
 
-def test_execute_parameters_name(sqlite):
+def test_execute_parameters_name(sqlite) -> None:
     with sqlite.cursor() as cursor:
         cursor.execute("SELECT @a + 1, @b", {"@b": 2, "@a": 1})
         df = cursor.fetch_polars()
@@ -201,7 +201,7 @@ def test_execute_parameters_name(sqlite):
         )
 
 
-def test_executemany_parameters_name(sqlite):
+def test_executemany_parameters_name(sqlite) -> None:
     with sqlite.cursor() as cursor:
         cursor.execute("CREATE TABLE executemany_params (a, b)")
 

--- a/python/adbc_driver_manager/tests/test_lowlevel.py
+++ b/python/adbc_driver_manager/tests/test_lowlevel.py
@@ -40,18 +40,18 @@ def _import(handle):
     raise NotImplementedError(f"Importing {handle!r}")
 
 
-def _bind(stmt, batch):
+def _bind(stmt, batch) -> None:
     array = adbc_driver_manager.ArrowArrayHandle()
     schema = adbc_driver_manager.ArrowSchemaHandle()
     batch._export_to_c(array.address, schema.address)
     stmt.bind(array, schema)
 
 
-def test_version():
+def test_version() -> None:
     assert adbc_driver_manager.__version__  # type:ignore
 
 
-def test_database_init():
+def test_database_init() -> None:
     with pytest.raises(
         adbc_driver_manager.ProgrammingError,
         match=".*Must set 'driver' option.*",
@@ -60,7 +60,7 @@ def test_database_init():
             pass
 
 
-def test_error_mapping():
+def test_error_mapping() -> None:
     import adbc_driver_manager._lib as _lib
     from adbc_driver_manager import AdbcStatusCode
 
@@ -99,7 +99,7 @@ def test_error_mapping():
 
 
 @pytest.mark.sqlite
-def test_database_set_options(sqlite_raw):
+def test_database_set_options(sqlite_raw) -> None:
     db, _ = sqlite_raw
     with pytest.raises(
         adbc_driver_manager.NotSupportedError,
@@ -115,7 +115,7 @@ def test_database_set_options(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_connection_get_info(sqlite_raw):
+def test_connection_get_info(sqlite_raw) -> None:
     _, conn = sqlite_raw
     codes = [
         adbc_driver_manager.AdbcInfoCode.VENDOR_NAME.value,
@@ -140,7 +140,7 @@ def test_connection_get_info(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_connection_get_objects(sqlite_raw):
+def test_connection_get_objects(sqlite_raw) -> None:
     _, conn = sqlite_raw
     data = pyarrow.record_batch(
         [
@@ -169,7 +169,7 @@ def test_connection_get_objects(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_connection_get_table_schema(sqlite_raw):
+def test_connection_get_table_schema(sqlite_raw) -> None:
     _, conn = sqlite_raw
     data = pyarrow.record_batch(
         [
@@ -188,7 +188,7 @@ def test_connection_get_table_schema(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_connection_get_table_types(sqlite_raw):
+def test_connection_get_table_types(sqlite_raw) -> None:
     _, conn = sqlite_raw
     handle = conn.get_table_types()
     table = _import(handle).read_all()
@@ -196,14 +196,14 @@ def test_connection_get_table_types(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_connection_read_partition(sqlite_raw):
+def test_connection_read_partition(sqlite_raw) -> None:
     _, conn = sqlite_raw
     with pytest.raises(adbc_driver_manager.NotSupportedError):
         conn.read_partition(b"")
 
 
 @pytest.mark.sqlite
-def test_connection_set_options(sqlite_raw):
+def test_connection_set_options(sqlite_raw) -> None:
     _, conn = sqlite_raw
     with pytest.raises(
         adbc_driver_manager.NotSupportedError,
@@ -219,7 +219,7 @@ def test_connection_set_options(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_statement_query(sqlite_raw):
+def test_statement_query(sqlite_raw) -> None:
     _, conn = sqlite_raw
     with adbc_driver_manager.AdbcStatement(conn) as stmt:
         stmt.set_sql_query("SELECT 1")
@@ -229,7 +229,7 @@ def test_statement_query(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_statement_prepared(sqlite_raw):
+def test_statement_prepared(sqlite_raw) -> None:
     _, conn = sqlite_raw
     with adbc_driver_manager.AdbcStatement(conn) as stmt:
         stmt.set_sql_query("SELECT ?")
@@ -242,7 +242,7 @@ def test_statement_prepared(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_statement_ingest(sqlite_raw):
+def test_statement_ingest(sqlite_raw) -> None:
     _, conn = sqlite_raw
     data = pyarrow.record_batch(
         [
@@ -263,7 +263,7 @@ def test_statement_ingest(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_statement_adbc_prepare(sqlite_raw):
+def test_statement_adbc_prepare(sqlite_raw) -> None:
     _, conn = sqlite_raw
     with adbc_driver_manager.AdbcStatement(conn) as stmt:
         stmt.set_sql_query("SELECT 1")
@@ -283,7 +283,7 @@ def test_statement_adbc_prepare(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_statement_autocommit(sqlite_raw):
+def test_statement_autocommit(sqlite_raw) -> None:
     _, conn = sqlite_raw
 
     # Autocommit enabled by default
@@ -357,7 +357,7 @@ def test_statement_autocommit(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_statement_set_options(sqlite_raw):
+def test_statement_set_options(sqlite_raw) -> None:
     _, conn = sqlite_raw
 
     with adbc_driver_manager.AdbcStatement(conn) as stmt:
@@ -375,7 +375,7 @@ def test_statement_set_options(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_child_tracking(sqlite_raw):
+def test_child_tracking(sqlite_raw) -> None:
     with adbc_driver_manager.AdbcDatabase(driver="adbc_driver_sqlite") as db:
         with adbc_driver_manager.AdbcConnection(db) as conn:
             with adbc_driver_manager.AdbcStatement(conn):
@@ -396,7 +396,7 @@ def test_child_tracking(sqlite_raw):
 
 
 @pytest.mark.sqlite
-def test_pycapsule(sqlite_raw):
+def test_pycapsule(sqlite_raw) -> None:
     _, conn = sqlite_raw
     handle = conn.get_table_types()
     with pyarrow.RecordBatchReader._import_from_c_capsule(
@@ -467,7 +467,7 @@ def test_pycapsule(sqlite_raw):
     del capsule
 
 
-def test_driver_path():
+def test_driver_path() -> None:
     with pytest.raises(
         adbc_driver_manager.ProgrammingError,
         match="(dlopen|LoadLibraryExW).*failed:",

--- a/python/adbc_driver_manager/tests/test_polars.py
+++ b/python/adbc_driver_manager/tests/test_polars.py
@@ -22,7 +22,7 @@ polars.testing = pytest.importorskip("polars.testing")
 
 
 @pytest.mark.sqlite
-def test_query_fetch_polars(sqlite):
+def test_query_fetch_polars(sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.execute("SELECT 1, 'foo' AS foo, 2.0")
         polars.testing.assert_frame_equal(

--- a/python/adbc_driver_manager/tests/test_reader.py
+++ b/python/adbc_driver_manager/tests/test_reader.py
@@ -34,12 +34,12 @@ def _make_reader():
     return AdbcRecordBatchReader._import_from_c(exported.address)
 
 
-def test_reader():
+def test_reader() -> None:
     wrapped = _make_reader()
     assert wrapped.read_next_batch() == batches[0]
 
 
-def test_reader_error():
+def test_reader_error() -> None:
     schema = pyarrow.schema([("ints", "int32")])
 
     def batches():
@@ -56,7 +56,7 @@ def test_reader_error():
         wrapped.read_next_batch()
 
 
-def test_reader_methods():
+def test_reader_methods() -> None:
     with _make_reader() as reader:
         assert reader.read_all() == pyarrow.Table.from_batches(batches, schema)
 


### PR DESCRIPTION
Add return type annotations to functions in the Python driver manager.