### PR TITLE
docs: set up Matomo for website analytics

### DIFF
--- a/docs/source/_templates/base.html
+++ b/docs/source/_templates/base.html
@@ -70,6 +70,24 @@
     font-weight: bold;
   }
 </style>
+
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  /* We explicitly disable cookie tracking to avoid privacy issues */
+  _paq.push(['disableCookies']);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://analytics.apache.org/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '20']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
 {% endblock %}
 
 {# Inject skeleton of version switcher #}


### PR DESCRIPTION
This PR sets up Matomo analytics for the ADBC docs sub-website (/adbc) using the same approach and site ID as Arrow used to set up theirs: https://github.com/apache/arrow/issues/31788.

I tested this PR locally by building the docs site and confirming my change injects the `script` tag in the `head` tag of pages.