### PR TITLE
chore: document post release task for brew

### DIFF
--- a/docs/source/development/releasing.rst
+++ b/docs/source/development/releasing.rst
@@ -440,6 +440,17 @@ Be sure to go through on the following checklist:
 
    A conda-forge or feedstock maintainer can review and merge.
 
+.. dropdown:: Update Homebrew formulae
+   :class-title: sd-fs-5
+   :class-container: sd-shadow-md
+
+   File separate PRs to update each formula for the new release:
+
+   - apache-arrow-adbc
+   - apache-arrow-adbc-glib
+
+   See https://docs.brew.sh/Formula-Cookbook#updating-formulae.
+
 .. dropdown:: Remove old artifacts
    :class-title: sd-fs-5
    :class-container: sd-shadow-md


### PR DESCRIPTION
Adds a post-release task for updating the ADBC Homebrew formulae.

Ref: https://github.com/apache/arrow-adbc/issues/338#issuecomment-4101454028
