### PR TITLE
fix(dev/release): add `CONDA_BUILD=1` when verifying with USE_CONDA=1

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -530,6 +530,7 @@ test_cpp() {
     export CMAKE_PREFIX_PATH="${CONDA_BACKUP_CMAKE_PREFIX_PATH}:${CMAKE_PREFIX_PATH}"
     # The CMake setup forces RPATH to be the Conda prefix
     export CPP_INSTALL_PREFIX="${CONDA_PREFIX}"
+    export CONDA_BUILD=1
   else
     export CPP_INSTALL_PREFIX="${ARROW_TMPDIR}/local"
   fi


### PR DESCRIPTION
Ran into an issue when verifying with some driver-manager tests failing, turned out to be the mismatch between using a conda environment but CONDA_BUILD wasn't set. So the test for a specific error message didn't get the message it was expecting. Adding the right `export CONDA_BUILD=1` was sufficient to fix the verification.

Nice, simple one-line fix.