### PR TITLE
docs(javascript): create basic scaffold for typedoc js docs

### DIFF
--- a/ci/scripts/docs_build.sh
+++ b/ci/scripts/docs_build.sh
@@ -31,7 +31,7 @@ main() {
 
     pushd "$source_dir/javascript"
     npm install --ignore-scripts
-    npx typedoc
+    npm run docs
     popd
 
     pushd "$source_dir/docs"

--- a/ci/scripts/docs_build.sh
+++ b/ci/scripts/docs_build.sh
@@ -80,7 +80,17 @@ main() {
       # Python's documentation build can run without installing the R
       # packages). Packages are installed in ci/scripts/r_build.sh
       if Rscript -e "loadNamespace('$pkg_name')" ; then
-        R -e "pkgdown::build_site(pkg = '$pkg', override = list(destination = '$source_dir/docs/build/html/r/$pkg_name'), new_process = FALSE, preview = FALSE)"
+        # The steps below, aside from the pkgdown::build_site call are to work
+        # around a macOS-specific Docker quirk: build_site internally calls
+        # chmod on `destination` and this fails on macOS with "permission
+        # denied". This is a CI script but it's useful for developers to be able
+        # to run `docker compose run docs` to test the site build locally.
+        local tmp_dest
+        tmp_dest=$(mktemp -d)
+        R -e "pkgdown::build_site(pkg = '$pkg', override = list(destination = '$tmp_dest'), new_process = FALSE, preview = FALSE)"
+        rm -rf "$source_dir/docs/build/html/r/$pkg_name"
+        cp -r "$tmp_dest" "$source_dir/docs/build/html/r/$pkg_name"
+        rm -rf "$tmp_dest"
       fi
     done
 

--- a/ci/scripts/docs_build.sh
+++ b/ci/scripts/docs_build.sh
@@ -29,6 +29,11 @@ main() {
     mvn --no-transfer-progress -Pjni site
     popd
 
+    pushd "$source_dir/javascript"
+    npm install --ignore-scripts
+    npx typedoc
+    popd
+
     pushd "$source_dir/docs"
     # The project name/version don't really matter here.
     python "$source_dir/docs/source/ext/doxygen_inventory.py" \
@@ -38,22 +43,33 @@ main() {
            --xml-path "$source_dir/c/apidoc/xml" \
            "cpp/api" \
            "$source_dir/c/apidoc"
+
     python "$source_dir/docs/source/ext/javadoc_inventory.py" \
            "ADBC Java" \
            "version" \
            "$source_dir/java/target/site/apidocs" \
            "java/api"
 
+    python "$source_dir/docs/source/ext/typedoc_inventory.py" \
+           "ADBC JavaScript" \
+           "version" \
+           "$source_dir/javascript/typedoc" \
+           "javascript/api"
+
+
     # We need to determine the base URL without knowing it...
     # Inject a dummy URL here, and fix it up in website_build.sh
     export ADBC_INTERSPHINX_MAPPING_java_adbc="http://javadocs.home.arpa/;$source_dir/java/target/site/apidocs/objects.inv"
     export ADBC_INTERSPHINX_MAPPING_cpp_adbc="http://doxygen.home.arpa/;$source_dir/c/apidoc/objects.inv"
+    export ADBC_INTERSPHINX_MAPPING_js_adbc="http://typedoc.home.arpa/;$source_dir/javascript/typedoc/objects.inv"
 
     sphinx-build --builder html --nitpicky --fail-on-warning --keep-going source build/html
     rm -rf "$source_dir/docs/build/html/cpp/api"
     cp -r "$source_dir/c/apidoc/html" "$source_dir/docs/build/html/cpp/api"
     rm -rf "$source_dir/docs/build/html/java/api"
     cp -r "$source_dir/java/target/site/apidocs" "$source_dir/docs/build/html/java/api"
+    rm -rf "$source_dir/docs/build/html/javascript/api"
+    cp -r "$source_dir/javascript/typedoc" "$source_dir/docs/build/html/javascript/api"
     make doctest
     popd
 
@@ -64,6 +80,7 @@ main() {
       # Python's documentation build can run without installing the R
       # packages). Packages are installed in ci/scripts/r_build.sh
       if Rscript -e "loadNamespace('$pkg_name')" ; then
+        rm -rf "$source_dir/docs/build/html/r/$pkg_name"
         R -e "pkgdown::build_site_github_pages(pkg = '$pkg', dest_dir = '$source_dir/docs/build/html/r/$pkg_name')"
       fi
     done

--- a/ci/scripts/docs_build.sh
+++ b/ci/scripts/docs_build.sh
@@ -80,7 +80,7 @@ main() {
       # Python's documentation build can run without installing the R
       # packages). Packages are installed in ci/scripts/r_build.sh
       if Rscript -e "loadNamespace('$pkg_name')" ; then
-        R -e "pkgdown::build_site(pkg = '$pkg', dest_dir = '$source_dir/docs/build/html/r/$pkg_name', new_process = FALSE, preview = FALSE)"
+        R -e "pkgdown::build_site(pkg = '$pkg', override = list(destination = '$source_dir/docs/build/html/r/$pkg_name'), new_process = FALSE, preview = FALSE)"
       fi
     done
 

--- a/ci/scripts/docs_build.sh
+++ b/ci/scripts/docs_build.sh
@@ -80,17 +80,7 @@ main() {
       # Python's documentation build can run without installing the R
       # packages). Packages are installed in ci/scripts/r_build.sh
       if Rscript -e "loadNamespace('$pkg_name')" ; then
-        # The steps below, aside from the pkgdown::build_site call are to work
-        # around a macOS-specific Docker quirk: build_site internally calls
-        # chmod on `destination` and this fails on macOS with "permission
-        # denied". This is a CI script but it's useful for developers to be able
-        # to run `docker compose run docs` to test the site build locally.
-        local tmp_dest
-        tmp_dest=$(mktemp -d)
-        R -e "pkgdown::build_site(pkg = '$pkg', override = list(destination = '$tmp_dest'), new_process = FALSE, preview = FALSE)"
-        rm -rf "$source_dir/docs/build/html/r/$pkg_name"
-        cp -r "$tmp_dest" "$source_dir/docs/build/html/r/$pkg_name"
-        rm -rf "$tmp_dest"
+        R -e "pkgdown::build_site(pkg = '$pkg', override = list(destination = '$source_dir/docs/build/html/r/$pkg_name'), new_process = FALSE, preview = FALSE)"
       fi
     done
 

--- a/ci/scripts/docs_build.sh
+++ b/ci/scripts/docs_build.sh
@@ -80,8 +80,7 @@ main() {
       # Python's documentation build can run without installing the R
       # packages). Packages are installed in ci/scripts/r_build.sh
       if Rscript -e "loadNamespace('$pkg_name')" ; then
-        rm -rf "$source_dir/docs/build/html/r/$pkg_name"
-        R -e "pkgdown::build_site_github_pages(pkg = '$pkg', dest_dir = '$source_dir/docs/build/html/r/$pkg_name')"
+        R -e "pkgdown::build_site(pkg = '$pkg', dest_dir = '$source_dir/docs/build/html/r/$pkg_name', new_process = FALSE, preview = FALSE)"
       fi
     done
 

--- a/ci/scripts/website_build.sh
+++ b/ci/scripts/website_build.sh
@@ -67,6 +67,7 @@ main() {
     # Assumes GNU sed
     sed -i "s|http://javadocs.home.arpa/|https://arrow.apache.org/adbc/${directory}/|g" $(grep -Rl javadocs.home.arpa "${site}/${directory}/")
     sed -i "s|http://doxygen.home.arpa/|https://arrow.apache.org/adbc/${directory}/|g" $(grep -Rl doxygen.home.arpa "${site}/${directory}/")
+    sed -i "s|http://typedoc.home.arpa/|https://arrow.apache.org/adbc/${directory}/|g" $(grep -Rl typedoc.home.arpa "${site}/${directory}/")
     git -C "${site}" add --force "${directory}"
 
     # Copy the version script and regenerate the version list

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,6 +49,8 @@ extensions = [
     "sphinx_recipe",
     # generic directives to enable intersphinx for java
     "adbc_java_domain",
+    # generic directives to enable intersphinx for javascript
+    "adbc_js_domain",
     "numpydoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",

--- a/docs/source/ext/adbc_js_domain.py
+++ b/docs/source/ext/adbc_js_domain.py
@@ -28,7 +28,9 @@ def setup(app: Sphinx) -> dict[str, typing.Any]:
     app.add_object_type("jsclass", "jsclass", objname="JavaScript Class")
     app.add_object_type("jsinterface", "jsinterface", objname="JavaScript Interface")
     app.add_object_type("jsenum", "jsenum", objname="JavaScript Enum")
-    app.add_object_type("jsenummember", "jsenummember", objname="JavaScript Enum Member")
+    app.add_object_type(
+        "jsenummember", "jsenummember", objname="JavaScript Enum Member"
+    )
     app.add_object_type("jsvariable", "jsvariable", objname="JavaScript Variable")
     app.add_object_type("jsfunction", "jsfunction", objname="JavaScript Function")
     app.add_object_type("jstypealias", "jstypealias", objname="JavaScript Type Alias")
@@ -36,7 +38,9 @@ def setup(app: Sphinx) -> dict[str, typing.Any]:
     app.add_object_type("jsmodule", "jsmodule", objname="JavaScript Module")
     app.add_object_type("jsproperty", "jsproperty", objname="JavaScript Property")
     app.add_object_type("jsmethod", "jsmethod", objname="JavaScript Method")
-    app.add_object_type("jsconstructor", "jsconstructor", objname="JavaScript Constructor")
+    app.add_object_type(
+        "jsconstructor", "jsconstructor", objname="JavaScript Constructor"
+    )
     app.add_object_type("jsaccessor", "jsaccessor", objname="JavaScript Accessor")
     return {
         "version": "0.1",

--- a/docs/source/ext/adbc_js_domain.py
+++ b/docs/source/ext/adbc_js_domain.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Object types for cross-referencing TypeDoc-generated JavaScript API docs."""
+
+import typing
+
+from sphinx.application import Sphinx
+
+
+def setup(app: Sphinx) -> dict[str, typing.Any]:
+    # XXX: despite documentation, these are added to 'std' domain not 'rst'
+    # domain (look at the source) — matching what typedoc_inventory.py writes.
+    app.add_object_type("jsclass", "jsclass", objname="JavaScript Class")
+    app.add_object_type("jsinterface", "jsinterface", objname="JavaScript Interface")
+    app.add_object_type("jsenum", "jsenum", objname="JavaScript Enum")
+    app.add_object_type("jsenummember", "jsenummember", objname="JavaScript Enum Member")
+    app.add_object_type("jsvariable", "jsvariable", objname="JavaScript Variable")
+    app.add_object_type("jsfunction", "jsfunction", objname="JavaScript Function")
+    app.add_object_type("jstypealias", "jstypealias", objname="JavaScript Type Alias")
+    app.add_object_type("jsnamespace", "jsnamespace", objname="JavaScript Namespace")
+    app.add_object_type("jsmodule", "jsmodule", objname="JavaScript Module")
+    app.add_object_type("jsproperty", "jsproperty", objname="JavaScript Property")
+    app.add_object_type("jsmethod", "jsmethod", objname="JavaScript Method")
+    app.add_object_type("jsconstructor", "jsconstructor", objname="JavaScript Constructor")
+    app.add_object_type("jsaccessor", "jsaccessor", objname="JavaScript Accessor")
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/source/ext/typedoc_inventory.py
+++ b/docs/source/ext/typedoc_inventory.py
@@ -1,0 +1,192 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Generate a Sphinx inventory for a TypeDoc HTML site.
+
+TypeDoc outputs HTML pages whose URLs follow a predictable pattern based on
+the reflection kind and the module.Name structure.  This script walks the
+TypeDoc JSON output, derives the URL for each symbol, and writes a Sphinx
+``objects.inv`` file that can be used with intersphinx.
+
+Usage::
+
+    python typedoc_inventory.py "ADBC JavaScript" "version" \\
+        /path/to/typedoc/output javascript/api
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import sphinx.util.inventory
+from fake_inventory import (
+    FakeBuildEnvironment,
+    FakeBuilder,
+    FakeDomain,
+    FakeDomainsContainer,
+    FakeEnv,
+    FakeObject,
+)
+
+# TypeDoc reflection kind constants
+# https://typedoc.org/api/enums/Models.ReflectionKind.html
+_KIND_MODULE = 2
+_KIND_NAMESPACE = 4
+_KIND_ENUM = 8
+_KIND_ENUM_MEMBER = 16
+_KIND_VARIABLE = 32
+_KIND_FUNCTION = 64
+_KIND_CLASS = 128
+_KIND_INTERFACE = 256
+_KIND_CONSTRUCTOR = 512
+_KIND_PROPERTY = 1024
+_KIND_METHOD = 2048
+_KIND_ACCESSOR = 262144
+_KIND_TYPE_ALIAS = 2097152
+
+# Map TypeDoc kind → (Sphinx object type, HTML subdirectory)
+# Subdirectory is None for members that live on their parent's page.
+_KIND_INFO: dict[int, tuple[str, str | None]] = {
+    _KIND_CLASS: ("jsclass", "classes"),
+    _KIND_INTERFACE: ("jsinterface", "interfaces"),
+    _KIND_ENUM: ("jsenum", "enums"),
+    _KIND_VARIABLE: ("jsvariable", "variables"),
+    _KIND_FUNCTION: ("jsfunction", "functions"),
+    _KIND_TYPE_ALIAS: ("jstypealias", "types"),
+    _KIND_NAMESPACE: ("jsnamespace", "modules"),
+    _KIND_MODULE: ("jsmodule", "modules"),
+    # Members live on the parent page
+    _KIND_PROPERTY: ("jsproperty", None),
+    _KIND_METHOD: ("jsmethod", None),
+    _KIND_CONSTRUCTOR: ("jsconstructor", None),
+    _KIND_ENUM_MEMBER: ("jsenummember", None),
+    _KIND_ACCESSOR: ("jsaccessor", None),
+}
+
+
+def _walk(
+    reflection: dict,
+    base_url: str,
+    objects: list[FakeObject],
+    module_name: str = "",
+    parent_page: str = "",
+    parent_name: str = "",
+) -> None:
+    """Recursively walk the TypeDoc reflection tree and emit FakeObjects."""
+    kind = reflection.get("kind", 0)
+    name = reflection.get("name", "")
+
+    if not name:
+        return
+
+    kind_info = _KIND_INFO.get(kind)
+
+    if kind == _KIND_MODULE:
+        # Descend into the module, passing its name as context
+        for child in reflection.get("children", []):
+            _walk(child, base_url, objects, module_name=name, parent_page="", parent_name="")
+        return
+
+    if kind_info is None:
+        # Unknown/uninteresting kind – still descend
+        for child in reflection.get("children", []):
+            _walk(child, base_url, objects, module_name, parent_page, parent_name)
+        return
+
+    sphinx_type, subdir = kind_info
+    full_name = f"{parent_name}.{name}" if parent_name else name
+
+    if subdir is not None:
+        # Top-level symbol: has its own HTML page
+        page = f"{base_url}{subdir}/{module_name}.{name}.html"
+        anchor = ""
+    else:
+        # Member: fragment on the parent's page
+        page = parent_page
+        anchor = name.lower()
+
+    objects.append(
+        FakeObject(
+            name=full_name,
+            dispname=full_name,
+            typ=sphinx_type,
+            docname=page,
+            anchor=anchor,
+            prio=1,
+        )
+    )
+
+    # Recurse into children (class/interface members, enum members, etc.)
+    child_page = page if subdir is None else f"{base_url}{subdir}/{module_name}.{name}.html"
+    for child in reflection.get("children", []):
+        _walk(child, base_url, objects, module_name, child_page, full_name)
+
+
+def make_fake_domains(root: Path, base_url: str) -> dict[str, FakeDomain]:
+    """Parse TypeDoc JSON and return fake Sphinx domains."""
+    if not base_url.endswith("/"):
+        base_url += "/"
+
+    json_path = root / "typedoc.json"
+    if not json_path.exists():
+        raise FileNotFoundError(
+            f"TypeDoc JSON not found at {json_path}. Did you run TypeDoc?"
+        )
+
+    with open(json_path) as f:
+        data = json.load(f)
+
+    objects: list[FakeObject] = []
+    for child in data.get("children", []):
+        _walk(child, base_url, objects)
+
+    return {"std": FakeDomain("std", objects=objects)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate a Sphinx objects.inv from TypeDoc JSON+HTML output."
+    )
+    parser.add_argument("project", help="Project name.")
+    parser.add_argument("version", help="Project version.")
+    parser.add_argument(
+        "path",
+        type=Path,
+        help="Path to the TypeDoc output directory (must contain typedoc.json).",
+    )
+    parser.add_argument("url", help="Eventual base URL of the TypeDoc HTML site.")
+    args = parser.parse_args()
+
+    domains = make_fake_domains(args.path, args.url)
+    config = FakeEnv(project=args.project, version=args.version)
+    env = FakeBuildEnvironment(
+        config=config, domains=FakeDomainsContainer.from_dict(domains)
+    )
+
+    output = args.path / "objects.inv"
+    sphinx.util.inventory.InventoryFile.dump(
+        str(output),
+        env,
+        FakeBuilder(),
+    )
+    print("Wrote", output)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/ext/typedoc_inventory.py
+++ b/docs/source/ext/typedoc_inventory.py
@@ -100,7 +100,14 @@ def _walk(
     if kind == _KIND_MODULE:
         # Descend into the module, passing its name as context
         for child in reflection.get("children", []):
-            _walk(child, base_url, objects, module_name=name, parent_page="", parent_name="")
+            _walk(
+                child,
+                base_url,
+                objects,
+                module_name=name,
+                parent_page="",
+                parent_name="",
+            )
         return
 
     if kind_info is None:
@@ -133,7 +140,9 @@ def _walk(
     )
 
     # Recurse into children (class/interface members, enum members, etc.)
-    child_page = page if subdir is None else f"{base_url}{subdir}/{module_name}.{name}.html"
+    child_page = (
+        page if subdir is None else f"{base_url}{subdir}/{module_name}.{name}.html"
+    )
     for child in reflection.get("children", []):
         _walk(child, base_url, objects, module_name, child_page, full_name)
 

--- a/docs/source/javascript/api/index.rst
+++ b/docs/source/javascript/api/index.rst
@@ -1,0 +1,23 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+========================
+JavaScript API Reference
+========================
+
+This is a stub page for the TypeDoc API reference. If you're seeing this page,
+it means that the actual TypeDoc output was not generated.

--- a/docs/source/javascript/index.rst
+++ b/docs/source/javascript/index.rst
@@ -29,3 +29,4 @@ with `Node.js <https://nodejs.org/en>`_ 22+, `Deno <https://deno.com/>`_ 2.0+, a
 
    quickstart
    driver_manager
+   api/index

--- a/docs/source/javascript/quickstart.rst
+++ b/docs/source/javascript/quickstart.rst
@@ -65,9 +65,10 @@ For apt and dnf packages, see :doc:`/driver/installation`.
 Creating a Database and Connection
 ==================================
 
-The entry point is ``AdbcDatabase``.  Pass a ``driver`` option to identify the
-backend — either a short name (resolved via :doc:`/format/driver_manifests`
-search paths) or absolute path to a driver shared library:
+The entry point is :external+js_adbc:jsclass:`AdbcDatabase`.  Pass a ``driver``
+option to identify the backend — either a short name (resolved via
+:doc:`/format/driver_manifests` search paths) or absolute path to a driver
+shared library:
 
 .. code-block:: javascript
 
@@ -80,17 +81,18 @@ search paths) or absolute path to a driver shared library:
 Executing a Query
 =================
 
-To run a query, use ``AdbcConnection.query``, which returns an Apache Arrow
-``Table`` containing the full result:
+To run a query, use :external+js_adbc:jsmethod:`AdbcConnection.query`, which
+returns an Apache Arrow ``Table`` containing the full result:
 
 .. code-block:: javascript
 
    const table = await conn.query("SELECT 1 AS id, 'hello' AS greeting");
    console.log(table.getChild('greeting')?.get(0));  // "hello"
 
-For large result sets, use ``AdbcConnection.queryStream`` instead. It
-returns a ``RecordBatchReader`` that yields results one batch at a time without
-loading the entire result into memory:
+For large result sets, use
+:external+js_adbc:jsmethod:`AdbcConnection.queryStream` instead. It returns a
+``RecordBatchReader`` that yields results one batch at a time without loading
+the entire result into memory:
 
 .. code-block:: javascript
 
@@ -102,8 +104,9 @@ loading the entire result into memory:
 Executing Updates
 =================
 
-Use ``AdbcConnection.execute`` to execute statements that do not return rows
-(INSERT, UPDATE, DELETE, DDL).  It returns the number of rows affected:
+Use :external+js_adbc:jsmethod:`AdbcConnection.execute` to execute statements
+that do not return rows (INSERT, UPDATE, DELETE, DDL).  It returns the number of
+rows affected:
 
 .. code-block:: javascript
 
@@ -128,7 +131,8 @@ the bind parameters (``?`` placeholders) in the SQL statement:
    const result = await conn.query('SELECT name FROM users WHERE id = ?', params);
    console.log(result.getChild('name')?.get(0));  // "Alice"
 
-The same approach works with ``AdbcConnection.execute`` for DML:
+The same approach works with :external+js_adbc:jsmethod:`AdbcConnection.execute`
+for DML:
 
 .. code-block:: javascript
 
@@ -138,8 +142,10 @@ The same approach works with ``AdbcConnection.execute`` for DML:
 Ingesting Bulk Data
 ===================
 
-``AdbcConnection.ingest`` inserts an Arrow ``Table`` into a database
-table in a single call, avoiding per-row overhead:
+:external+js_adbc:jsmethod:`AdbcConnection.ingest` inserts an Arrow ``Table``
+into a database table in a single call, avoiding per-row overhead.  Pass a
+``mode`` option using :external+js_adbc:jsenum:`IngestMode` to control whether
+to create a new table or append to an existing one:
 
 .. code-block:: javascript
 
@@ -158,8 +164,9 @@ table in a single call, avoiding per-row overhead:
    const more = tableFromArrays({ id: [4], name: ['dave'] });
    await conn.ingest('sample', more, { mode: IngestMode.Append });
 
-For datasets that do not fit in memory use ``AdbcConnection.ingestStream`` with
-a ``RecordBatchReader``:
+For datasets that do not fit in memory use
+:external+js_adbc:jsmethod:`AdbcConnection.ingestStream` with a
+``RecordBatchReader``:
 
 .. code-block:: javascript
 
@@ -172,8 +179,8 @@ a ``RecordBatchReader``:
 Getting Database Metadata
 =========================
 
-``AdbcConnection.getObjects`` returns a nested Arrow structure describing all
-catalogs, schemas, and tables in the database:
+:external+js_adbc:jsmethod:`AdbcConnection.getObjects` returns a nested Arrow
+structure describing all catalogs, schemas, and tables in the database:
 
 .. code-block:: javascript
 
@@ -183,15 +190,16 @@ catalogs, schemas, and tables in the database:
    const tables = dbSchemas?.get(0)?.db_schema_tables;
    console.log(tables?.get(0)?.table_name);  // "sample"
 
-``AdbcConnection.getTableSchema`` returns the Arrow schema for a specific table:
+:external+js_adbc:jsmethod:`AdbcConnection.getTableSchema` returns the Arrow
+schema for a specific table:
 
 .. code-block:: javascript
 
    const schema = await conn.getTableSchema({ tableName: 'sample' });
    console.log(schema.fields.map(f => f.name));  // ["id", "name"]
 
-``AdbcConnection.getTableTypes`` lists the types of table objects supported by
-the database:
+:external+js_adbc:jsmethod:`AdbcConnection.getTableTypes` lists the types of
+table objects supported by the database:
 
 .. code-block:: javascript
 
@@ -205,8 +213,11 @@ the database:
 Transactions
 ============
 
-By default, connections operate in autocommit mode.  Disable autocommit to
-manage transactions manually:
+By default, connections operate in autocommit mode.  Call
+:external+js_adbc:jsmethod:`AdbcConnection.setAutoCommit` with ``false`` to
+manage transactions manually, then use
+:external+js_adbc:jsmethod:`AdbcConnection.commit` or
+:external+js_adbc:jsmethod:`AdbcConnection.rollback`:
 
 .. code-block:: javascript
 
@@ -221,9 +232,10 @@ manage transactions manually:
 Low-Level Statement API
 =======================
 
-``AdbcStatement`` gives direct access to ADBC's statement lifecycle for use
-cases that require more control, such as binding parameters separately from
-execution or reusing a statement across multiple queries:
+:external+js_adbc:jsclass:`AdbcStatement` gives direct access to ADBC's
+statement lifecycle for use cases that require more control, such as binding
+parameters separately from execution or reusing a statement across multiple
+queries:
 
 .. code-block:: javascript
 

--- a/docs/source/javascript/quickstart.rst
+++ b/docs/source/javascript/quickstart.rst
@@ -144,7 +144,7 @@ Ingesting Bulk Data
 
 :external+js_adbc:jsmethod:`AdbcConnection.ingest` inserts an Arrow ``Table``
 into a database table in a single call, avoiding per-row overhead.  Pass a
-``mode`` option using :external+js_adbc:jsenum:`IngestMode` to control whether
+``mode`` option using :external+js_adbc:jsvariable:`IngestMode` to control whether
 to create a new table or append to an existing one:
 
 .. code-block:: javascript

--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -24,3 +24,4 @@ binding.js
 binding.mjs
 index.js
 index.d.ts
+typedoc

--- a/javascript/lib/index.ts
+++ b/javascript/lib/index.ts
@@ -121,6 +121,7 @@ export class AdbcDatabase implements AdbcDatabaseInterface {
 export class AdbcConnection implements AdbcConnectionInterface {
   private _inner: NativeAdbcConnection
 
+  /** @internal */
   constructor(inner: NativeAdbcConnection) {
     this._inner = inner
   }
@@ -324,6 +325,7 @@ export class AdbcConnection implements AdbcConnectionInterface {
 export class AdbcStatement implements AdbcStatementInterface {
   private _inner: NativeAdbcStatement
 
+  /** @internal */
   constructor(inner: NativeAdbcStatement) {
     this._inner = inner
   }

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1884,6 +1884,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2412,7 +2413,6 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
       "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -2442,15 +2442,13 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
       "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/command-line-usage": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2467,7 +2465,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.15.tgz",
       "integrity": "sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2554,7 +2551,6 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
       "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -2607,7 +2603,6 @@
       "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
       "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2"
       },
@@ -2623,7 +2618,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2639,7 +2633,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2705,7 +2698,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2717,8 +2709,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -2732,7 +2723,6 @@
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
       "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "find-replace": "^5.0.2",
@@ -2756,7 +2746,6 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
       "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "chalk-template": "^0.4.0",
@@ -2965,7 +2954,6 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
       "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -2982,8 +2970,7 @@
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3031,7 +3018,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3096,7 +3082,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
       "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
-      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -3250,8 +3235,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -3669,7 +3653,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3682,7 +3665,6 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
       "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "wordwrapjs": "^5.1.0"
@@ -3770,6 +3752,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3783,7 +3766,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
       "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -3799,8 +3781,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
@@ -3814,7 +3795,6 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
       "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -33,6 +33,21 @@
         "apache-arrow": "^21.1.0"
       }
     },
+    "node_modules/@apache-arrow/adbc-driver-manager-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-linux-arm64-gnu": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-linux-x64-gnu": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-win32-x64-msvc": {
+      "optional": true
+    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -1869,6 +1884,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2397,7 +2413,6 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
       "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -2427,15 +2442,13 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
       "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/command-line-usage": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2452,7 +2465,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.15.tgz",
       "integrity": "sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2539,7 +2551,6 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
       "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -2592,7 +2603,6 @@
       "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
       "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2"
       },
@@ -2608,7 +2618,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2624,7 +2633,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2690,7 +2698,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2702,8 +2709,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -2717,7 +2723,6 @@
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
       "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "find-replace": "^5.0.2",
@@ -2741,7 +2746,6 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
       "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "chalk-template": "^0.4.0",
@@ -2950,7 +2954,6 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
       "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -2967,8 +2970,7 @@
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3016,7 +3018,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3081,7 +3082,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
       "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
-      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -3235,8 +3235,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -3654,7 +3653,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3667,7 +3665,6 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
       "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "wordwrapjs": "^5.1.0"
@@ -3755,6 +3752,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3768,7 +3766,6 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
       "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -3784,8 +3781,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
@@ -3799,7 +3795,6 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
       "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -33,21 +33,6 @@
         "apache-arrow": "^21.1.0"
       }
     },
-    "node_modules/@apache-arrow/adbc-driver-manager-darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-darwin-x64": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-linux-arm64-gnu": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-linux-x64-gnu": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-win32-x64-msvc": {
-      "optional": true
-    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -1884,7 +1869,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2413,6 +2397,7 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
       "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -2442,13 +2427,15 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
       "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/command-line-usage": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2465,6 +2452,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.15.tgz",
       "integrity": "sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2551,6 +2539,7 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
       "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -2603,6 +2592,7 @@
       "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
       "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2"
       },
@@ -2618,6 +2608,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2633,6 +2624,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2698,6 +2690,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2709,7 +2702,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -2723,6 +2717,7 @@
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
       "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "find-replace": "^5.0.2",
@@ -2746,6 +2741,7 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
       "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "chalk-template": "^0.4.0",
@@ -2954,6 +2950,7 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
       "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -2970,7 +2967,8 @@
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3018,6 +3016,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3082,6 +3081,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
       "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -3235,7 +3235,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -3653,6 +3654,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3665,6 +3667,7 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
       "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "wordwrapjs": "^5.1.0"
@@ -3752,7 +3755,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3766,6 +3768,7 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
       "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -3781,7 +3784,8 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
@@ -3795,6 +3799,7 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
       "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -33,21 +33,6 @@
         "apache-arrow": "^21.1.0"
       }
     },
-    "node_modules/@apache-arrow/adbc-driver-manager-darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-darwin-x64": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-linux-arm64-gnu": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-linux-x64-gnu": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-win32-x64-msvc": {
-      "optional": true
-    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -16,6 +16,7 @@
         "oxlint": "^1.14.0",
         "prettier": "^3.6.2",
         "tsx": "^4.0.0",
+        "typedoc": "^0.28.0",
         "typescript": "^5.9.2"
       },
       "engines": {
@@ -31,6 +32,21 @@
       "peerDependencies": {
         "apache-arrow": "^21.1.0"
       }
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-linux-arm64-gnu": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-linux-x64-gnu": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-win32-x64-msvc": {
+      "optional": true
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -506,6 +522,20 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -2328,6 +2358,55 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
@@ -2373,6 +2452,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.10.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.15.tgz",
@@ -2382,6 +2471,13 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
@@ -2463,12 +2559,35 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -2697,6 +2816,19 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -2976,6 +3108,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "16.2.7",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
@@ -3182,6 +3324,38 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -3207,6 +3381,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -3351,6 +3541,16 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -3540,6 +3740,30 @@
         "website"
       ]
     },
+    "node_modules/typedoc": {
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3563,6 +3787,13 @@
       "engines": {
         "node": ">=12.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -16,7 +16,6 @@
         "oxlint": "^1.14.0",
         "prettier": "^3.6.2",
         "tsx": "^4.0.0",
-        "typedoc": "^0.28.0",
         "typescript": "^5.9.2"
       },
       "engines": {
@@ -32,21 +31,6 @@
       "peerDependencies": {
         "apache-arrow": "^21.1.0"
       }
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-darwin-x64": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-linux-arm64-gnu": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-linux-x64-gnu": {
-      "optional": true
-    },
-    "node_modules/@apache-arrow/adbc-driver-manager-win32-x64-msvc": {
-      "optional": true
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -522,20 +506,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
-      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.23.0",
-        "@shikijs/langs": "^3.23.0",
-        "@shikijs/themes": "^3.23.0",
-        "@shikijs/types": "^3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -2358,55 +2328,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "node_modules/@shikijs/langs": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@shikijs/themes": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/@shikijs/vscode-textmate": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
-      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
@@ -2452,16 +2373,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "24.10.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.15.tgz",
@@ -2471,13 +2382,6 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
-    },
-    "node_modules/@types/unist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
@@ -2559,35 +2463,12 @@
         "node": ">=12.17"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -2816,19 +2697,6 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -3108,16 +2976,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/lint-staged": {
       "version": "16.2.7",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
@@ -3324,38 +3182,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -3381,22 +3207,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -3541,16 +3351,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -3740,30 +3540,6 @@
         "website"
       ]
     },
-    "node_modules/typedoc": {
-      "version": "0.28.19",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
-      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@gerrit0/mini-shiki": "^3.23.0",
-        "lunr": "^2.3.9",
-        "markdown-it": "^14.1.1",
-        "minimatch": "^10.2.5",
-        "yaml": "^2.8.3"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 18",
-        "pnpm": ">= 10"
-      },
-      "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3787,13 +3563,6 @@
       "engines": {
         "node": ">=12.17"
       }
-    },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -16,6 +16,7 @@
         "oxlint": "^1.14.0",
         "prettier": "^3.6.2",
         "tsx": "^4.0.0",
+        "typedoc": "^0.28.0",
         "typescript": "^5.9.2"
       },
       "engines": {
@@ -31,6 +32,21 @@
       "peerDependencies": {
         "apache-arrow": "^21.1.0"
       }
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-linux-arm64-gnu": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-linux-x64-gnu": {
+      "optional": true
+    },
+    "node_modules/@apache-arrow/adbc-driver-manager-win32-x64-msvc": {
+      "optional": true
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -506,6 +522,20 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -1854,6 +1884,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2328,12 +2359,60 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
       "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -2363,25 +2442,39 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
       "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/command-line-usage": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "24.10.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.15.tgz",
       "integrity": "sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
@@ -2458,9 +2551,18 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
       "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/before-after-hook": {
@@ -2469,6 +2571,19 @@
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -2488,7 +2603,6 @@
       "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
       "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2"
       },
@@ -2504,7 +2618,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2520,7 +2633,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2586,7 +2698,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2598,8 +2709,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -2613,7 +2723,6 @@
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
       "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "find-replace": "^5.0.2",
@@ -2637,7 +2746,6 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
       "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "chalk-template": "^0.4.0",
@@ -2697,6 +2805,19 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -2833,7 +2954,6 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
       "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -2850,8 +2970,7 @@
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2899,7 +3018,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2964,7 +3082,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
       "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
-      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -2975,6 +3092,16 @@
       "integrity": "sha512-QObKu6nxy7NsxqR0VK4rkXnsNr5L9ElJaGEg+ucJ6J7/suoKZ0n+p76cu9aCqowytxEbwYNzvrMerfMkXneF5A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/lint-staged": {
       "version": "16.2.7",
@@ -3108,8 +3235,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -3182,6 +3308,38 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -3207,6 +3365,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -3353,6 +3527,16 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3469,7 +3653,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3482,7 +3665,6 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
       "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "wordwrapjs": "^5.1.0"
@@ -3540,12 +3722,37 @@
         "website"
       ]
     },
+    "node_modules/typedoc": {
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3559,17 +3766,22 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
       "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
@@ -3583,7 +3795,6 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
       "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.17"
       }

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1884,7 +1884,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -2413,6 +2412,7 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
       "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -2442,13 +2442,15 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
       "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/command-line-usage": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2465,6 +2467,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.15.tgz",
       "integrity": "sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2551,6 +2554,7 @@
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
       "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -2603,6 +2607,7 @@
       "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
       "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.2"
       },
@@ -2618,6 +2623,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2633,6 +2639,7 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2698,6 +2705,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2709,7 +2717,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -2723,6 +2732,7 @@
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
       "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "find-replace": "^5.0.2",
@@ -2746,6 +2756,7 @@
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
       "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "chalk-template": "^0.4.0",
@@ -2954,6 +2965,7 @@
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
       "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -2970,7 +2982,8 @@
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3018,6 +3031,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3082,6 +3096,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
       "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -3235,7 +3250,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -3653,6 +3669,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3665,6 +3682,7 @@
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
       "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "wordwrapjs": "^5.1.0"
@@ -3752,7 +3770,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3766,6 +3783,7 @@
       "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
       "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }
@@ -3781,7 +3799,8 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
@@ -3795,6 +3814,7 @@
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
       "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17"
       }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -46,6 +46,7 @@
     "check": "npm run check:js && npm run check:rust",
     "check:js": "prettier --check . && oxlint . && tsc --noEmit",
     "check:rust": "cargo fmt -- --check && cargo clippy -- -D warnings",
+    "docs": "typedoc",
     "test": "tsx --test __test__/*.spec.ts",
     "preversion": "napi build --platform --esm && git add .",
     "version": "napi version",
@@ -53,6 +54,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.2.0",
+    "typedoc": "^0.28.0",
     "@taplo/cli": "^0.7.0",
     "tsx": "^4.0.0",
     "husky": "^9.1.7",

--- a/javascript/typedoc.json
+++ b/javascript/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["lib/index.ts", "lib/types.ts", "lib/error.ts"],
+  "out": "typedoc",
+  "json": "typedoc/typedoc.json",
+  "name": "ADBC JavaScript Driver Manager",
+  "skipErrorChecking": true,
+  "excludeInternal": true,
+  "sort": ["source-order"]
+}


### PR DESCRIPTION
Adds TypeDoc docs for the JS implementation and an intersphinx config to integrate it with the Sphinx docs. There's a sphinx-js package but when I tried to integrate it with our conda environment I ran into all kinds of compatibility issues. I had an agent build a manual system like we already have for Java and it seems to work well enough.

Follow on to https://github.com/apache/arrow-adbc/pull/4232
Closes #4237 