### PR TITLE
fix(r/adbcdrivermanager): replace non-API `Rf_findVarInFrame` call for R 4.5.0 or later

### DIFF
--- a/r/adbcdrivermanager/src/radbc.cc
+++ b/r/adbcdrivermanager/src/radbc.cc
@@ -56,7 +56,8 @@ static int adbc_update_parent_child_count(SEXP xptr, int delta) {
 
   SEXP child_count_sym = PROTECT(Rf_install(".child_count"));
 #if defined(R_VERSION) && R_VERSION >= R_Version(4, 5, 0)
-  SEXP child_count_sexp = PROTECT(R_getVarEx(child_count_sym, parent_env, FALSE, R_UnboundValue));
+  SEXP child_count_sexp =
+      PROTECT(R_getVarEx(child_count_sym, parent_env, FALSE, R_UnboundValue));
   if (child_count_sexp == R_UnboundValue) {
     Rf_error("Internal error: .child_count not found");
   }


### PR DESCRIPTION
Fix #4122