### PR TITLE
ci: fix gemfury push for Node.js packages

### DIFF
--- a/ci/scripts/node_npm_upload.sh
+++ b/ci/scripts/node_npm_upload.sh
@@ -32,6 +32,7 @@ main() {
     local packages_dir
     packages_dir="$(realpath "$1")"
     local registry="${NPM_REGISTRY:-https://registry.npmjs.org}"
+    local registry_key="${registry%/}"  # strip trailing slash for .npmrc key construction
     local dry_run_flag=""
     if [[ "${DRY_RUN:-0}" == "1" ]]; then
         dry_run_flag="--dry-run"
@@ -41,22 +42,26 @@ main() {
         tag_flag="--tag ${NPM_TAG}"
     fi
 
+    if [[ -z "${NPM_TOKEN:-}" ]]; then
+        echo "Error: NPM_TOKEN is required" >&2
+        exit 1
+    fi
+
     # Write a temp .npmrc with the auth token for the target registry
     local npmrc
     npmrc=$(mktemp)
     trap "rm -f ${npmrc}" EXIT
-    echo "//${registry#*://}/:_authToken=${NPM_TOKEN:-}" > "${npmrc}"
-    export NPM_CONFIG_USERCONFIG="${npmrc}"
+    echo "//${registry_key#*://}/:_authToken=${NPM_TOKEN}" > "${npmrc}"
 
     # Publish platform-specific packages first, then the main package
     for pkg in "${packages_dir}"/apache-arrow-adbc-driver-manager-*-*.tgz; do
         echo "==== Publishing ${pkg}"
-        npm publish "${pkg}" --access public --registry "${registry}" ${tag_flag} ${dry_run_flag}
+        npm publish "${pkg}" --access public --registry "${registry}" --userconfig "${npmrc}" ${tag_flag} ${dry_run_flag}
     done
 
     echo "==== Publishing main package"
     npm publish "${packages_dir}"/apache-arrow-adbc-driver-manager-[0-9]*.tgz \
-        --access public --registry "${registry}" ${tag_flag} ${dry_run_flag}
+        --access public --registry "${registry}" --userconfig "${npmrc}" ${tag_flag} ${dry_run_flag}
 }
 
 main "$@"

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -29,7 +29,7 @@ support browser or Deno environments. Bun is not officially tested.
 ## Installation
 
 ```bash
-npm install adbc-driver-manager apache-arrow
+npm install @apache-arrow/adbc-driver-manager apache-arrow
 ```
 
 ## Usage
@@ -39,7 +39,7 @@ name. When using a short name, the driver manager searches system and user
 paths for a matching ADBC driver manifest or library.
 
 ```typescript
-import { AdbcDatabase } from 'adbc-driver-manager'
+import { AdbcDatabase } from '@apache-arrow/adbc-driver-manager'
 
 // Short name (resolves from system/user paths)
 const db = new AdbcDatabase({ driver: 'sqlite' })


### PR DESCRIPTION
Fixed `ENEEDAUTH` when publishing npm packages to Gemfury.

The root cause is the script not accounting for NPM_REGISTRY URL having a trailing slash, causing a double-slash in the generated `.npmrc` key (`npm.fury.io/arrow-adbc-nightlies//:_authToken`)

**Test Plan**

Tested full gemfury package upload on my fork
- Pointed URL's to my own gemfury
- https://github.com/kentkwu/arrow-adbc/actions/runs/23171042963/job/67325129419

Closes #4093.
