### PR TITLE
fix(python/adbc_driver_manager): allow overriding search paths

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ on:
       - "rust/**"
       - ".github/workflows/rust.yml"
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - "c/**"
       - "rust/**"

--- a/ci/scripts/python_venv_test.sh
+++ b/ci/scripts/python_venv_test.sh
@@ -86,6 +86,44 @@ EOF
     "${scratch}"/.venv/bin/python "${scratch}/test3.py"
     test -f /tmp/test.db
     echo "PASSED: find profile"
+
+    # If we specify the additional path explicitly, then that overrides the
+    # virtualenv path
+    cat >"${scratch}/test4.py" <<EOF
+import adbc_driver_manager.dbapi
+
+db_kwargs = {
+    "additional_profile_search_path_list": "/",
+}
+with adbc_driver_manager.dbapi.connect(profile="sqlite/dev", db_kwargs=db_kwargs) as con:
+    with con.cursor() as cur:
+        cur.execute("SELECT 1")
+        assert cur.fetchall() == [(1,)]
+EOF
+
+    if "${scratch}"/.venv/bin/python "${scratch}/test4.py"; then
+        echo "FAILED: override profile path"
+        exit 1
+    fi
+    echo "PASSED: override profile path"
+
+    cat >"${scratch}/test5.py" <<EOF
+import adbc_driver_manager.dbapi
+
+db_kwargs = {
+    "additional_manifest_search_path_list": "/",
+}
+with adbc_driver_manager.dbapi.connect(driver="sqlite", db_kwargs=db_kwargs) as con:
+    with con.cursor() as cur:
+        cur.execute("SELECT 1")
+        assert cur.fetchall() == [(1,)]
+EOF
+
+    if "${scratch}"/.venv/bin/python "${scratch}/test5.py"; then
+        echo "FAILED: override manifest path"
+        exit 1
+    fi
+    echo "PASSED: override manifest path"
 }
 
 main "$@"

--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -625,20 +625,26 @@ cdef class AdbcDatabase(_AdbcHandle):
         # check if we're running in a venv
         if sys.prefix != sys.base_prefix:
             # if we're in a venv, add the venv prefix to the search path list
-            status = AdbcDriverManagerDatabaseSetAdditionalSearchPathList(
-                &self.database, _to_bytes(os.path.join(sys.prefix, "etc/adbc/drivers"),
-                                          "sys.prefix"),
-                &c_error)
-            check_error(status, &c_error)
 
-            profile_path = _to_bytes(
-                os.path.join(sys.prefix, "etc/adbc/profiles"),
-                "sys.prefix")
-            c_value = profile_path
-            status = AdbcDatabaseSetOption(
-                &self.database, "additional_profile_search_path_list", c_value,
-                &c_error)
-            check_error(status, &c_error)
+            key = "additional_manifest_search_path_list"
+            if key not in kwargs:
+                manifest_path = _to_bytes(
+                    os.path.join(sys.prefix, "etc/adbc/drivers"),
+                    "sys.prefix")
+                c_key = b"additional_manifest_search_path_list"
+                c_value = manifest_path
+                status = AdbcDatabaseSetOption(&self.database, c_key, c_value, &c_error)
+                check_error(status, &c_error)
+
+            key = "additional_profile_search_path_list"
+            if key not in kwargs:
+                profile_path = _to_bytes(
+                    os.path.join(sys.prefix, "etc/adbc/profiles"),
+                    "sys.prefix")
+                c_key = b"additional_profile_search_path_list"
+                c_value = profile_path
+                status = AdbcDatabaseSetOption(&self.database, c_key, c_value, &c_error)
+                check_error(status, &c_error)
 
         with nogil:
             status = AdbcDatabaseInit(&self.database, &c_error)

--- a/python/adbc_driver_sqlite/tests/test_dbapi.py
+++ b/python/adbc_driver_sqlite/tests/test_dbapi.py
@@ -133,7 +133,8 @@ def test_extension() -> None:
         "ENABLE_FTS3",
         "ENABLE_FTS4",
         "ENABLE_FTS5",
-        "ENABLE_GEOPOLY",
+        # We enable this in wheel builds but not all CI has it
+        # "ENABLE_GEOPOLY",
         "ENABLE_MATH_FUNCTIONS",
         "ENABLE_RTREE",
     ],


### PR DESCRIPTION
Fixes some CI failures when testing under a virtualenv.