### PR TITLE
feat(python/adbc_driver_manager): allow ``connect(profile="foo")``

### DIFF
--- a/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
+++ b/python/adbc_driver_manager/adbc_driver_manager/dbapi.py
@@ -183,9 +183,10 @@ else:
 
 
 def connect(
-    driver: Union[str, pathlib.Path],
+    driver: Optional[Union[str, pathlib.Path]] = None,
     uri: Optional[str] = None,
     *,
+    profile: Optional[str] = None,
     entrypoint: Optional[str] = None,
     db_kwargs: Optional[Dict[str, Union[str, pathlib.Path]]] = None,
     conn_kwargs: Optional[Dict[str, str]] = None,
@@ -217,10 +218,17 @@ def connect(
           where the scheme happens to be the same as the driver name (so
           PostgreSQL works, but not SQLite, for example, as SQLite uses
           ``file:`` URIs).
+
+        - If the URI begins with ``profile://``, then a connection profile
+          will be loaded instead. See :doc:`/format/connection_profiles`.
     uri
         The "uri" parameter to the database (if applicable).  This is
         equivalent to passing it in ``db_kwargs`` but is slightly cleaner.
         If given, takes precedence over any value in ``db_kwargs``.
+    profile
+        A connection profile to load. Loading ``profile="profile-name"`` is
+        the same as loading the URI ``profile://profile-name``. See
+        :doc:`/format/connection_profiles`.
     entrypoint
         The driver-specific entrypoint, if different than the default.
     db_kwargs
@@ -238,15 +246,21 @@ def connect(
     conn = None
 
     db_kwargs = dict(db_kwargs or {})
-    db_kwargs["driver"] = driver
+    if driver:
+        db_kwargs["driver"] = driver
     if uri:
         db_kwargs["uri"] = uri
     if entrypoint:
         db_kwargs["entrypoint"] = entrypoint
+    if profile:
+        db_kwargs["profile"] = profile
     if conn_kwargs is None:
         conn_kwargs = {}
     # N.B. treating uri = "postgresql://..." as driver = "postgresql", uri =
     # "..." is handled at the C driver manager layer
+
+    if all(k not in db_kwargs for k in ("driver", "uri", "profile")):
+        raise TypeError("Must specify at least one of 'driver', 'uri', or 'profile'")
 
     try:
         db = _lib.AdbcDatabase(**db_kwargs)

--- a/python/adbc_driver_manager/pyproject.toml
+++ b/python/adbc_driver_manager/pyproject.toml
@@ -42,6 +42,7 @@ build-backend = "setuptools.build_meta"
 enable = ["cpython-freethreading"]
 
 [tool.pytest.ini_options]
+filterwarnings = ["error"]
 markers = [
     "duckdb: tests that require DuckDB",
     "panicdummy: tests that require the testing-only panicdummy driver",

--- a/python/adbc_driver_manager/tests/test_dbapi.py
+++ b/python/adbc_driver_manager/tests/test_dbapi.py
@@ -735,7 +735,7 @@ def test_connect(tmp_path: pathlib.Path, monkeypatch) -> None:
             cur.execute("SELECT * FROM foo")
             assert cur.fetchone() == (1,)
 
-    monkeypatch.setenv("ADBC_DRIVER_PATH", tmp_path)
+    monkeypatch.setenv("ADBC_DRIVER_PATH", str(tmp_path))
     with (tmp_path / "foobar.toml").open("w") as f:
         f.write(
             """
@@ -746,4 +746,14 @@ shared = "adbc_driver_foobar"
     # Just check that the driver gets detected and loaded (should fail)
     with pytest.raises(dbapi.ProgrammingError, match="NOT_FOUND"):
         with dbapi.connect("foobar://localhost:5439"):
+            pass
+
+    # https://github.com/apache/arrow-adbc/issues/4077: allow profile argument
+    # Just check that the profile gets detected and loaded (should fail)
+    with pytest.raises(dbapi.ProgrammingError, match="NOT_FOUND.*Profile not found"):
+        with dbapi.connect(profile="nonexistent"):
+            pass
+
+    with pytest.raises(TypeError):
+        with dbapi.connect():
             pass


### PR DESCRIPTION
Closes #4077.