### PR TITLE
build(python/adbc_driver_sqlite): enable optional features

### DIFF
--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -30,12 +30,12 @@ ENTRYPOINT ["/bin/bash", "-i", "-c"]
 
 # -------------------- System Dependencies --------------------
 # Some of these dependencies are needed to build things like OpenSSL in vcpkg
-RUN ulimit -n 1024 && yum install -y autoconf curl git flex perl-IPC-Cmd unzip wget yum-utils zip
+RUN ulimit -n 1024 && yum install -y autoconf autoconf-archive curl git flex perl-IPC-Cmd perl-Time-Piece unzip wget yum-utils zip
 # docker is aliased to podman by AlmaLinux, but we want real Docker
 # (podman is just too different)
 RUN ulimit -n 1024 && yum remove -y docker
 RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-RUN ulimit -n 1024 && yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin perl-Time-Piece
+RUN ulimit -n 1024 && yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # -------------------- Python --------------------
 RUN PYTHON_ROOT=$(find /opt/python -name cp${PYTHON/./}-cp${PYTHON/./}) && \

--- a/ci/scripts/python_util.sh
+++ b/ci/scripts/python_util.sh
@@ -71,7 +71,7 @@ function build_drivers {
     echo "=== Setup VCPKG ==="
 
     # Need to install sqlite3 to make CMake be able to find it below
-    "${VCPKG_ROOT}/vcpkg" install libpq sqlite3 \
+    "${VCPKG_ROOT}/vcpkg" install libpq 'sqlite3[dbstat,fts3,fts4,fts5,geopoly,json1,limit,math,rtree,session,snapshot,soundex]' \
           --overlay-triplets "${VCPKG_OVERLAY_TRIPLETS}" \
           --triplet "${VCPKG_DEFAULT_TRIPLET}"
 

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -31,7 +31,7 @@ set VCPKG_TARGET_TRIPLET=x64-windows-static
 
 IF NOT DEFINED VCPKG_ROOT (echo "Must set VCPKG_ROOT" && exit /B 1)
 
-%VCPKG_ROOT%\vcpkg install --triplet=%VCPKG_TARGET_TRIPLET% libpq sqlite3
+%VCPKG_ROOT%\vcpkg install --triplet=%VCPKG_TARGET_TRIPLET% libpq "sqlite3[dbstat,fts3,fts4,fts5,geopoly,json1,limit,math,rtree,session,snapshot,soundex]"
 IF %errorlevel% NEQ 0 EXIT /B %errorlevel%
 
 mkdir %build_dir%

--- a/python/adbc_driver_sqlite/tests/test_dbapi.py
+++ b/python/adbc_driver_sqlite/tests/test_dbapi.py
@@ -125,3 +125,21 @@ def test_extension() -> None:
 
         with pytest.raises(conn.OperationalError):
             conn.load_extension("nonexistent", entrypoint="entrypoint")
+
+
+@pytest.mark.parametrize(
+    "feature",
+    [
+        "ENABLE_FTS3",
+        "ENABLE_FTS4",
+        "ENABLE_FTS5",
+        "ENABLE_GEOPOLY",
+        "ENABLE_MATH_FUNCTIONS",
+        "ENABLE_RTREE",
+    ],
+)
+def test_enabled_features(feature: str) -> None:
+    # Regression test for https://github.com/apache/arrow-adbc/issues/4143
+    with dbapi.connect() as conn:
+        options = {row[0] for row in conn.execute("PRAGMA compile_options").fetchall()}
+    assert feature in options


### PR DESCRIPTION
I couldn't enable 'unicode' as ICU won't build in the Docker container and ran out of time to fully investigate.

Closes #4143.