### PR TITLE
chore: remove unnecessary setup-msbuild step

### DIFF
--- a/.github/workflows/native-windows.yml
+++ b/.github/workflows/native-windows.yml
@@ -374,8 +374,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
       - name: Setup MSYS2 tools
         run: |
           # msys64 is pre-installed on windows but not added to path


### PR DESCRIPTION
This isn't in the ASF allowlist and it turns out we don't even use it.