### PR TITLE
chore(ci): use closer.lua for maven download, bump maven version

### DIFF
--- a/ci/scripts/verify_ubuntu.sh
+++ b/ci/scripts/verify_ubuntu.sh
@@ -25,7 +25,7 @@
 set -euo pipefail
 
 : ${JDK:=21}
-: ${MAVEN:=3.9.14}
+: ${MAVEN:=3.9.15}
 
 main() {
     local -r source_dir="${1}"
@@ -103,7 +103,7 @@ main() {
     echo "============================================================"
     echo "Installing Maven ${MAVEN}..."
     echo "============================================================"
-    wget -O apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/${MAVEN}/binaries/apache-maven-${MAVEN}-bin.tar.gz
+    wget -O apache-maven.tar.gz https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN}/binaries/apache-maven-${MAVEN}-bin.tar.gz?action=download
     mkdir -p /opt/maven
     tar -C /opt/maven -xzvf apache-maven.tar.gz --strip-components=1
     export PATH=/opt/maven/bin:$PATH


### PR DESCRIPTION
Maven released a new version (3.9.15) and that caused our CI to start failing in https://github.com/apache/arrow-adbc/actions/runs/25006855596/job/73231969200?pr=4273 due to a 404.

Bumping the version alone would have fixed CI but I decided to change the URL so it uses the closer.lua mechanism the ASF recommends.