### PR TITLE
ci: delete existing npm versions before nightly Gemfury upload

### DIFF
--- a/ci/scripts/gemfury_clean.py
+++ b/ci/scripts/gemfury_clean.py
@@ -50,12 +50,17 @@ def main():
             print(versions)
             versions.sort(key=lambda v: v["created_at"], reverse=True)
 
-            # Always keep at least 1 version
-            to_delete = [
-                version["id"]
-                for version in versions[1:]
-                if version["created_at"] < cutoff.isoformat()
-            ]
+            # npm registries don't allow re-uploading an existing version, so all
+            # existing versions must be removed to allow the nightly re-upload
+            if package.get("kind") == "npm":
+                to_delete = [version["id"] for version in versions]
+            else:
+                # Always keep at least 1 version
+                to_delete = [
+                    version["id"]
+                    for version in versions[1:]
+                    if version["created_at"] < cutoff.isoformat()
+                ]
             print("Removing", len(to_delete), "version(s) of", len(versions))
 
             for version_id in to_delete:


### PR DESCRIPTION
This PR attempts to fix an issue where gemfury rejects the nightly npm upload because an entry with the same version already exists.