### PR TITLE
feat(javascript): emit ESM instead of CJS

### DIFF
--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -21,5 +21,6 @@ dist
 *.tgz
 *.tsbuildinfo
 binding.js
+binding.mjs
 index.js
 index.d.ts

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -9,6 +9,7 @@
     "url": "git+https://github.com/apache/arrow-adbc.git",
     "directory": "javascript"
   },
+  "type": "module",
   "license": "Apache-2.0",
   "keywords": [
     "adbc",
@@ -36,9 +37,9 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "build": "napi build --platform --release && mv index.js binding.js && mv index.d.ts binding.d.ts && tsc",
-    "build:ci": "napi build --platform --release --js binding.js --dts binding.d.ts",
-    "build:debug": "napi build --platform && mv index.js binding.js && mv index.d.ts binding.d.ts && tsc",
+    "build": "napi build --platform --release --esm && mv index.js binding.js && mv index.d.ts binding.d.ts && tsc",
+    "build:ci": "napi build --platform --release --esm --js binding.js --dts binding.d.ts",
+    "build:debug": "napi build --platform --esm && mv index.js binding.js && mv index.d.ts binding.d.ts && tsc",
     "build:ts": "tsc",
     "build:driver": "../ci/scripts/node_build.sh $(pwd)/build",
     "fix": "prettier . -w && oxlint . --fix",
@@ -46,7 +47,7 @@
     "check:js": "prettier --check . && oxlint . && tsc --noEmit",
     "check:rust": "cargo fmt -- --check && cargo clippy -- -D warnings",
     "test": "tsx --test __test__/*.spec.ts",
-    "preversion": "napi build --platform && git add .",
+    "preversion": "napi build --platform --esm && git add .",
     "version": "napi version",
     "prepare": "husky"
   },

--- a/javascript/tsconfig.json
+++ b/javascript/tsconfig.json
@@ -1,13 +1,11 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "strict": true,
-    "moduleResolution": "node",
-    "module": "CommonJS",
+    "moduleResolution": "nodenext",
+    "module": "nodenext",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "rootDir": "lib",
     "outDir": "./dist",
     "declaration": true,


### PR DESCRIPTION
**Summary**
  - Switch package output from CommonJS to ESM
  - Add `"type": "module"` to package.json
  - Generate napi-rs binding with `--esm` flag
  - Update tsconfig to `module: "nodenext"`, `target: "ES2022"`

Because we require Node.js >= 22, we can emit ESM instead of CJS. `apache-arrow` ships dual CJS/ESM. Emitting ESM exclusively removes a class of compatibility issues where users `import` one and `require` the other.