### PR TITLE
fix(csharp/src/Telemetry/Traces/Listeners/FileListener): ensure to flush to file on each line

### DIFF
--- a/csharp/src/Telemetry/Traces/Listeners/FileListener/TracingFile.cs
+++ b/csharp/src/Telemetry/Traces/Listeners/FileListener/TracingFile.cs
@@ -127,7 +127,7 @@ namespace Apache.Arrow.Adbc.Telemetry.Traces.Listeners.FileListener
             }
             await stream.CopyToAsync(_currentFileStream).ConfigureAwait(false);
             // Flush for robustness to crashing
-            await stream.FlushAsync().ConfigureAwait(false);
+            await _currentFileStream.FlushAsync().ConfigureAwait(false);
         }
 
         private async Task OpenNewTracingFileAsync()


### PR DESCRIPTION
Corrects a bug where the file was not flush, as intended, for each line.