### PR TITLE
fix(csharp/src/Drivers): Make AdbcCommandTimeoutProperty to optional

### DIFF
--- a/csharp/src/Client/AdbcCommand.cs
+++ b/csharp/src/Client/AdbcCommand.cs
@@ -129,16 +129,12 @@ namespace Apache.Arrow.Adbc.Client
 
         /// <summary>
         /// Gets or sets the name of the command timeout property for the underlying ADBC driver.
+        /// When set, <see cref="CommandTimeout"/> will propagate the value to the driver via this property.
+        /// When not set, <see cref="CommandTimeout"/> only stores the value locally.
         /// </summary>
-        public string AdbcCommandTimeoutProperty
+        public string? AdbcCommandTimeoutProperty
         {
-            get
-            {
-                if (string.IsNullOrEmpty(_commandTimeoutProperty))
-                    throw new InvalidOperationException("CommandTimeoutProperty is not set.");
-
-                return _commandTimeoutProperty!;
-            }
+            get => _commandTimeoutProperty;
             set => _commandTimeoutProperty = value;
         }
 
@@ -147,9 +143,11 @@ namespace Apache.Arrow.Adbc.Client
             get => _timeout;
             set
             {
-                // ensures the property exists before setting the CommandTimeout value
-                string property = AdbcCommandTimeoutProperty;
-                _adbcStatement.SetOption(property, value.ToString(CultureInfo.InvariantCulture));
+                // if the driver property is set, propagate the timeout value to the driver
+                if (!string.IsNullOrEmpty(_commandTimeoutProperty))
+                {
+                    _adbcStatement.SetOption(_commandTimeoutProperty!, value.ToString(CultureInfo.InvariantCulture));
+                }
                 _timeout = value;
             }
         }

--- a/csharp/test/Apache.Arrow.Adbc.Tests/Client/ClientTests.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/Client/ClientTests.cs
@@ -221,12 +221,12 @@ namespace Apache.Arrow.Adbc.Tests.Client
 
             if (!string.IsNullOrEmpty(connectionStringExample.CommandTimeoutProperty))
             {
-                Assert.True(cmd.AdbcCommandTimeoutProperty == connectionStringExample.CommandTimeoutProperty);
-                Assert.True(cmd.CommandTimeout == connectionStringExample.CommandTimeout);
+                Assert.Equal(connectionStringExample.CommandTimeoutProperty, cmd.AdbcCommandTimeoutProperty);
+                Assert.Equal(connectionStringExample.CommandTimeout, cmd.CommandTimeout);
             }
             else
             {
-                Assert.Throws<InvalidOperationException>(() => cmd.AdbcCommandTimeoutProperty);
+                Assert.Null(cmd.AdbcCommandTimeoutProperty);
             }
         }
     }


### PR DESCRIPTION
Previously, setting CommandTimeout required AdbcCommandTimeoutProperty to be set first, throwing InvalidOperationException if it was not, specifically in Snowflake's case. 
Now, AdbcCommandTimeoutProperty is nullable and CommandTimeout stores the value locally when no driver property is configured, only propagating to the driver via SetOption when the property is set.
Fixed previous PR: https://github.com/apache/arrow-adbc/pull/2312