### PR TITLE
feat(java/driver/jni): allow loading shared library from external path

### DIFF
--- a/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLibraryResolver.java
+++ b/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLibraryResolver.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.adbc.driver.jni.impl;
+
+import java.io.File;
+
+/**
+ * Resolves the JNI native library path from the {@code arrow.adbc.driver.jni.library.path} system
+ * property. Separated from {@link JniLoader} so that it can be tested without triggering native
+ * library loading.
+ */
+class JniLibraryResolver {
+
+  static final String LIBRARY_NAME = "adbc_driver_jni";
+  static final String LIBRARY_PATH_PROPERTY = "arrow.adbc.driver.jni.library.path";
+
+  private JniLibraryResolver() {}
+
+  /**
+   * Resolve the native library path from the {@code arrow.adbc.driver.jni.library.path} system
+   * property. Returns the absolute path to load, or {@code null} if the property is not set or the
+   * library file does not exist at the specified location.
+   */
+  static String resolveLibraryPath(String libraryName) {
+    String libraryPath = System.getProperty(LIBRARY_PATH_PROPERTY);
+    if (libraryPath != null) {
+      File libraryFile = new File(libraryPath, System.mapLibraryName(libraryName));
+      if (libraryFile.isFile()) {
+        return libraryFile.getAbsolutePath();
+      }
+    }
+    return null;
+  }
+}

--- a/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLibraryResolver.java
+++ b/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLibraryResolver.java
@@ -18,32 +18,38 @@
 package org.apache.arrow.adbc.driver.jni.impl;
 
 import java.io.File;
+import java.util.Locale;
 
-/**
- * Resolves the JNI native library path from the {@code arrow.adbc.driver.jni.library.path} system
- * property. Separated from {@link JniLoader} so that it can be tested without triggering native
- * library loading.
- */
+/** Resolves the JNI native library location. */
 class JniLibraryResolver {
 
-  static final String LIBRARY_NAME = "adbc_driver_jni";
-  static final String LIBRARY_PATH_PROPERTY = "arrow.adbc.driver.jni.library.path";
+  static final String PROPERTY = "arrow.adbc.driver.jni.library.path";
+  private static final String LIBRARY_NAME = "adbc_driver_jni";
 
-  private JniLibraryResolver() {}
-
-  /**
-   * Resolve the native library path from the {@code arrow.adbc.driver.jni.library.path} system
-   * property. Returns the absolute path to load, or {@code null} if the property is not set or the
-   * library file does not exist at the specified location.
-   */
-  static String resolveLibraryPath(String libraryName) {
-    String libraryPath = System.getProperty(LIBRARY_PATH_PROPERTY);
-    if (libraryPath != null) {
-      File libraryFile = new File(libraryPath, System.mapLibraryName(libraryName));
-      if (libraryFile.isFile()) {
-        return libraryFile.getAbsolutePath();
-      }
+  /** Returns absolute file path if the system property points to an existing library, else null. */
+  static String resolve() {
+    String dir = System.getProperty(PROPERTY);
+    if (dir == null) {
+      return null;
     }
-    return null;
+    File file = new File(dir, System.mapLibraryName(LIBRARY_NAME));
+    return file.isFile() ? file.getAbsolutePath() : null;
+  }
+
+  /** Returns the platform-specific resource path for JAR extraction. */
+  static String resourcePath() {
+    return LIBRARY_NAME + "/" + getNormalizedArch() + "/" + System.mapLibraryName(LIBRARY_NAME);
+  }
+
+  private static String getNormalizedArch() {
+    String arch = System.getProperty("os.arch").toLowerCase(Locale.US);
+    switch (arch) {
+      case "amd64":
+        return "x86_64";
+      case "aarch64":
+        return "aarch_64";
+      default:
+        throw new RuntimeException("ADBC JNI driver not supported on architecture " + arch);
+    }
   }
 }

--- a/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLoader.java
+++ b/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLoader.java
@@ -34,8 +34,20 @@ public enum JniLoader {
   INSTANCE;
 
   JniLoader() {
-    // The JAR may contain multiple binaries for different platforms, so load the appropriate one.
     final String libraryName = "adbc_driver_jni";
+
+    // If 'arrow.adbc.driver.jni.library.path' is defined, try to load the native library from
+    // there
+    String libraryPath = System.getProperty("arrow.adbc.driver.jni.library.path");
+    if (libraryPath != null) {
+      File libraryFile = new File(libraryPath, System.mapLibraryName(libraryName));
+      if (libraryFile.isFile()) {
+        System.load(libraryFile.getAbsolutePath());
+        return;
+      }
+    }
+
+    // The JAR may contain multiple binaries for different platforms, so load the appropriate one.
     String libraryToLoad =
         libraryName + "/" + getNormalizedArch() + "/" + System.mapLibraryName(libraryName);
 

--- a/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLoader.java
+++ b/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLoader.java
@@ -33,11 +33,12 @@ import org.apache.arrow.c.ArrowSchema;
 public enum JniLoader {
   INSTANCE;
 
-  static final String LIBRARY_NAME = "adbc_driver_jni";
-  static final String LIBRARY_PATH_PROPERTY = "arrow.adbc.driver.jni.library.path";
-
   JniLoader() {
-    String resolvedPath = resolveLibraryPath(LIBRARY_NAME);
+    final String libraryName = JniLibraryResolver.LIBRARY_NAME;
+
+    // If 'arrow.adbc.driver.jni.library.path' is defined, try to load the native library from
+    // there
+    String resolvedPath = JniLibraryResolver.resolveLibraryPath(libraryName);
     if (resolvedPath != null) {
       System.load(resolvedPath);
       return;
@@ -45,7 +46,7 @@ public enum JniLoader {
 
     // The JAR may contain multiple binaries for different platforms, so load the appropriate one.
     String libraryToLoad =
-        LIBRARY_NAME + "/" + getNormalizedArch() + "/" + System.mapLibraryName(LIBRARY_NAME);
+        libraryName + "/" + getNormalizedArch() + "/" + System.mapLibraryName(libraryName);
 
     try {
       InputStream is = JniLoader.class.getClassLoader().getResourceAsStream(libraryToLoad);
@@ -64,22 +65,6 @@ public enum JniLoader {
     } catch (IOException e) {
       throw new IllegalStateException("Error loading native library " + libraryToLoad, e);
     }
-  }
-
-  /**
-   * Resolve the native library path from the {@code arrow.adbc.driver.jni.library.path} system
-   * property. Returns the absolute path to load, or {@code null} if the property is not set or the
-   * library file does not exist at the specified location.
-   */
-  static String resolveLibraryPath(String libraryName) {
-    String libraryPath = System.getProperty(LIBRARY_PATH_PROPERTY);
-    if (libraryPath != null) {
-      File libraryFile = new File(libraryPath, System.mapLibraryName(libraryName));
-      if (libraryFile.isFile()) {
-        return libraryFile.getAbsolutePath();
-      }
-    }
-    return null;
   }
 
   private String getNormalizedArch() {

--- a/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLoader.java
+++ b/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLoader.java
@@ -33,23 +33,19 @@ import org.apache.arrow.c.ArrowSchema;
 public enum JniLoader {
   INSTANCE;
 
-  JniLoader() {
-    final String libraryName = "adbc_driver_jni";
+  static final String LIBRARY_NAME = "adbc_driver_jni";
+  static final String LIBRARY_PATH_PROPERTY = "arrow.adbc.driver.jni.library.path";
 
-    // If 'arrow.adbc.driver.jni.library.path' is defined, try to load the native library from
-    // there
-    String libraryPath = System.getProperty("arrow.adbc.driver.jni.library.path");
-    if (libraryPath != null) {
-      File libraryFile = new File(libraryPath, System.mapLibraryName(libraryName));
-      if (libraryFile.isFile()) {
-        System.load(libraryFile.getAbsolutePath());
-        return;
-      }
+  JniLoader() {
+    String resolvedPath = resolveLibraryPath(LIBRARY_NAME);
+    if (resolvedPath != null) {
+      System.load(resolvedPath);
+      return;
     }
 
     // The JAR may contain multiple binaries for different platforms, so load the appropriate one.
     String libraryToLoad =
-        libraryName + "/" + getNormalizedArch() + "/" + System.mapLibraryName(libraryName);
+        LIBRARY_NAME + "/" + getNormalizedArch() + "/" + System.mapLibraryName(LIBRARY_NAME);
 
     try {
       InputStream is = JniLoader.class.getClassLoader().getResourceAsStream(libraryToLoad);
@@ -68,6 +64,22 @@ public enum JniLoader {
     } catch (IOException e) {
       throw new IllegalStateException("Error loading native library " + libraryToLoad, e);
     }
+  }
+
+  /**
+   * Resolve the native library path from the {@code arrow.adbc.driver.jni.library.path} system
+   * property. Returns the absolute path to load, or {@code null} if the property is not set or the
+   * library file does not exist at the specified location.
+   */
+  static String resolveLibraryPath(String libraryName) {
+    String libraryPath = System.getProperty(LIBRARY_PATH_PROPERTY);
+    if (libraryPath != null) {
+      File libraryFile = new File(libraryPath, System.mapLibraryName(libraryName));
+      if (libraryFile.isFile()) {
+        return libraryFile.getAbsolutePath();
+      }
+    }
+    return null;
   }
 
   private String getNormalizedArch() {

--- a/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLoader.java
+++ b/java/driver/jni/src/main/java/org/apache/arrow/adbc/driver/jni/impl/JniLoader.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.Locale;
 import java.util.Map;
 import org.apache.arrow.adbc.core.AdbcException;
 import org.apache.arrow.c.ArrowArray;
@@ -34,19 +33,15 @@ public enum JniLoader {
   INSTANCE;
 
   JniLoader() {
-    final String libraryName = JniLibraryResolver.LIBRARY_NAME;
-
-    // If 'arrow.adbc.driver.jni.library.path' is defined, try to load the native library from
-    // there
-    String resolvedPath = JniLibraryResolver.resolveLibraryPath(libraryName);
+    // If 'arrow.adbc.driver.jni.library.path' is set, load from there instead of the JAR.
+    String resolvedPath = JniLibraryResolver.resolve();
     if (resolvedPath != null) {
       System.load(resolvedPath);
       return;
     }
 
     // The JAR may contain multiple binaries for different platforms, so load the appropriate one.
-    String libraryToLoad =
-        libraryName + "/" + getNormalizedArch() + "/" + System.mapLibraryName(libraryName);
+    String libraryToLoad = JniLibraryResolver.resourcePath();
 
     try {
       InputStream is = JniLoader.class.getClassLoader().getResourceAsStream(libraryToLoad);
@@ -64,19 +59,6 @@ public enum JniLoader {
       Runtime.getRuntime().load(temp.getAbsolutePath());
     } catch (IOException e) {
       throw new IllegalStateException("Error loading native library " + libraryToLoad, e);
-    }
-  }
-
-  private String getNormalizedArch() {
-    // Be consistent with our CMake config
-    String arch = System.getProperty("os.arch").toLowerCase(Locale.US);
-    switch (arch) {
-      case "amd64":
-        return "x86_64";
-      case "aarch64":
-        return "aarch_64";
-      default:
-        throw new RuntimeException("ADBC JNI driver not supported on architecture " + arch);
     }
   }
 

--- a/java/driver/jni/src/test/java/org/apache/arrow/adbc/driver/jni/impl/JniLibraryResolverTest.java
+++ b/java/driver/jni/src/test/java/org/apache/arrow/adbc/driver/jni/impl/JniLibraryResolverTest.java
@@ -26,41 +26,41 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-class JniLoaderTest {
+class JniLibraryResolverTest {
 
   @AfterEach
   void clearProperty() {
-    System.clearProperty(JniLoader.LIBRARY_PATH_PROPERTY);
+    System.clearProperty(JniLibraryResolver.LIBRARY_PATH_PROPERTY);
   }
 
   @Test
   void resolveLibraryPathPropertyNotSet() {
-    assertThat(JniLoader.resolveLibraryPath(JniLoader.LIBRARY_NAME)).isNull();
+    assertThat(JniLibraryResolver.resolveLibraryPath(JniLibraryResolver.LIBRARY_NAME)).isNull();
   }
 
   @Test
   void resolveLibraryPathFileExists(@TempDir Path tempDir) throws IOException {
-    String libraryFileName = System.mapLibraryName(JniLoader.LIBRARY_NAME);
+    String libraryFileName = System.mapLibraryName(JniLibraryResolver.LIBRARY_NAME);
     File libraryFile = tempDir.resolve(libraryFileName).toFile();
     assertThat(libraryFile.createNewFile()).isTrue();
 
-    System.setProperty(JniLoader.LIBRARY_PATH_PROPERTY, tempDir.toString());
+    System.setProperty(JniLibraryResolver.LIBRARY_PATH_PROPERTY, tempDir.toString());
 
-    String resolved = JniLoader.resolveLibraryPath(JniLoader.LIBRARY_NAME);
+    String resolved = JniLibraryResolver.resolveLibraryPath(JniLibraryResolver.LIBRARY_NAME);
     assertThat(resolved).isEqualTo(libraryFile.getAbsolutePath());
   }
 
   @Test
   void resolveLibraryPathFileMissing(@TempDir Path tempDir) {
-    System.setProperty(JniLoader.LIBRARY_PATH_PROPERTY, tempDir.toString());
+    System.setProperty(JniLibraryResolver.LIBRARY_PATH_PROPERTY, tempDir.toString());
 
-    assertThat(JniLoader.resolveLibraryPath(JniLoader.LIBRARY_NAME)).isNull();
+    assertThat(JniLibraryResolver.resolveLibraryPath(JniLibraryResolver.LIBRARY_NAME)).isNull();
   }
 
   @Test
   void resolveLibraryPathDirectoryDoesNotExist() {
-    System.setProperty(JniLoader.LIBRARY_PATH_PROPERTY, "/nonexistent/path");
+    System.setProperty(JniLibraryResolver.LIBRARY_PATH_PROPERTY, "/nonexistent/path");
 
-    assertThat(JniLoader.resolveLibraryPath(JniLoader.LIBRARY_NAME)).isNull();
+    assertThat(JniLibraryResolver.resolveLibraryPath(JniLibraryResolver.LIBRARY_NAME)).isNull();
   }
 }

--- a/java/driver/jni/src/test/java/org/apache/arrow/adbc/driver/jni/impl/JniLibraryResolverTest.java
+++ b/java/driver/jni/src/test/java/org/apache/arrow/adbc/driver/jni/impl/JniLibraryResolverTest.java
@@ -30,37 +30,40 @@ class JniLibraryResolverTest {
 
   @AfterEach
   void clearProperty() {
-    System.clearProperty(JniLibraryResolver.LIBRARY_PATH_PROPERTY);
+    System.clearProperty(JniLibraryResolver.PROPERTY);
   }
 
   @Test
-  void resolveLibraryPathPropertyNotSet() {
-    assertThat(JniLibraryResolver.resolveLibraryPath(JniLibraryResolver.LIBRARY_NAME)).isNull();
+  void propertyNotSet() {
+    assertThat(JniLibraryResolver.resolve()).isNull();
   }
 
   @Test
-  void resolveLibraryPathFileExists(@TempDir Path tempDir) throws IOException {
-    String libraryFileName = System.mapLibraryName(JniLibraryResolver.LIBRARY_NAME);
-    File libraryFile = tempDir.resolve(libraryFileName).toFile();
-    assertThat(libraryFile.createNewFile()).isTrue();
+  void fileExists(@TempDir Path tempDir) throws IOException {
+    File lib = tempDir.resolve(System.mapLibraryName("adbc_driver_jni")).toFile();
+    assertThat(lib.createNewFile()).isTrue();
 
-    System.setProperty(JniLibraryResolver.LIBRARY_PATH_PROPERTY, tempDir.toString());
-
-    String resolved = JniLibraryResolver.resolveLibraryPath(JniLibraryResolver.LIBRARY_NAME);
-    assertThat(resolved).isEqualTo(libraryFile.getAbsolutePath());
+    System.setProperty(JniLibraryResolver.PROPERTY, tempDir.toString());
+    assertThat(JniLibraryResolver.resolve()).isEqualTo(lib.getAbsolutePath());
   }
 
   @Test
-  void resolveLibraryPathFileMissing(@TempDir Path tempDir) {
-    System.setProperty(JniLibraryResolver.LIBRARY_PATH_PROPERTY, tempDir.toString());
-
-    assertThat(JniLibraryResolver.resolveLibraryPath(JniLibraryResolver.LIBRARY_NAME)).isNull();
+  void fileMissing(@TempDir Path tempDir) {
+    System.setProperty(JniLibraryResolver.PROPERTY, tempDir.toString());
+    assertThat(JniLibraryResolver.resolve()).isNull();
   }
 
   @Test
-  void resolveLibraryPathDirectoryDoesNotExist() {
-    System.setProperty(JniLibraryResolver.LIBRARY_PATH_PROPERTY, "/nonexistent/path");
+  void directoryDoesNotExist() {
+    System.setProperty(JniLibraryResolver.PROPERTY, "/nonexistent/path");
+    assertThat(JniLibraryResolver.resolve()).isNull();
+  }
 
-    assertThat(JniLibraryResolver.resolveLibraryPath(JniLibraryResolver.LIBRARY_NAME)).isNull();
+  @Test
+  void resourcePathContainsLibraryAndArch() {
+    String path = JniLibraryResolver.resourcePath();
+    assertThat(path).startsWith("adbc_driver_jni/");
+    assertThat(path).containsPattern("(x86_64|aarch_64)");
+    assertThat(path).endsWith(System.mapLibraryName("adbc_driver_jni"));
   }
 }

--- a/java/driver/jni/src/test/java/org/apache/arrow/adbc/driver/jni/impl/JniLoaderTest.java
+++ b/java/driver/jni/src/test/java/org/apache/arrow/adbc/driver/jni/impl/JniLoaderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.adbc.driver.jni.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JniLoaderTest {
+
+  @AfterEach
+  void clearProperty() {
+    System.clearProperty(JniLoader.LIBRARY_PATH_PROPERTY);
+  }
+
+  @Test
+  void resolveLibraryPathPropertyNotSet() {
+    assertThat(JniLoader.resolveLibraryPath(JniLoader.LIBRARY_NAME)).isNull();
+  }
+
+  @Test
+  void resolveLibraryPathFileExists(@TempDir Path tempDir) throws IOException {
+    String libraryFileName = System.mapLibraryName(JniLoader.LIBRARY_NAME);
+    File libraryFile = tempDir.resolve(libraryFileName).toFile();
+    assertThat(libraryFile.createNewFile()).isTrue();
+
+    System.setProperty(JniLoader.LIBRARY_PATH_PROPERTY, tempDir.toString());
+
+    String resolved = JniLoader.resolveLibraryPath(JniLoader.LIBRARY_NAME);
+    assertThat(resolved).isEqualTo(libraryFile.getAbsolutePath());
+  }
+
+  @Test
+  void resolveLibraryPathFileMissing(@TempDir Path tempDir) {
+    System.setProperty(JniLoader.LIBRARY_PATH_PROPERTY, tempDir.toString());
+
+    assertThat(JniLoader.resolveLibraryPath(JniLoader.LIBRARY_NAME)).isNull();
+  }
+
+  @Test
+  void resolveLibraryPathDirectoryDoesNotExist() {
+    System.setProperty(JniLoader.LIBRARY_PATH_PROPERTY, "/nonexistent/path");
+
+    assertThat(JniLoader.resolveLibraryPath(JniLoader.LIBRARY_NAME)).isNull();
+  }
+}


### PR DESCRIPTION
Add `arrow.adbc.driver.jni.library.path` JVM system property to load the JNI native library from a custom directory. Falls back to JAR extraction when the property is unset or the file is not found.

Consistent with [arrow-java's JniLoader approach](https://github.com/apache/arrow-java/blob/0d55ba78aeed3e6b28e3d65ced37c360f5e0ed4e/c/src/main/java/org/apache/arrow/c/jni/JniLoader.java#L80-L92). I just make it a bit more testable.

Closes apache/arrow-adbc#4207