### PR TITLE
ci(javascript): fix flaky msvc test

### DIFF
--- a/ci/scripts/node_build.sh
+++ b/ci/scripts/node_build.sh
@@ -37,9 +37,10 @@ cmake -S "${REPO_ROOT}/c" -B "${OUT_DIR}" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DADBC_DRIVER_SQLITE=ON \
   -DADBC_BUILD_TESTS=OFF \
-  -DADBC_BUILD_SHARED=ON
+  -DADBC_BUILD_SHARED=ON \
+  -DADBC_BUILD_STATIC=OFF
 
-cmake --build "${OUT_DIR}" --target install -j
+cmake --build "${OUT_DIR}" --config RelWithDebInfo --target install -j
 
 # 2. Build Node.js Package
 echo "=== Building Node.js Package ==="


### PR DESCRIPTION
This PR fixes the flaky msvc JavaScript tests.

Disables static SQLite build as it's not necessary for the test suite, and sets `--config RelWithDebInfo` to ensure we build with the correct config on windows.

**Test Plan**

Ran on my fork a few times and saw no more failures

https://github.com/kentkwu/arrow-adbc/actions/workflows/javascript.yml?query=event%3Aworkflow_dispatch+branch%3Agh-4124

closes #4124 