### PR TITLE
build: increase manylinux requirement to 2_28 from 2014

### DIFF
--- a/.env
+++ b/.env
@@ -29,7 +29,7 @@ ARCH_CONDA_FORGE=linux_64_
 
 # Default versions for various dependencies
 JDK=21
-MANYLINUX=2014
+MANYLINUX=2_28
 MAVEN=3.9.10
 PLATFORM=linux/amd64
 PYTHON=3.13
@@ -41,7 +41,7 @@ DOTNET=8.0
 # ci/scripts/install_vcpkg.sh script. Keep in sync with apache/arrow .env.
 # When updating, also update the docs, which list the version of libpq/SQLite
 # that vcpkg (and hence our wheels) ship
-VCPKG="4334d8b4c8916018600212ab4dd4bbdc343065d1"    # 2025.09.17 Release
+VCPKG="66c0373dc7fca549e5803087b9487edfe3aca0a1"    # 2026.01.16 Release
 
 # These are used to tell tests where to find services for integration testing.
 # They are valid if the services are started with the compose config.

--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -16,11 +16,11 @@
 # under the License.
 
 ARG MANYLINUX
-FROM quay.io/pypa/manylinux${MANYLINUX}:latest
+FROM quay.io/pypa/manylinux_${MANYLINUX}:latest
 
-ARG CMAKE=4.1.2
+ARG CMAKE=4.3.0
 ARG GO
-ARG NINJA=1.13.1
+ARG NINJA=1.13.2
 ARG PYTHON
 ARG VCPKG
 ARG TARGETPLATFORM
@@ -35,7 +35,7 @@ RUN ulimit -n 1024 && yum install -y autoconf curl git flex perl-IPC-Cmd unzip w
 # (podman is just too different)
 RUN ulimit -n 1024 && yum remove -y docker
 RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-RUN ulimit -n 1024 && yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+RUN ulimit -n 1024 && yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin perl-Time-Piece
 
 # -------------------- Python --------------------
 RUN PYTHON_ROOT=$(find /opt/python -name cp${PYTHON/./}-cp${PYTHON/./}) && \

--- a/ci/scripts/python_sdist_test.sh
+++ b/ci/scripts/python_sdist_test.sh
@@ -47,11 +47,7 @@ echo "=== Installing sdists ==="
 for component in ${COMPONENTS}; do
     pip install --no-deps --force-reinstall ${source_dir}/python/${component}/dist/*.tar.gz
 done
-# N.B. for now, we still support manylinux2014 while PyArrow dropped support.
-# Explicitly install the last version of PyArrow supporting manylinux2014.
-# - https://github.com/apache/arrow-adbc/issues/3182
-# - https://github.com/apache/arrow/issues/46959
-pip install importlib-resources pytest pyarrow==20.0.0 pandas polars protobuf
+pip install importlib-resources pytest pyarrow pandas polars protobuf
 
 echo "=== (${PYTHON_VERSION}) Testing sdists ==="
 test_packages

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -135,10 +135,8 @@ function setup_build_vars {
     fi
     # No PyPy, no Python 3.8, no Python 3.9
     export CIBW_SKIP="pp* cp38-* cp39-* ${CIBW_SKIP}"
-    # Make sure our manylinux version doesn't creep up (this only matters for
-    # the driver manager)
-    export CIBW_MANYLINUX_X86_64_IMAGE="manylinux2014"
-    export CIBW_MANYLINUX_AARCH64_IMAGE="manylinux2014"
+    export CIBW_MANYLINUX_X86_64_IMAGE="manylinux_2_28"
+    export CIBW_MANYLINUX_AARCH64_IMAGE="manylinux_2_28"
 }
 
 function test_packages {

--- a/ci/scripts/python_wheel_unix_build.sh
+++ b/ci/scripts/python_wheel_unix_build.sh
@@ -49,20 +49,21 @@ function check_visibility {
 
     # Also check the max glibc/glibcxx version, to avoid accidentally bumping
     # our manylinux requirement
-    # See https://peps.python.org/pep-0599/#the-manylinux2014-policy
-    local -r glibc_max=2.17
-    local -r glibcxx_max=3.4.19
+    # https://github.com/pypa/manylinux?tab=readme-ov-file#manylinux_2_28-almalinux-8-based
+    # https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
+    local -r glibc_max=2.28
+    local -r glibcxx_max=3.4.33
     local -r glibc_requirement=$(grep -Eo 'GLIBC_\S+' nm_arrow.log | awk -F_ '{print $2}' | sort --version-sort -u | tail -n1)
     local -r glibc_maxver=$(echo -e "${glibc_requirement}\n${glibc_max}" | sort --version-sort | tail -n1)
     local -r glibcxx_requirement=$(grep -Eo 'GLIBCXX_\S+' nm_arrow.log | awk -F_ '{print $2}' | sort --version-sort -u | tail -n1)
     local -r glibcxx_maxver=$(echo -e "${glibcxx_requirement}\n${glibcxx_max}" | sort --version-sort | tail -n1)
-    if [[ "${glibc_maxver}" != "2.17" ]]; then
+    if [[ "${glibc_maxver}" != "${glibc_max}" ]]; then
         echo "== glibc check failed for $1 =="
-        echo "Expected GLIBC_${glibc_max} but found GLIBC_${glibc_requirement}"
+        echo "Expected GLIBC_${glibc_maxver} but found GLIBC_${glibc_requirement}"
         exit 1
-    elif [[ "${glibcxx_maxver}" != "3.4.19" ]]; then
+    elif [[ "${glibcxx_maxver}" != "${glibcxx_max}" ]]; then
         echo "== glibc check failed for $1 =="
-        echo "Expected GLIBCXX_${glibcxx_max} but found GLIBCXX_${glibcxx_requirement}"
+        echo "Expected GLIBCXX_${glibcxx_maxver} but found GLIBCXX_${glibcxx_requirement}"
         exit 1
     fi
 }

--- a/ci/scripts/python_wheel_unix_relocate.sh
+++ b/ci/scripts/python_wheel_unix_relocate.sh
@@ -29,7 +29,7 @@ source "${script_dir}/python_util.sh"
 function check_wheels {
     if [[ $(uname) == "Linux" ]]; then
         echo "=== Tag $component wheel with manylinux${MANYLINUX_VERSION} ==="
-        auditwheel repair "$@" -L . -w repaired_wheels --plat manylinux_2_17_${CIBW_ARCHS}
+        auditwheel repair "$@" -L . -w repaired_wheels --plat manylinux_2_28_${CIBW_ARCHS}
     else # macOS
         echo "=== Tag $component wheel with macOS ==="
         delocate-wheel -v -k -w repaired_wheels "$@"
@@ -82,9 +82,8 @@ for component in $COMPONENTS; do
 
         for wheel in repaired_wheels/*.whl; do
             if [[ "$(uname)" = "Linux" ]]; then
-                # We only check 2_17, though in principle everything should work on 2014
-                if ! [[ $(basename "${wheel}") == *manylinux_2_17* ]]; then
-                    echo "Wheel does not support manylinux_2_17: ${wheel}"
+                if ! [[ $(basename "${wheel}") == *manylinux_2_28* ]]; then
+                    echo "Wheel does not support manylinux_2_28: ${wheel}"
                     exit 1
                 fi
             fi

--- a/docs/source/driver/sqlite.rst
+++ b/docs/source/driver/sqlite.rst
@@ -242,6 +242,6 @@ Driver-specific options:
 Software Versions
 =================
 
-For Python wheels, the shipped version of SQLite is 3.50.4.  For conda-forge
+For Python wheels, the shipped version of SQLite is 3.51.2.  For conda-forge
 packages, the version of sqlite is the same as the version of sqlite in your
 Conda environment.


### PR DESCRIPTION
Also updates vcpkg and fixes the check for glibc compatibility.

Motivation: I was trying to solve #4143, but icu failed to build; I tried to raise the vcpkg version but found that required a newer version of other dependencies, and decided it was easiest to just raise the manylinux version first. (That said it seems icu still doesn't build, but that's a separate issue; it's still good to raise the vcpkg version.)

Closes #4145.