### PR TITLE
chore(ruby): update gemspec to use homebrew apache-arrow-adbc-glib

### DIFF
--- a/ruby/red-adbc.gemspec
+++ b/ruby/red-adbc.gemspec
@@ -63,6 +63,7 @@ Gem::Specification.new do |spec|
   [
     ["debian", "libadbc-glib-dev"],
     ["rhel", "adbc-glib-devel"],
+    ["homebrew", "apache-arrow-adbc-glib"],
   ].each do |platform, package|
     spec.requirements <<
       "system: adbc-glib>=#{required_adbc_glib_version}: " +


### PR DESCRIPTION
I think now that the ADBC glib bindings will be on homebrew we can update the gemspec like this. I tested that,

1. Without the `apache-arrow-adbc-glib` formula installed and no other setup, `require 'adbc'` fails with `Typelib file for namespace 'ADBC' (any version) not found`
2. _With_ a local install of the new `apache-arrow-adbc-glib` formula, `require 'adbc'` now works