### PR TITLE
test(go,r): add basic Go and R tests for connection profiles

### DIFF
--- a/go/adbc/drivermgr/profile_test.go
+++ b/go/adbc/drivermgr/profile_test.go
@@ -1,0 +1,146 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build cgo
+
+package drivermgr_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/arrow-adbc/go/adbc/drivermgr"
+	"github.com/stretchr/testify/require"
+)
+
+const simpleProfile = `
+profile_version = 1
+driver = "adbc_driver_sqlite"
+
+[Options]
+uri = ":memory:"
+`
+
+func writeProfile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name+".toml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+	return path
+}
+
+// TestProfileAbsolutePath loads a profile via the absolute path in the "profile" option.
+func TestProfileAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	profilePath := writeProfile(t, dir, "myprofile", simpleProfile)
+
+	var drv drivermgr.Driver
+	db, err := drv.NewDatabase(map[string]string{
+		"profile": profilePath,
+	})
+	require.NoError(t, err)
+
+	conn, err := db.Open(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	require.NoError(t, db.Close())
+}
+
+// TestProfileByNameViaSearchPath loads a profile by name using
+// additional_profile_search_path_list.
+func TestProfileByNameViaSearchPath(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "myprofile", simpleProfile)
+
+	var drv drivermgr.Driver
+	db, err := drv.NewDatabase(map[string]string{
+		"profile":                            "myprofile",
+		"additional_profile_search_path_list": dir,
+	})
+	require.NoError(t, err)
+
+	conn, err := db.Open(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	require.NoError(t, db.Close())
+}
+
+// TestProfileByNameViaEnvVar loads a profile by name with ADBC_PROFILE_PATH set.
+func TestProfileByNameViaEnvVar(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "myprofile", simpleProfile)
+
+	t.Setenv("ADBC_PROFILE_PATH", dir)
+
+	var drv drivermgr.Driver
+	db, err := drv.NewDatabase(map[string]string{
+		"profile": "myprofile",
+	})
+	require.NoError(t, err)
+
+	conn, err := db.Open(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	require.NoError(t, db.Close())
+}
+
+// TestProfileViaURIOption loads a profile using a profile:// URI in the "uri" key.
+func TestProfileViaURIOption(t *testing.T) {
+	dir := t.TempDir()
+	profilePath := writeProfile(t, dir, "myprofile", simpleProfile)
+
+	var drv drivermgr.Driver
+	db, err := drv.NewDatabase(map[string]string{
+		"uri": "profile://" + profilePath,
+	})
+	require.NoError(t, err)
+
+	conn, err := db.Open(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	require.NoError(t, db.Close())
+}
+
+// TestProfileViaDriverOption loads a profile using a profile:// URI in the "driver" key.
+func TestProfileViaDriverOption(t *testing.T) {
+	dir := t.TempDir()
+	profilePath := writeProfile(t, dir, "myprofile", simpleProfile)
+
+	var drv drivermgr.Driver
+	db, err := drv.NewDatabase(map[string]string{
+		"driver": "profile://" + profilePath,
+	})
+	require.NoError(t, err)
+
+	conn, err := db.Open(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	require.NoError(t, db.Close())
+}
+
+// TestProfileNotFound verifies that a missing profile returns an error.
+func TestProfileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("ADBC_PROFILE_PATH", dir)
+
+	var drv drivermgr.Driver
+	_, err := drv.NewDatabase(map[string]string{
+		"profile": "does_not_exist",
+	})
+	require.Error(t, err)
+}

--- a/go/adbc/drivermgr/profile_test.go
+++ b/go/adbc/drivermgr/profile_test.go
@@ -45,7 +45,7 @@ func writeProfile(t *testing.T, dir, name, content string) string {
 	return path
 }
 
-// TestProfileAbsolutePath loads a profile via the absolute path in the "profile" option.
+// loads a profile via the absolute path in the "profile" option.
 func TestProfileAbsolutePath(t *testing.T) {
 	dir := t.TempDir()
 	profilePath := writeProfile(t, dir, "myprofile", simpleProfile)
@@ -57,8 +57,7 @@ func TestProfileAbsolutePath(t *testing.T) {
 	require.ErrorContains(t, err, "nonexistent")
 }
 
-// TestProfileByNameViaSearchPath loads a profile by name using
-// additional_profile_search_path_list.
+// loads a profile by name using additional_profile_search_path_list.
 func TestProfileByNameViaSearchPath(t *testing.T) {
 	dir := t.TempDir()
 	writeProfile(t, dir, "myprofile", simpleProfile)
@@ -71,7 +70,7 @@ func TestProfileByNameViaSearchPath(t *testing.T) {
 	require.ErrorContains(t, err, "nonexistent")
 }
 
-// TestProfileByNameViaEnvVar loads a profile by name with ADBC_PROFILE_PATH set.
+// loads a profile by name with ADBC_PROFILE_PATH set.
 func TestProfileByNameViaEnvVar(t *testing.T) {
 	dir := t.TempDir()
 	writeProfile(t, dir, "myprofile", simpleProfile)
@@ -85,7 +84,7 @@ func TestProfileByNameViaEnvVar(t *testing.T) {
 	require.ErrorContains(t, err, "nonexistent")
 }
 
-// TestProfileViaURIOption loads a profile using a profile:// URI in the "uri" key.
+// loads a profile using a profile:// URI in the "uri" key.
 func TestProfileViaURIOption(t *testing.T) {
 	dir := t.TempDir()
 	profilePath := writeProfile(t, dir, "myprofile", simpleProfile)
@@ -97,7 +96,7 @@ func TestProfileViaURIOption(t *testing.T) {
 	require.ErrorContains(t, err, "nonexistent")
 }
 
-// TestProfileViaDriverOption loads a profile using a profile:// URI in the "driver" key.
+// loads a profile using a profile:// URI in the "driver" key.
 func TestProfileViaDriverOption(t *testing.T) {
 	dir := t.TempDir()
 	profilePath := writeProfile(t, dir, "myprofile", simpleProfile)
@@ -109,7 +108,7 @@ func TestProfileViaDriverOption(t *testing.T) {
 	require.ErrorContains(t, err, "nonexistent")
 }
 
-// TestProfileNotFound verifies that a missing profile returns an error.
+// verifies that a missing profile returns an error.
 func TestProfileNotFound(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("ADBC_PROFILE_PATH", dir)
@@ -118,5 +117,5 @@ func TestProfileNotFound(t *testing.T) {
 	_, err := drv.NewDatabase(map[string]string{
 		"profile": "does_not_exist",
 	})
-	require.ErrorContains(t, err, "does_not_exist")
+	require.ErrorContains(t, err, "Profile not found: does_not_exist")
 }

--- a/go/adbc/drivermgr/profile_test.go
+++ b/go/adbc/drivermgr/profile_test.go
@@ -20,7 +20,6 @@
 package drivermgr_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,12 +28,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// simpleProfile references a nonexistent driver. These tests only verify that
+// the profile mechanism routes correctly — i.e., the error comes from failing
+// to load the driver, not from failing to find or parse the profile.
 const simpleProfile = `
 profile_version = 1
-driver = "adbc_driver_sqlite"
+driver = "/nonexistent/driver.so"
 
 [Options]
-uri = ":memory:"
 `
 
 func writeProfile(t *testing.T, dir, name, content string) string {
@@ -50,15 +51,10 @@ func TestProfileAbsolutePath(t *testing.T) {
 	profilePath := writeProfile(t, dir, "myprofile", simpleProfile)
 
 	var drv drivermgr.Driver
-	db, err := drv.NewDatabase(map[string]string{
+	_, err := drv.NewDatabase(map[string]string{
 		"profile": profilePath,
 	})
-	require.NoError(t, err)
-
-	conn, err := db.Open(context.Background())
-	require.NoError(t, err)
-	require.NoError(t, conn.Close())
-	require.NoError(t, db.Close())
+	require.ErrorContains(t, err, "nonexistent")
 }
 
 // TestProfileByNameViaSearchPath loads a profile by name using
@@ -68,16 +64,11 @@ func TestProfileByNameViaSearchPath(t *testing.T) {
 	writeProfile(t, dir, "myprofile", simpleProfile)
 
 	var drv drivermgr.Driver
-	db, err := drv.NewDatabase(map[string]string{
+	_, err := drv.NewDatabase(map[string]string{
 		"profile":                             "myprofile",
 		"additional_profile_search_path_list": dir,
 	})
-	require.NoError(t, err)
-
-	conn, err := db.Open(context.Background())
-	require.NoError(t, err)
-	require.NoError(t, conn.Close())
-	require.NoError(t, db.Close())
+	require.ErrorContains(t, err, "nonexistent")
 }
 
 // TestProfileByNameViaEnvVar loads a profile by name with ADBC_PROFILE_PATH set.
@@ -88,15 +79,10 @@ func TestProfileByNameViaEnvVar(t *testing.T) {
 	t.Setenv("ADBC_PROFILE_PATH", dir)
 
 	var drv drivermgr.Driver
-	db, err := drv.NewDatabase(map[string]string{
+	_, err := drv.NewDatabase(map[string]string{
 		"profile": "myprofile",
 	})
-	require.NoError(t, err)
-
-	conn, err := db.Open(context.Background())
-	require.NoError(t, err)
-	require.NoError(t, conn.Close())
-	require.NoError(t, db.Close())
+	require.ErrorContains(t, err, "nonexistent")
 }
 
 // TestProfileViaURIOption loads a profile using a profile:// URI in the "uri" key.
@@ -105,15 +91,10 @@ func TestProfileViaURIOption(t *testing.T) {
 	profilePath := writeProfile(t, dir, "myprofile", simpleProfile)
 
 	var drv drivermgr.Driver
-	db, err := drv.NewDatabase(map[string]string{
+	_, err := drv.NewDatabase(map[string]string{
 		"uri": "profile://" + profilePath,
 	})
-	require.NoError(t, err)
-
-	conn, err := db.Open(context.Background())
-	require.NoError(t, err)
-	require.NoError(t, conn.Close())
-	require.NoError(t, db.Close())
+	require.ErrorContains(t, err, "nonexistent")
 }
 
 // TestProfileViaDriverOption loads a profile using a profile:// URI in the "driver" key.
@@ -122,15 +103,10 @@ func TestProfileViaDriverOption(t *testing.T) {
 	profilePath := writeProfile(t, dir, "myprofile", simpleProfile)
 
 	var drv drivermgr.Driver
-	db, err := drv.NewDatabase(map[string]string{
+	_, err := drv.NewDatabase(map[string]string{
 		"driver": "profile://" + profilePath,
 	})
-	require.NoError(t, err)
-
-	conn, err := db.Open(context.Background())
-	require.NoError(t, err)
-	require.NoError(t, conn.Close())
-	require.NoError(t, db.Close())
+	require.ErrorContains(t, err, "nonexistent")
 }
 
 // TestProfileNotFound verifies that a missing profile returns an error.
@@ -142,5 +118,5 @@ func TestProfileNotFound(t *testing.T) {
 	_, err := drv.NewDatabase(map[string]string{
 		"profile": "does_not_exist",
 	})
-	require.Error(t, err)
+	require.ErrorContains(t, err, "does_not_exist")
 }

--- a/go/adbc/drivermgr/profile_test.go
+++ b/go/adbc/drivermgr/profile_test.go
@@ -69,7 +69,7 @@ func TestProfileByNameViaSearchPath(t *testing.T) {
 
 	var drv drivermgr.Driver
 	db, err := drv.NewDatabase(map[string]string{
-		"profile":                            "myprofile",
+		"profile":                             "myprofile",
 		"additional_profile_search_path_list": dir,
 	})
 	require.NoError(t, err)

--- a/r/adbcdrivermanager/tests/testthat/test-profile.R
+++ b/r/adbcdrivermanager/tests/testthat/test-profile.R
@@ -46,11 +46,10 @@ test_that("can load a profile by absolute path via 'profile' option", {
 
   profile_path <- write_profile(dir, "myprofile")
 
-  browser()
   expect_error(
-    adbc_database_init_default(
+    adbc_database_init(
       adbc_driver_for_profile(),
-      list(profile = profile_path)
+      profile = profile_path
     ),
     regexp = "nonexistent"
   )
@@ -64,12 +63,10 @@ test_that("can load a profile by name via additional_profile_search_path_list", 
   write_profile(dir, "myprofile")
 
   expect_error(
-    adbc_database_init_default(
+    adbc_database_init(
       adbc_driver_for_profile(),
-      list(
-        profile = "myprofile",
-        additional_profile_search_path_list = dir
-      )
+      profile = "myprofile",
+      additional_profile_search_path_list = dir
     ),
     regexp = "nonexistent"
   )
@@ -85,9 +82,9 @@ test_that("can load a profile by name via ADBC_PROFILE_PATH env var", {
   withr::with_envvar(
     list(ADBC_PROFILE_PATH = dir),
     expect_error(
-      adbc_database_init_default(
+      adbc_database_init(
         adbc_driver_for_profile(),
-        list(profile = "myprofile")
+        profile = "myprofile"
       ),
       regexp = "nonexistent"
     )
@@ -102,9 +99,9 @@ test_that("can load a profile via profile:// URI in 'uri' option", {
   profile_path <- write_profile(dir, "myprofile")
 
   expect_error(
-    adbc_database_init_default(
+    adbc_database_init(
       adbc_driver_for_profile(),
-      list(uri = paste0("profile://", profile_path))
+      uri = paste0("profile://", profile_path)
     ),
     regexp = "nonexistent"
   )
@@ -120,7 +117,7 @@ test_that("can load a profile via profile:// URI in 'driver' option", {
   expect_error(
     adbc_database_init_default(
       adbc_driver_for_profile(),
-      list(driver = paste0("profile://", profile_path))
+      list(driver = paste0("profile://", profile_path)) # Wrap in list() to avoid arg names clashing
     ),
     regexp = "nonexistent"
   )
@@ -138,7 +135,8 @@ test_that("missing profile returns an error", {
         adbc_driver_for_profile(),
         list(profile = "does_not_exist")
       ),
-      regexp = "Profile not found: does_not_exist"
+      # "does_not_exist" is the profile name; keep in sync with C error message format
+      regexp = "does_not_exist"
     )
   )
 })

--- a/r/adbcdrivermanager/tests/testthat/test-profile.R
+++ b/r/adbcdrivermanager/tests/testthat/test-profile.R
@@ -1,0 +1,181 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Profile tests require adbcsqlite to be installed so we have a real driver
+# to reference from profile TOML files.
+skip_if_not(
+  nzchar(system.file(package = "adbcsqlite")),
+  "adbcsqlite package not installed"
+)
+
+# Return the path to the adbcsqlite shared library so profiles can reference it.
+adbcsqlite_shared <- function() {
+  shared <- system.file(
+    "libs",
+    .Platform$r_arch,
+    paste0("adbcsqlite", .Platform$dynlib.ext),
+    package = "adbcsqlite"
+  )
+  if (!identical(shared, "")) return(shared)
+
+  system.file(
+    "src",
+    paste0("adbcsqlite", .Platform$dynlib.ext),
+    package = "adbcsqlite"
+  )
+}
+
+# Build a minimal driver object that carries no pre-loaded init func or name.
+# This lets adbc_database_init_default call RAdbcDatabaseNew(NULL, load_flags),
+# leaving the driver manager free to load the driver specified in the profile.
+adbc_driver_for_profile <- function() {
+  driver <- new.env(parent = emptyenv())
+  driver$load_flags <- adbc_load_flags()
+  class(driver) <- "adbc_driver"
+  driver
+}
+
+# Write a simple profile TOML that loads the sqlite driver with an in-memory db.
+write_profile <- function(dir, name) {
+  content <- paste0(
+    'profile_version = 1\n',
+    'driver = "', adbcsqlite_shared(), '"\n',
+    '\n',
+    '[Options]\n',
+    'uri = ":memory:"\n'
+  )
+  path <- file.path(dir, paste0(name, ".toml"))
+  writeLines(content, path)
+  path
+}
+
+test_that("can load a profile by absolute path via 'profile' option", {
+  dir <- tempfile()
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE))
+
+  profile_path <- write_profile(dir, "myprofile")
+
+  db <- adbc_database_init_default(
+    adbc_driver_for_profile(),
+    list(profile = profile_path)
+  )
+  expect_s3_class(db, "adbc_database")
+
+  con <- adbc_connection_init(db)
+  expect_s3_class(con, "adbc_connection")
+  adbc_connection_release(con)
+  adbc_database_release(db)
+})
+
+test_that("can load a profile by name via additional_profile_search_path_list", {
+  dir <- tempfile()
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE))
+
+  write_profile(dir, "myprofile")
+
+  db <- adbc_database_init_default(
+    adbc_driver_for_profile(),
+    list(
+      profile = "myprofile",
+      additional_profile_search_path_list = dir
+    )
+  )
+  expect_s3_class(db, "adbc_database")
+
+  con <- adbc_connection_init(db)
+  adbc_connection_release(con)
+  adbc_database_release(db)
+})
+
+test_that("can load a profile by name via ADBC_PROFILE_PATH env var", {
+  dir <- tempfile()
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE))
+
+  write_profile(dir, "myprofile")
+
+  withr::with_envvar(
+    list(ADBC_PROFILE_PATH = dir),
+    {
+      db <- adbc_database_init_default(
+        adbc_driver_for_profile(),
+        list(profile = "myprofile")
+      )
+      expect_s3_class(db, "adbc_database")
+
+      con <- adbc_connection_init(db)
+      adbc_connection_release(con)
+      adbc_database_release(db)
+    }
+  )
+})
+
+test_that("can load a profile via profile:// URI in 'uri' option", {
+  dir <- tempfile()
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE))
+
+  profile_path <- write_profile(dir, "myprofile")
+
+  db <- adbc_database_init_default(
+    adbc_driver_for_profile(),
+    list(uri = paste0("profile://", profile_path))
+  )
+  expect_s3_class(db, "adbc_database")
+
+  con <- adbc_connection_init(db)
+  adbc_connection_release(con)
+  adbc_database_release(db)
+})
+
+test_that("can load a profile via profile:// URI in 'driver' option", {
+  dir <- tempfile()
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE))
+
+  profile_path <- write_profile(dir, "myprofile")
+
+  db <- adbc_database_init_default(
+    adbc_driver_for_profile(),
+    list(driver = paste0("profile://", profile_path))
+  )
+  expect_s3_class(db, "adbc_database")
+
+  con <- adbc_connection_init(db)
+  adbc_connection_release(con)
+  adbc_database_release(db)
+})
+
+test_that("missing profile returns an error", {
+  dir <- tempfile()
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE))
+
+  withr::with_envvar(
+    list(ADBC_PROFILE_PATH = dir),
+    {
+      expect_error(
+        adbc_database_init_default(
+          adbc_driver_for_profile(),
+          list(profile = "does_not_exist")
+        )
+      )
+    }
+  )
+})

--- a/r/adbcdrivermanager/tests/testthat/test-profile.R
+++ b/r/adbcdrivermanager/tests/testthat/test-profile.R
@@ -15,33 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Profile tests require adbcsqlite to be installed so we have a real driver
-# to reference from profile TOML files.
-skip_if_not(
-  nzchar(system.file(package = "adbcsqlite")),
-  "adbcsqlite package not installed"
-)
+# This suite is just a smoke test to make sure connection profiles are hooked
+# up. We make a fake driver and a broken connection profile just to test that
+# the driver manager is producing the right error message as proof connection
+# profiles are hooked up.
 
-# Return the path to the adbcsqlite shared library so profiles can reference it.
-adbcsqlite_shared <- function() {
-  shared <- system.file(
-    "libs",
-    .Platform$r_arch,
-    paste0("adbcsqlite", .Platform$dynlib.ext),
-    package = "adbcsqlite"
-  )
-  if (!identical(shared, "")) return(shared)
-
-  system.file(
-    "src",
-    paste0("adbcsqlite", .Platform$dynlib.ext),
-    package = "adbcsqlite"
-  )
-}
-
-# Build a minimal driver object that carries no pre-loaded init func or name.
-# This lets adbc_database_init_default call RAdbcDatabaseNew(NULL, load_flags),
-# leaving the driver manager free to load the driver specified in the profile.
 adbc_driver_for_profile <- function() {
   driver <- new.env(parent = emptyenv())
   driver$load_flags <- adbc_load_flags()
@@ -49,14 +27,12 @@ adbc_driver_for_profile <- function() {
   driver
 }
 
-# Write a simple profile TOML that loads the sqlite driver with an in-memory db.
 write_profile <- function(dir, name) {
   content <- paste0(
     'profile_version = 1\n',
-    'driver = "', adbcsqlite_shared(), '"\n',
+    'driver = "/nonexistent/driver.so"\n',
     '\n',
-    '[Options]\n',
-    'uri = ":memory:"\n'
+    '[Options]\n'
   )
   path <- file.path(dir, paste0(name, ".toml"))
   writeLines(content, path)
@@ -70,16 +46,14 @@ test_that("can load a profile by absolute path via 'profile' option", {
 
   profile_path <- write_profile(dir, "myprofile")
 
-  db <- adbc_database_init_default(
-    adbc_driver_for_profile(),
-    list(profile = profile_path)
+  browser()
+  expect_error(
+    adbc_database_init_default(
+      adbc_driver_for_profile(),
+      list(profile = profile_path)
+    ),
+    regexp = "nonexistent"
   )
-  expect_s3_class(db, "adbc_database")
-
-  con <- adbc_connection_init(db)
-  expect_s3_class(con, "adbc_connection")
-  adbc_connection_release(con)
-  adbc_database_release(db)
 })
 
 test_that("can load a profile by name via additional_profile_search_path_list", {
@@ -89,18 +63,16 @@ test_that("can load a profile by name via additional_profile_search_path_list", 
 
   write_profile(dir, "myprofile")
 
-  db <- adbc_database_init_default(
-    adbc_driver_for_profile(),
-    list(
-      profile = "myprofile",
-      additional_profile_search_path_list = dir
-    )
+  expect_error(
+    adbc_database_init_default(
+      adbc_driver_for_profile(),
+      list(
+        profile = "myprofile",
+        additional_profile_search_path_list = dir
+      )
+    ),
+    regexp = "nonexistent"
   )
-  expect_s3_class(db, "adbc_database")
-
-  con <- adbc_connection_init(db)
-  adbc_connection_release(con)
-  adbc_database_release(db)
 })
 
 test_that("can load a profile by name via ADBC_PROFILE_PATH env var", {
@@ -112,17 +84,13 @@ test_that("can load a profile by name via ADBC_PROFILE_PATH env var", {
 
   withr::with_envvar(
     list(ADBC_PROFILE_PATH = dir),
-    {
-      db <- adbc_database_init_default(
+    expect_error(
+      adbc_database_init_default(
         adbc_driver_for_profile(),
         list(profile = "myprofile")
-      )
-      expect_s3_class(db, "adbc_database")
-
-      con <- adbc_connection_init(db)
-      adbc_connection_release(con)
-      adbc_database_release(db)
-    }
+      ),
+      regexp = "nonexistent"
+    )
   )
 })
 
@@ -133,15 +101,13 @@ test_that("can load a profile via profile:// URI in 'uri' option", {
 
   profile_path <- write_profile(dir, "myprofile")
 
-  db <- adbc_database_init_default(
-    adbc_driver_for_profile(),
-    list(uri = paste0("profile://", profile_path))
+  expect_error(
+    adbc_database_init_default(
+      adbc_driver_for_profile(),
+      list(uri = paste0("profile://", profile_path))
+    ),
+    regexp = "nonexistent"
   )
-  expect_s3_class(db, "adbc_database")
-
-  con <- adbc_connection_init(db)
-  adbc_connection_release(con)
-  adbc_database_release(db)
 })
 
 test_that("can load a profile via profile:// URI in 'driver' option", {
@@ -151,15 +117,13 @@ test_that("can load a profile via profile:// URI in 'driver' option", {
 
   profile_path <- write_profile(dir, "myprofile")
 
-  db <- adbc_database_init_default(
-    adbc_driver_for_profile(),
-    list(driver = paste0("profile://", profile_path))
+  expect_error(
+    adbc_database_init_default(
+      adbc_driver_for_profile(),
+      list(driver = paste0("profile://", profile_path))
+    ),
+    regexp = "nonexistent"
   )
-  expect_s3_class(db, "adbc_database")
-
-  con <- adbc_connection_init(db)
-  adbc_connection_release(con)
-  adbc_database_release(db)
 })
 
 test_that("missing profile returns an error", {
@@ -169,13 +133,12 @@ test_that("missing profile returns an error", {
 
   withr::with_envvar(
     list(ADBC_PROFILE_PATH = dir),
-    {
-      expect_error(
-        adbc_database_init_default(
-          adbc_driver_for_profile(),
-          list(profile = "does_not_exist")
-        )
-      )
-    }
+    expect_error(
+      adbc_database_init_default(
+        adbc_driver_for_profile(),
+        list(profile = "does_not_exist")
+      ),
+      regexp = "Profile not found: does_not_exist"
+    )
   )
 })

--- a/r/adbcsqlite/DESCRIPTION
+++ b/r/adbcsqlite/DESCRIPTION
@@ -19,7 +19,8 @@ RoxygenNote: 7.3.2
 SystemRequirements: SQLite3
 Suggests:
     nanoarrow,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
 Config/testthat/edition: 3
 Config/build/bootstrap: TRUE
 URL: https://arrow.apache.org/adbc/current/r/adbcsqlite/, https://github.com/apache/arrow-adbc

--- a/r/adbcsqlite/tests/testthat/test-connection-profiles.R
+++ b/r/adbcsqlite/tests/testthat/test-connection-profiles.R
@@ -16,19 +16,19 @@
 # under the License.
 
 adbcsqlite_shared <- function() {
-  path <- system.file(
-    "libs",
-    paste0("adbcsqlite", .Platform$dynlib.ext),
-    package = "adbcsqlite"
-  )
+  lib_name <- paste0("adbcsqlite", .Platform$dynlib.ext)
+  r_arch <- .Platform$r_arch
+
+  path <- if (nzchar(r_arch)) {
+    system.file("libs", r_arch, lib_name, package = "adbcsqlite")
+  } else {
+    system.file("libs", lib_name, package = "adbcsqlite")
+  }
+
   if (nzchar(path)) {
     return(path)
   }
-  system.file(
-    "src",
-    paste0("adbcsqlite", .Platform$dynlib.ext),
-    package = "adbcsqlite"
-  )
+  system.file("src", lib_name, package = "adbcsqlite")
 }
 
 adbc_driver_for_profile <- function() {

--- a/r/adbcsqlite/tests/testthat/test-connection-profiles.R
+++ b/r/adbcsqlite/tests/testthat/test-connection-profiles.R
@@ -16,6 +16,14 @@
 # under the License.
 
 adbcsqlite_shared <- function() {
+  path <- system.file(
+    "libs",
+    paste0("adbcsqlite", .Platform$dynlib.ext),
+    package = "adbcsqlite"
+  )
+  if (nzchar(path)) {
+    return(path)
+  }
   system.file(
     "src",
     paste0("adbcsqlite", .Platform$dynlib.ext),

--- a/r/adbcsqlite/tests/testthat/test-connection-profiles.R
+++ b/r/adbcsqlite/tests/testthat/test-connection-profiles.R
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+adbcsqlite_shared <- function() {
+  system.file(
+    "src",
+    paste0("adbcsqlite", .Platform$dynlib.ext),
+    package = "adbcsqlite"
+  )
+}
+
+adbc_driver_for_profile <- function() {
+  driver <- new.env(parent = emptyenv())
+  driver$load_flags <- adbcdrivermanager:::adbc_load_flags()
+  class(driver) <- "adbc_driver"
+  driver
+}
+
+write_sqlite_profile <- function(dir, name) {
+  driver_path <- adbcsqlite_shared()
+  stopifnot(file.exists(driver_path))
+
+  content <- paste0(
+    'profile_version = 1\n',
+    'driver = "',
+    driver_path,
+    '"\n',
+    '[Options]\n'
+  )
+  path <- file.path(dir, paste0(name, ".toml"))
+  writeLines(content, path)
+  stopifnot(file.exists(path))
+
+  path
+}
+
+test_that("can open a sqlite database via a profile from path via env var", {
+  dir <- tempfile()
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE))
+
+  profile_path <- write_sqlite_profile(dir, "my_sqlite")
+  dir <- dirname(profile_path)
+
+  withr::with_envvar(
+    list(ADBC_PROFILE_PATH = dir),
+    db <- adbc_database_init(
+      adbc_driver_for_profile(),
+      uri = "profile://my_sqlite"
+    ),
+  )
+
+  con <- adbcdrivermanager::adbc_connection_init(db)
+  on.exit({
+    adbcdrivermanager::adbc_connection_release(con)
+    adbcdrivermanager::adbc_database_release(db)
+  })
+
+  stream <- adbcdrivermanager::read_adbc(con, "SELECT 1 AS numbers")
+
+  expect_identical(
+    as.data.frame(stream),
+    data.frame(numbers = 1, check.names = FALSE)
+  )
+})


### PR DESCRIPTION
Adds basic tests for connection profiles for the Go and R driver managers just to catch regressions and make it easier for people (or agents) poking around the codebase to know profiles work in these languages. The driver manager tests don't test a real driver+manifest combo and just check the we get profile-specific errors and that args are passed through. Also adds one test with a real driver to the R adbcsqlite package. 