### PR TITLE
ci: analyze workflows with zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore: "
     groups:
@@ -43,6 +45,8 @@ updates:
         patterns:
           - "go.opentelemetry.io/otel"
           - "go.opentelemetry.io/otel/*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "maven"
     directory: "/java/"
     schedule:
@@ -59,6 +63,8 @@ updates:
           - "dep.org.checkerframework*"
           - "org.checkerframework:*"
           - "org.junit:*"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "nuget"
     directory: "/csharp/"
     schedule:
@@ -75,6 +81,8 @@ updates:
       - dependency-name: "System.*"
         update-types:
           - "version-update:semver-major"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "cargo"
     directory: "/rust/"
     schedule:
@@ -87,3 +95,5 @@ updates:
         patterns:
           - "arrow-*"
           - "datafusion*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 # See https://github.com/apache/iceberg/blob/main/.github/workflows/asf-allowlist-check.yml
-name: "Check actions are on ASF allowlist"
+name: "GitHub Actions Checks"
 
 on:
   pull_request:
@@ -28,15 +28,28 @@ on:
     paths:
       - ".github/**"
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
-  asf-allowlist-check:
-    runs-on: ubuntu-slim
+  gha:
+    name: "Analyze Actions"
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
+
+    # Check that actions are pinned and on the ASF allowlist.
     # Intentionally unpinned to always use the latest allowlist from the ASF.
     - uses: apache/infrastructure-actions/allowlist-check@main # zizmor: ignore[unpinned-uses]
+
+    # Analyze workflows with Zizmor
+    - name: Run zizmor 🌈
+      uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+      with:
+        advanced-security: false

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -24,11 +24,14 @@ on:
       - created
       - edited
 
+permissions:
+  contents: read
+
 jobs:
   issue_assign:
     name: "Assign issue"
     permissions:
-      issues: write
+      issues: write  # needed to comment on the issue
     if: github.event.comment.body == 'take'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -54,14 +54,15 @@ jobs:
         os: [ubuntu-latest, windows-2022, macos-15-intel, macos-latest]
     steps:
       - name: Install C#
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: ${{ matrix.dotnet }}
       - name: Checkout ADBC
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           submodules: recursive
+          persist-credentials: false
       - name: Build
         shell: bash
         run: ci/scripts/csharp_build.sh $(pwd)
@@ -84,12 +85,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout ADBC
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           submodules: recursive
+          persist-credentials: false
       - name: Install .NET 10
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           # NativeAOT for our producer requires net10. Using 10.0.x selects
           # the latest available SDK; preview tags may be needed until GA.
@@ -107,7 +109,7 @@ jobs:
             csharp/src/Drivers/Apache/Apache.Arrow.Adbc.Drivers.Apache.Native/Apache.Arrow.Adbc.Drivers.Apache.Native.csproj \
             -c Release -r win-x64
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
       - name: Install Python dependencies

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -73,25 +73,25 @@ jobs:
     name: "pre-commit"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
       - name: Get required Go version
         run: |
           (. .env && echo "GO_VERSION=${GO}") >> $GITHUB_ENV
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
       - name: install golangci-lint
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
       - name: pre-commit (cache)
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/dev_adbc.yml
+++ b/.github/workflows/dev_adbc.yml
@@ -45,13 +45,13 @@ jobs:
     name: "pre-commit"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,7 +57,7 @@ jobs:
     name: "DuckDB Integration Tests"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -66,7 +66,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}
@@ -104,7 +104,7 @@ jobs:
     name: "FlightSQL Integration Tests (Dremio, SQLite, and GizmoSQL)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -116,7 +116,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}
@@ -131,7 +131,7 @@ jobs:
             --file ci/conda_env_cpp.txt \
             --file ci/conda_env_python.txt
           pip install pytest-error-for-skips
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
@@ -181,7 +181,7 @@ jobs:
           # Preinstalled tools use a lot of disk space, free up some space
           # https://github.com/actions/runner-images/issues/2840
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -190,7 +190,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}
@@ -289,7 +289,7 @@ jobs:
     name: "Snowflake Integration Tests"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -301,7 +301,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}
@@ -318,7 +318,7 @@ jobs:
       - name: Work around ASAN issue (GH-1617)
         run: |
           sudo sysctl vm.mmap_rnd_bits=28
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
@@ -328,7 +328,7 @@ jobs:
         env:
           BUILD_ALL: "0"
           BUILD_DRIVER_SNOWFLAKE: "1"
-          ADBC_SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
+          ADBC_SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }} # zizmor: ignore[secrets-outside-env]
         run: |
           ./ci/scripts/cpp_build.sh "$(pwd)" "$(pwd)/build"
           ./ci/scripts/cpp_test.sh "$(pwd)/build"
@@ -337,7 +337,7 @@ jobs:
           BUILD_ALL: "0"
           BUILD_DRIVER_MANAGER: "1"
           BUILD_DRIVER_SNOWFLAKE: "1"
-          ADBC_SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
+          ADBC_SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }} # zizmor: ignore[secrets-outside-env]
         run: |
           ./ci/scripts/python_build.sh "$(pwd)" "$(pwd)/build"
           env BUILD_DRIVER_MANAGER=0 ./ci/scripts/python_test.sh "$(pwd)" "$(pwd)/build"
@@ -346,14 +346,14 @@ jobs:
     name: "FlightSQL C# Interop"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Get required Go version
         run: |
           (. .env && echo "GO_VERSION=${GO}") >> $GITHUB_ENV
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -50,12 +50,12 @@ jobs:
       matrix:
         java: ['11', '17', '21', '25']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
           submodules: recursive
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           cache: "maven"
           distribution: "temurin"
@@ -76,12 +76,12 @@ jobs:
       matrix:
         java: ['21', '25']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
           submodules: recursive
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           cache: "maven"
           distribution: "temurin"
@@ -116,11 +116,11 @@ jobs:
     env:
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           cache: "maven"
           distribution: "temurin"
@@ -132,7 +132,7 @@ jobs:
       - name: Install vcpkg
         run: |
           ./ci/scripts/install_vcpkg.sh $VCPKG_ROOT $VCPKG_VERSION
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
@@ -172,7 +172,7 @@ jobs:
           ls -laR artifacts
           mv artifacts artifacts-${{ matrix.os }}-${{ matrix.arch }}
           tar czf artifacts-${{ matrix.os }}-${{ matrix.arch }}.tgz artifacts-${{ matrix.os }}-${{ matrix.arch }}
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jni-artifacts-${{ matrix.os }}-${{ matrix.arch }}
           retention-days: 7
@@ -185,7 +185,7 @@ jobs:
           find "$VCPKG_ROOT" -name 'build-*.log' -exec cp '{}' ~/logs ';'
       - name: Upload failure logs
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jni-artifacts-${{ matrix.os }}-${{ matrix.arch }}
           retention-days: 7
@@ -204,17 +204,17 @@ jobs:
           - { java: '11', os: macOS, arch: arm64v8, vcpkg_arch: arm64, runner: macos-latest }
           - { java: '25', os: macOS, arch: arm64v8, vcpkg_arch: arm64, runner: macos-latest }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
           submodules: recursive
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: jni-artifacts-*
           merge-multiple: true
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           cache: "maven"
           distribution: "temurin"

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -42,17 +42,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'npm'
@@ -95,12 +98,12 @@ jobs:
     name: Build Node.js ${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'npm'
@@ -122,7 +125,7 @@ jobs:
         working-directory: javascript
         run: codesign --sign - *.node
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bindings-${{ matrix.settings.target }}
           path: javascript/*.node
@@ -147,12 +150,12 @@ jobs:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'npm'
@@ -161,7 +164,7 @@ jobs:
         working-directory: javascript
         run: npm ci --omit=optional
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: bindings-${{ matrix.settings.target }}
           path: javascript

--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -81,7 +81,7 @@ jobs:
       # https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
       CXXFLAGS: "-D_LIBCPP_DISABLE_AVAILABILITY"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -93,7 +93,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}
@@ -106,7 +106,7 @@ jobs:
         run: |
           ./ci/scripts/remamba.sh install -c conda-forge \
             --file ci/conda_env_cpp.txt
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
@@ -141,7 +141,7 @@ jobs:
           cd
           tar czf ~/local.tgz local
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: driver-manager-${{ matrix.os }}
           retention-days: 3
@@ -162,7 +162,7 @@ jobs:
       # https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
       CXXFLAGS: "-D_LIBCPP_DISABLE_AVAILABILITY"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -171,7 +171,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}
@@ -219,7 +219,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -230,14 +230,14 @@ jobs:
       - name: Get required Go version
         run: |
           (. .env && echo "GO_VERSION=${GO}") >> $GITHUB_ENV
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
       - name: Install Meson via Python
@@ -281,7 +281,7 @@ jobs:
     name: "clang-tidy"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -290,7 +290,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}
@@ -327,7 +327,7 @@ jobs:
       # https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
       CXXFLAGS: "-D_LIBCPP_DISABLE_AVAILABILITY"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -336,7 +336,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}
@@ -356,7 +356,7 @@ jobs:
         run: |
           sudo sysctl vm.mmap_rnd_bits=28
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: driver-manager-${{ matrix.os }}
           path: "~"
@@ -399,7 +399,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -408,7 +408,7 @@ jobs:
       # the 'toolchain' parameter and staticcheck tends to need the latest Go
       - id: toolchain
         run: echo "GO_VERSION=$(sed -n 's/^toolchain go//p' go/adbc/go.mod)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ steps.toolchain.outputs.GO_VERSION }}
           check-latest: true
@@ -424,7 +424,7 @@ jobs:
           ./ci/scripts/go_build.sh "$(pwd)" "$(pwd)/build" "$HOME/local"
       - name: Go Test
         env:
-          SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
+          SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }} # zizmor: ignore[secrets-outside-env]
         run: |
           ./ci/scripts/go_test.sh "$(pwd)" "$(pwd)/build" "$HOME/local"
 
@@ -449,7 +449,7 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -461,7 +461,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}
@@ -479,14 +479,14 @@ jobs:
         run: |
           ./ci/scripts/remamba.sh install -c conda-forge \
             --file ci/conda_env_cpp.txt
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: driver-manager-${{ matrix.os }}
           path: "~"
@@ -503,7 +503,7 @@ jobs:
 
       - name: Go Test
         env:
-          SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }}
+          SNOWFLAKE_URI: ${{ secrets.SNOWFLAKE_URI }} # zizmor: ignore[secrets-outside-env]
         run: |
           export PATH=$RUNNER_TOOL_CACHE/go/${GO_VERSION}/${{ matrix.goarch }}/bin:$PATH
           ./ci/scripts/go_test.sh "$(pwd)" "$(pwd)/build" "$HOME/local"
@@ -525,7 +525,7 @@ jobs:
       # https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
       CXXFLAGS: "-D_LIBCPP_DISABLE_AVAILABILITY"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -537,7 +537,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}
@@ -556,14 +556,14 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo sysctl vm.mmap_rnd_bits=28
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: driver-manager-${{ matrix.os }}
           path: "~"
@@ -654,7 +654,7 @@ jobs:
         os: ["ubuntu-latest"]
         python: ["3.14"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -663,7 +663,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/conda_pkgs_dir
           key: conda-${{ runner.os }}-${{ steps.get-date.outputs.today }}-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/**') }}
@@ -683,7 +683,7 @@ jobs:
         run: |
           sudo sysctl vm.mmap_rnd_bits=28
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: driver-manager-${{ matrix.os }}
           path: "~"
@@ -705,7 +705,7 @@ jobs:
         run: |
           ./ci/scripts/docs_build.sh "$(pwd)"
       - name: Archive docs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs
           retention-days: 2

--- a/.github/workflows/native-windows.yml
+++ b/.github/workflows/native-windows.yml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         os: ["windows-latest"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -74,7 +74,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           # Increment this to reset cache manually
           CACHE_NUMBER: 0
@@ -102,7 +102,7 @@ jobs:
         run: |
           .\ci\scripts\cpp_build.ps1 $pwd ${{ github.workspace }}\build
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: driver-manager-${{ matrix.os }}
           retention-days: 3
@@ -119,7 +119,7 @@ jobs:
       matrix:
         os: ["windows-latest"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -129,7 +129,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           # Increment this to reset cache manually
           CACHE_NUMBER: 0
@@ -187,7 +187,7 @@ jobs:
       matrix:
         os: ["windows-latest"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -201,7 +201,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           # Increment this to reset cache manually
           CACHE_NUMBER: 0
@@ -216,14 +216,14 @@ jobs:
         run: |
           mamba install -c conda-forge `
             --file ci\conda_env_cpp.txt
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
           cache: true
           cache-dependency-path: go/adbc/go.sum
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: driver-manager-${{ matrix.os }}
           path: ${{ github.workspace }}/build
@@ -255,7 +255,7 @@ jobs:
         os: ["windows-latest"]
         python: ["3.10", "3.14"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -268,7 +268,7 @@ jobs:
 
       - name: Cache Winlibs
         id: cache-winlibs
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ runner.temp }}/winlibs
           key: winlibs-${{ steps.winlibs-version.outputs.winlibs_asset_name }}
@@ -278,7 +278,7 @@ jobs:
         shell: pwsh
         run: |
           $base_url = "https://github.com/brechtsanders/winlibs_mingw/releases/download/15.2.0posix-13.0.0-ucrt-r4/"
-          $asset_name = "${{ steps.winlibs-version.outputs.winlibs_asset_name }}"
+          $asset_name = "$env:STEPS_WINLIBS_VERSION_OUTPUTS_WINLIBS_ASSET_NAME"
           $hash_expected = "148175f2ba3c4ab0bfd93116b75f7ff172e9e0d06ca8680c8a98c375ec45abb5"
           $url = $base_url + $asset_name
 
@@ -294,6 +294,8 @@ jobs:
           Write-Host "Extracting..."
           7z x $asset_name -o"${{ runner.temp }}/winlibs" -y
           Remove-Item $asset_name -Force
+        env:
+          STEPS_WINLIBS_VERSION_OUTPUTS_WINLIBS_ASSET_NAME: ${{ steps.winlibs-version.outputs.winlibs_asset_name }}
 
       - name: Add Winlibs to PATH
         shell: pwsh
@@ -308,7 +310,7 @@ jobs:
         run: |
           echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Cache Conda
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           # Increment this to reset cache manually
           CACHE_NUMBER: 0
@@ -327,7 +329,7 @@ jobs:
             --file ci\conda_env_cpp.txt `
             --file ci\conda_env_python.txt
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: driver-manager-${{ matrix.os }}
           path: ${{ github.workspace }}/build
@@ -369,7 +371,7 @@ jobs:
         arch: ["x64"]
         config: ["debug", "release"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -50,7 +50,7 @@ jobs:
     if: github.event_name != 'schedule' || github.repository == 'apache/arrow-adbc'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -99,7 +99,7 @@ jobs:
           shasum --algorithm 512 \
             apache-arrow-adbc-${VERSION}.tar.gz > apache-arrow-adbc-${VERSION}.tar.gz.sha512
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: source
           retention-days: 7
@@ -119,7 +119,7 @@ jobs:
       matrix:
         os: ["macos-15-intel", "macos-latest", "ubuntu-latest", "windows-latest"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           path: arrow-adbc
@@ -131,14 +131,14 @@ jobs:
                       grep -E -o '[0-9]+\.[0-9]+\.[0-9]+')
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
           path: ${{ github.workspace }}/apache-arrow-adbc-${{ env.VERSION }}-rc0/
 
       - name: Setup directory structure
         run: |
-          mv apache-arrow-adbc-${{ env.VERSION }}-rc0/KEYS .
+          mv apache-arrow-adbc-${VERSION}-rc0/KEYS .
 
       - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167  # v3.3.0
         # The Unix script will set up conda itself
@@ -205,7 +205,7 @@ jobs:
     name: "Run Docker Tests"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           path: arrow-adbc
@@ -256,7 +256,7 @@ jobs:
           - os: ubuntu
             version: "24.04"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           path: arrow-adbc

--- a/.github/workflows/nightly-website.yml
+++ b/.github/workflows/nightly-website.yml
@@ -36,12 +36,15 @@ defaults:
     # 'bash' will expand to -eo pipefail
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Build Website"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -49,7 +52,7 @@ jobs:
         run: |
           docker compose run docs
       - name: Archive docs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs
           retention-days: 2
@@ -60,27 +63,30 @@ jobs:
     name: "Publish Website"
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      # need write since we push to asf-site
+      contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           path: site
           # NOTE: needed to push at the end
           persist-credentials: true
           ref: asf-site
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           path: scripts
           persist-credentials: false
       - name: Download docs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs
           path: temp
       # To use pip below, we need to install our own Python; the system Python's
       # pip won't let us install packages without a scary flag.
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
       - name: Build

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -55,6 +55,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   source:
     name: Source
@@ -62,7 +65,7 @@ jobs:
     # For cron: only run on the main repo, not forks
     if: github.event_name != 'schedule' || github.repository == 'apache/arrow-adbc'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -84,7 +87,7 @@ jobs:
             apache-arrow-adbc-${VERSION} \
             $(git log -n 1 --format=%h)
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: source
           retention-days: 7
@@ -102,7 +105,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-15-intel"]
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
@@ -120,11 +123,11 @@ jobs:
         run: |
           (. adbc/.env && echo "GO_VERSION=${GO}") >> $GITHUB_ENV
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
-          cache: true
+          cache: false
           cache-dependency-path: adbc/go/adbc/go.sum
 
       # run `make -i` because the Windows runs claim they can't delete the .h files, but they are still generated
@@ -135,7 +138,7 @@ jobs:
           popd
 
       - name: Upload Go binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: go-${{ matrix.os }}
           retention-days: 7
@@ -151,7 +154,7 @@ jobs:
       - go-binaries
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
@@ -168,10 +171,12 @@ jobs:
       - name: Show inputs
         run: |
           echo "upload_artifacts: ${{ inputs.upload_artifacts }}" >> $GITHUB_STEP_SUMMARY
-          echo "schedule: ${{ github.event.schedule }}" >> $GITHUB_STEP_SUMMARY
-          echo "ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "schedule: ${GITHUB_EVENT_SCHEDULE}" >> $GITHUB_STEP_SUMMARY
+          echo "ref: ${GITHUB_REF}" >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: go-*
           path: adbc/go/adbc/pkg
@@ -192,7 +197,7 @@ jobs:
           popd
 
       - name: Archive nupkg
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: csharp
           retention-days: 7
@@ -206,7 +211,7 @@ jobs:
     needs:
       - source
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
@@ -223,8 +228,10 @@ jobs:
       - name: Show inputs
         run: |
           echo "upload_artifacts: ${{ inputs.upload_artifacts }}" >> $GITHUB_STEP_SUMMARY
-          echo "schedule: ${{ github.event.schedule }}" >> $GITHUB_STEP_SUMMARY
-          echo "ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "schedule: ${GITHUB_EVENT_SCHEDULE}" >> $GITHUB_STEP_SUMMARY
+          echo "ref: ${GITHUB_REF}" >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
 
       - name: Build and test
         run: |
@@ -241,7 +248,7 @@ jobs:
           popd
 
       - name: Archive docs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs
           retention-days: 2
@@ -262,7 +269,7 @@ jobs:
           - { os: Windows, arch: amd64, runner: windows-latest }
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
       - name: Extract source archive
@@ -295,7 +302,7 @@ jobs:
           ls -laR artifacts
           mv artifacts artifacts-${{ matrix.os }}-${{ matrix.arch }}
           tar czf artifacts-${{ matrix.os }}-${{ matrix.arch }}.tgz artifacts-${{ matrix.os }}-${{ matrix.arch }}
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jni-artifacts-${{ matrix.os }}-${{ matrix.arch }}
           retention-days: 7
@@ -309,11 +316,11 @@ jobs:
       - source
       - java-jni
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: jni-artifacts-*
@@ -332,8 +339,10 @@ jobs:
       - name: Show inputs
         run: |
           echo "upload_artifacts: ${{ inputs.upload_artifacts }}" >> $GITHUB_STEP_SUMMARY
-          echo "schedule: ${{ github.event.schedule }}" >> $GITHUB_STEP_SUMMARY
-          echo "ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "schedule: ${GITHUB_EVENT_SCHEDULE}" >> $GITHUB_STEP_SUMMARY
+          echo "ref: ${GITHUB_REF}" >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
 
       - name: Build and test
         run: |
@@ -351,7 +360,7 @@ jobs:
           cp -a adbc/dist/ ./
 
       - name: Archive JARs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: java
           retention-days: 7
@@ -376,14 +385,15 @@ jobs:
           - ubuntu-jammy
           - ubuntu-noble
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: apache/arrow
           path: arrow
+          persist-credentials: false
 
       - name: Set output variables
         run: |
@@ -421,11 +431,12 @@ jobs:
           ruby-version: ruby
 
       - name: Cache ccache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: adbc/ci/linux-packages/${{ env.TASK_NAMESPACE }}/build/${{ matrix.target }}/ccache
           key: linux-${{ env.TASK_NAMESPACE }}-ccache-${{ matrix.target }}-{{ "${{ hashFiles('adbc.h', 'c/**', 'glib/**') }}" }}
           restore-keys: linux-${{ env.TASK_NAMESPACE }}-ccache-${{ matrix.target }}-
+          lookup-only: true
 
       - name: Login to GitHub Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
@@ -447,12 +458,12 @@ jobs:
       - name: Prepare artifacts
         run: |
           cp -a \
-            adbc/ci/linux-packages/${{ env.TASK_NAMESPACE }}/repositories/${DISTRIBUTION} \
+            adbc/ci/linux-packages/${TASK_NAMESPACE}/repositories/${DISTRIBUTION} \
             ./
           tar czf ${{ matrix.target }}.tar.gz ${DISTRIBUTION}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.target }}
           retention-days: 7
@@ -506,7 +517,7 @@ jobs:
         # TODO: "linux_aarch64_"
         arch: ["linux_64_"]
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
@@ -523,9 +534,12 @@ jobs:
 
       - name: Show inputs
         run: |
-          echo "upload_artifacts: ${{ github.event.inputs.upload_artifacts }}" >> $GITHUB_STEP_SUMMARY
-          echo "schedule: ${{ github.event.schedule }}" >> GITHUB_STEP_SUMMARY
-          echo "ref: ${{ github.ref }}" >> GITHUB_STEP_SUMMARY
+          echo "upload_artifacts: ${GITHUB_EVENT_INPUTS_UPLOAD_ARTIFACTS}" >> $GITHUB_STEP_SUMMARY
+          echo "schedule: ${GITHUB_EVENT_SCHEDULE}" >> GITHUB_STEP_SUMMARY
+          echo "ref: ${GITHUB_REF}" >> GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_EVENT_INPUTS_UPLOAD_ARTIFACTS: ${{ github.event.inputs.upload_artifacts }}
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
 
       - name: Build Conda package
         env:
@@ -538,7 +552,7 @@ jobs:
           popd
 
       - name: Archive Conda packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-${{ matrix.arch }}-conda
           retention-days: 7
@@ -572,7 +586,7 @@ jobs:
       run:
         shell: bash -l -eo pipefail {0}
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
@@ -589,9 +603,12 @@ jobs:
 
       - name: Show inputs
         run: |
-          echo "upload_artifacts: ${{ github.event.inputs.upload_artifacts }}" >> $GITHUB_STEP_SUMMARY
-          echo "schedule: ${{ github.event.schedule }}" >> $GITHUB_STEP_SUMMARY
-          echo "ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "upload_artifacts: ${GITHUB_EVENT_INPUTS_UPLOAD_ARTIFACTS}" >> $GITHUB_STEP_SUMMARY
+          echo "schedule: ${GITHUB_EVENT_SCHEDULE}" >> $GITHUB_STEP_SUMMARY
+          echo "ref: ${GITHUB_REF}" >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_EVENT_INPUTS_UPLOAD_ARTIFACTS: ${{ github.event.inputs.upload_artifacts }}
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
 
       - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167  # v3.3.0
         with:
@@ -612,7 +629,7 @@ jobs:
           ./adbc/ci/scripts/python_conda_build.sh $(pwd)/adbc ${ARCH_CONDA_FORGE}.yaml $(pwd)/adbc/build
 
       - name: Archive Conda packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-${{ matrix.arch }}-conda
           retention-days: 7
@@ -643,7 +660,7 @@ jobs:
             platform: "linux/arm64/v8"
             runs_on: "ubuntu-24.04-arm"
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
@@ -662,9 +679,12 @@ jobs:
 
       - name: Show inputs
         run: |
-          echo "upload_artifacts: ${{ github.event.inputs.upload_artifacts }}" >> $GITHUB_STEP_SUMMARY
-          echo "schedule: ${{ github.event.schedule }}" >> $GITHUB_STEP_SUMMARY
-          echo "ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "upload_artifacts: ${GITHUB_EVENT_INPUTS_UPLOAD_ARTIFACTS}" >> $GITHUB_STEP_SUMMARY
+          echo "schedule: ${GITHUB_EVENT_SCHEDULE}" >> $GITHUB_STEP_SUMMARY
+          echo "ref: ${GITHUB_REF}" >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_EVENT_INPUTS_UPLOAD_ARTIFACTS: ${{ github.event.inputs.upload_artifacts }}
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
 
       - name: Build wheel
         env:
@@ -682,7 +702,7 @@ jobs:
           popd
 
       - name: Archive wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-${{ matrix.arch }}-manylinux${{ matrix.manylinux_version }}
           retention-days: 7
@@ -761,7 +781,7 @@ jobs:
       # Where to install vcpkg
       VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
@@ -781,9 +801,12 @@ jobs:
 
       - name: Show inputs
         run: |
-          echo "upload_artifacts: ${{ github.event.inputs.upload_artifacts }}" >> $GITHUB_STEP_SUMMARY
-          echo "schedule: ${{ github.event.schedule }}" >> $GITHUB_STEP_SUMMARY
-          echo "ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "upload_artifacts: ${GITHUB_EVENT_INPUTS_UPLOAD_ARTIFACTS}" >> $GITHUB_STEP_SUMMARY
+          echo "schedule: ${GITHUB_EVENT_SCHEDULE}" >> $GITHUB_STEP_SUMMARY
+          echo "ref: ${GITHUB_REF}" >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_EVENT_INPUTS_UPLOAD_ARTIFACTS: ${{ github.event.inputs.upload_artifacts }}
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
 
       - name: Install Homebrew dependencies
         run: brew install autoconf bash pkg-config ninja
@@ -806,11 +829,11 @@ jobs:
         run: |
           (. adbc/.env && echo "GO_VERSION=${GO}") >> $GITHUB_ENV
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
-          cache: true
+          cache: false
           cache-dependency-path: adbc/go/adbc/go.sum
 
       - name: Downgrade XCode
@@ -831,7 +854,7 @@ jobs:
           popd
 
       - name: Archive wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-${{ matrix.arch }}-macos
           retention-days: 7
@@ -920,7 +943,7 @@ jobs:
 
       - name: Upload failure logs
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vcpkg-logs-${{ matrix.os }}-${{ matrix.arch }}
           retention-days: 7
@@ -940,7 +963,7 @@ jobs:
       # Where to install vcpkg
       VCPKG_ROOT: "${{ github.workspace }}\\vcpkg"
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
@@ -964,8 +987,10 @@ jobs:
         shell: pwsh
         run: |
           echo "upload_artifacts: ${{ inputs.upload_artifacts }}" >> $GITHUB_STEP_SUMMARY
-          echo "schedule: ${{ github.event.schedule }}" >> $GITHUB_STEP_SUMMARY
-          echo "ref: ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "schedule: $env:GITHUB_EVENT_SCHEDULE" >> $GITHUB_STEP_SUMMARY
+          echo "ref: $env:GITHUB_REF" >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
 
       - name: Install Chocolatey Dependencies
         shell: pwsh
@@ -989,21 +1014,22 @@ jobs:
           .\bootstrap-vcpkg.bat -disableMetrics
           popd
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true
-          cache: true
+          cache: false
           cache-dependency-path: adbc/go/adbc/go.sum
 
       - name: Install Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           check-latest: true
           python-version: ${{ matrix.python_version }}
 
       - name: Build wheel
-        shell: cmd
+        # TODO(https://github.com/apache/arrow-adbc/issues/4269): remove cmd.exe usage
+        shell: cmd # zizmor: ignore[misfeature]
         run: |
           where python.exe
           CALL "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
@@ -1013,7 +1039,7 @@ jobs:
           popd
 
       - name: Archive wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python${{ matrix.python_version }}-windows
           retention-days: 7
@@ -1026,7 +1052,8 @@ jobs:
             adbc/build/**/*.pdb
 
       - name: Test wheel
-        shell: cmd
+        # TODO(https://github.com/apache/arrow-adbc/issues/4269): remove cmd.exe usage
+        shell: cmd # zizmor: ignore[misfeature]
         env:
           PYTHON_VERSION: ${{ matrix.python_version }}
         run: |
@@ -1043,7 +1070,7 @@ jobs:
     needs:
       - source
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
@@ -1061,9 +1088,12 @@ jobs:
 
       - name: Show inputs
         run: |
-          echo "upload_artifacts: ${{ github.event.inputs.upload_artifacts }}"
-          echo "schedule: ${{ github.event.schedule }}"
-          echo "ref: ${{ github.ref }}"
+          echo "upload_artifacts: ${GITHUB_EVENT_INPUTS_UPLOAD_ARTIFACTS}"
+          echo "schedule: ${GITHUB_EVENT_SCHEDULE}"
+          echo "ref: ${GITHUB_REF}"
+        env:
+          GITHUB_EVENT_INPUTS_UPLOAD_ARTIFACTS: ${{ github.event.inputs.upload_artifacts }}
+          GITHUB_EVENT_SCHEDULE: ${{ github.event.schedule }}
 
       - name: Build sdist
         run: |
@@ -1074,7 +1104,7 @@ jobs:
           popd
 
       - name: Archive sdist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-sdist
           retention-days: 7
@@ -1111,7 +1141,7 @@ jobs:
           - host: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
@@ -1125,11 +1155,10 @@ jobs:
           mv apache-arrow-adbc-${VERSION} adbc
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          cache: 'npm'
-          cache-dependency-path: adbc/javascript/package-lock.json
+          package-manager-cache: false
 
       - name: Setup Rust
         run: |
@@ -1152,7 +1181,7 @@ jobs:
         run: codesign --sign - *.node
 
       - name: Upload Node.js binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bindings-${{ matrix.settings.target }}
           path: adbc/javascript/*.node
@@ -1165,7 +1194,7 @@ jobs:
       - source
       - node-binaries
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source
 
@@ -1179,11 +1208,10 @@ jobs:
           mv apache-arrow-adbc-${VERSION} adbc
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
-          cache: 'npm'
-          cache-dependency-path: adbc/javascript/package-lock.json
+          package-manager-cache: false
 
       - name: Setup Rust
         run: |
@@ -1199,7 +1227,7 @@ jobs:
         run: npm run build:ci && npm run build:ts
 
       - name: Download Node.js binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: bindings-*
           path: adbc/javascript/artifacts
@@ -1219,7 +1247,7 @@ jobs:
           done
 
       - name: Upload Node.js packages
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: node-packages
           retention-days: 7
@@ -1244,7 +1272,7 @@ jobs:
       - python-sdist
     steps:
       - name: Get All Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: release-artifacts
       - name: Release
@@ -1300,13 +1328,13 @@ jobs:
       run:
         shell: bash -l -eo pipefail {0}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: true
           submodules: recursive
       - name: Get All Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: conda-packages
       - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167  # v3.3.0
@@ -1323,14 +1351,14 @@ jobs:
           # Clean all existing packages, OK if we fail
           ./ci/scripts/python_conda_clean.sh
         env:
-          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
       - name: Upload
         run: |
           ls -laR conda-packages
           # Upload fresh packages
           ./ci/scripts/python_conda_upload.sh conda-packages/python-*-conda/*/*.tar.bz2
         env:
-          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
 
   # This takes a while due to sleeping to avoid rate limits, so run it first
   # and in parallel with the builds
@@ -1339,9 +1367,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_name == 'main' && (github.event.schedule || inputs.upload_artifacts)
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.13'
       - name: Clean
@@ -1349,7 +1379,7 @@ jobs:
           pip install requests
           ./ci/scripts/gemfury_clean.py
         env:
-          GEMFURY_API_TOKEN: ${{ secrets.GEMFURY_API_TOKEN }}
+          GEMFURY_API_TOKEN: ${{ secrets.GEMFURY_API_TOKEN }} # zizmor: ignore[secrets-outside-env]
 
   upload-gemfury:
     name: "Upload packages to Gemfury"
@@ -1364,13 +1394,13 @@ jobs:
       - python-windows
       - python-sdist
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: true
           submodules: recursive
       - name: Get All Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: nightly-artifacts
       - name: Upload
@@ -1394,6 +1424,6 @@ jobs:
           # Node.js
           ./ci/scripts/node_npm_upload.sh upload-staging
         env:
-          GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
+          GEMFURY_PUSH_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }} # zizmor: ignore[secrets-outside-env]
           NPM_REGISTRY: https://npm.fury.io/arrow-adbc-nightlies/
-          NPM_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GEMFURY_PUSH_TOKEN }} # zizmor: ignore[secrets-outside-env]

--- a/.github/workflows/r-check.yml
+++ b/.github/workflows/r-check.yml
@@ -48,11 +48,13 @@ jobs:
     runs-on: ${{ inputs.os }}-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Get required Go version
         run: |
           (. .env && echo "GO_VERSION=${GO}") >> $GITHUB_ENV
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
       - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  # v2
@@ -74,9 +76,11 @@ jobs:
           pushd r/adbcdrivermanager
           Rscript bootstrap.R
           popd
-          pushd "r/${{ inputs.pkg }}"
+          pushd "r/${INPUTS_PKG}"
           Rscript bootstrap.R
           popd
+        env:
+          INPUTS_PKG: ${{ inputs.pkg }}
 
       - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590
         with:
@@ -103,7 +107,7 @@ jobs:
 
       - uses: r-lib/actions/check-r-package@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  # v2
         env:
-          ADBC_SNOWFLAKE_TEST_URI: ${{ secrets.SNOWFLAKE_URI }}
+          ADBC_SNOWFLAKE_TEST_URI: ${{ secrets.SNOWFLAKE_URI }} # zizmor: ignore[secrets-outside-env]
           R_KEEP_PKG_SOURCE: yes
         with:
           working-directory: r/${{ inputs.pkg }}

--- a/.github/workflows/r-extended.yml
+++ b/.github/workflows/r-extended.yml
@@ -128,7 +128,9 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590  # v2
         with:
           rversion: ${{ matrix.rversion }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,7 @@ jobs:
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: "-Adead_code" # TODO(alexandreyc): remove this line when implementation is complete
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -85,7 +85,7 @@ jobs:
       - name: Get required Go version
         run: |
           (. ./.env && echo "GO_VERSION=${GO}") >> $GITHUB_ENV
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{ env.GO_VERSION }}"
           check-latest: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         os: ["macos-15-intel", "macos-latest", "ubuntu-latest"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -72,8 +72,10 @@ jobs:
           VERBOSE: "1"
           # Make this available to download_rc_binaries.py
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUTS_VERSION: ${{ inputs.version }}
+          INPUTS_RC: ${{ inputs.rc }}
         run: |
-          ./dev/release/verify-release-candidate.sh ${{ inputs.version }} ${{ inputs.rc }}
+          ./dev/release/verify-release-candidate.sh ${INPUTS_VERSION} ${INPUTS_RC}
 
   source-conda:
     name: "Verify Source (Conda)/${{ matrix.os }}"
@@ -82,7 +84,7 @@ jobs:
       matrix:
         os: ["macos-15-intel", "macos-latest", "ubuntu-latest", "windows-latest"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -124,11 +126,13 @@ jobs:
           TEST_SOURCE: "1"
           USE_CONDA: "1"
           VERBOSE: "1"
+          INPUTS_VERSION: ${{ inputs.version }}
+          INPUTS_RC: ${{ inputs.rc }}
         run: |
           # Required for macOS
           export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
           echo "CXXFLAGS=${CXXFLAGS}"
-          ./dev/release/verify-release-candidate.sh ${{ inputs.version }} ${{ inputs.rc }}
+          ./dev/release/verify-release-candidate.sh ${INPUTS_VERSION} ${INPUTS_RC}
       - name: Verify
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -139,5 +143,7 @@ jobs:
           TEST_SOURCE: "1"
           USE_CONDA: "1"
           VERBOSE: "1"
+          INPUTS_VERSION: ${{ inputs.version }}
+          INPUTS_RC: ${{ inputs.rc }}
         run: |
-          .\dev\release\verify-release-candidate.ps1 ${{ inputs.version }} ${{ inputs.rc }}
+          .\dev\release\verify-release-candidate.ps1 $env:INPUTS_VERSION $env:INPUTS_RC


### PR DESCRIPTION
- Add cooldowns to dependabot.yml
- Pin actions
- Use environment variables instead of directly expanding variables into shell blocks
- Disable caching in `packaging.yml` since this builds binaries
- Add some missing `permissions` and `concurrency` blocks