### PR TITLE
ci: build windows artifacts in release mode in packaging workflow

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -283,7 +283,7 @@ jobs:
           ADBC_USE_UBSAN: OFF
           BUILD_ALL: 0
           BUILD_DRIVER_MANAGER: 1
-          CMAKE_BUILD_TYPE: release
+          CMAKE_BUILD_TYPE: Release
         run: |
           ./ci/scripts/cpp_build.sh $(pwd) $(pwd)/build_driver_manager
           ./ci/scripts/java_build.sh $(pwd)

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -74,7 +74,7 @@ build_subproject() {
           -DADBC_DRIVER_MANAGER_TEST_MANIFEST_SYSTEM_LEVEL="${BUILD_DRIVER_MANAGER_SYSTEM_CONFIG_TEST}" \
           -DADBC_DRIVER_MANAGER_TEST_MANIFEST_USER_LEVEL="${BUILD_DRIVER_MANAGER_USER_CONFIG_TEST}"
     set +x
-    cmake --build . --target install -j
+    cmake --build . --config ${CMAKE_BUILD_TYPE} --target install -j
 
     popd
 }

--- a/ci/scripts/java_jni_build.sh
+++ b/ci/scripts/java_jni_build.sh
@@ -37,7 +37,7 @@ main() {
         -DCMAKE_PREFIX_PATH="${install_dir}/lib/cmake/"
     set +x
 
-    cmake --build . --target install -j
+    cmake --build . --config ${CMAKE_BUILD_TYPE} --target install -j
 
     popd
 }


### PR DESCRIPTION
Fixes an issue with the packaging.yaml workflow which was causing at least the windows JNI driver to get built in debug mode instead of release mode. My understanding of the issue is that when you use MSVC as a generator for CMake, it ignores CMAKE_BUILD_TYPE (defaults to Debug) so we need to pass it down correctly and set `--config` explicitly.