### PR TITLE
chore: update SQLite3 target with add alias for backwards compatibility

### DIFF
--- a/c/driver/sqlite/CMakeLists.txt
+++ b/c/driver/sqlite/CMakeLists.txt
@@ -17,7 +17,12 @@
 
 find_package(SQLite3)
 if(SQLite3_FOUND)
-  set(SQLite3_LINK_LIBRARIES SQLite::SQLite3)
+  # SQLite::SQLite3 is deprecated in newer cmake. Alias to support CMake < 4.3.
+  # See https://cmake.org/cmake/help/latest/module/FindSQLite3.html.
+  if(NOT TARGET SQLite3::SQLite3)
+    add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+  endif()
+  set(SQLite3_LINK_LIBRARIES SQLite3::SQLite3)
 else()
   # vcpkg
   find_package(unofficial-sqlite3 CONFIG REQUIRED)

--- a/c/integration/static_test/CMakeLists.txt
+++ b/c/integration/static_test/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(static_test
                               AdbcDriverPostgreSQL::adbc_driver_postgresql_static
                               AdbcDriverSQLite::adbc_driver_sqlite_static
                               PostgreSQL::PostgreSQL
-                              SQLite::SQLite3
+                              SQLite3::SQLite3
                               fmt::fmt
                               nanoarrow::nanoarrow
                               AdbcDriverCommon::adbc_driver_common


### PR DESCRIPTION
When using a newer CMake and building the SQLite driver, you get a warning about using a deprecated target of SQLite::SQLite 3. See recent builds like https://github.com/apache/arrow-adbc/actions/runs/24540510978/job/71745073971#step:9:238.

This patch silences the warning and should maintain a working configure step on new and older CMake versions.