### PR TITLE
fix: ensure package-lock.json is up to date

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Install dependencies
         working-directory: javascript
         run: npm ci
+      - name: Verify package-lock.json is up to date
+        working-directory: javascript
+        run: |
+          npm install --package-lock-only
+          git diff --exit-code package-lock.json
       - name: Check JS
         working-directory: javascript
         run: npm run check:js

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "adbc-driver-manager",
+  "name": "@apache-arrow/adbc-driver-manager",
   "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "adbc-driver-manager",
+      "name": "@apache-arrow/adbc-driver-manager",
       "version": "0.23.0",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -22,11 +22,11 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "adbc-driver-manager-darwin-arm64": "0.0.1",
-        "adbc-driver-manager-darwin-x64": "0.0.1",
-        "adbc-driver-manager-linux-arm64-gnu": "0.0.1",
-        "adbc-driver-manager-linux-x64-gnu": "0.0.1",
-        "adbc-driver-manager-win32-x64-msvc": "0.0.1"
+        "@apache-arrow/adbc-driver-manager-darwin-arm64": "0.23.0",
+        "@apache-arrow/adbc-driver-manager-darwin-x64": "0.23.0",
+        "@apache-arrow/adbc-driver-manager-linux-arm64-gnu": "0.23.0",
+        "@apache-arrow/adbc-driver-manager-linux-x64-gnu": "0.23.0",
+        "@apache-arrow/adbc-driver-manager-win32-x64-msvc": "0.23.0"
       },
       "peerDependencies": {
         "apache-arrow": "^21.1.0"


### PR DESCRIPTION
Updates `package-lock.json` and adds a step in CI to ensure that `package-lock.json` is up to date.