### PR TITLE
chore(ci): fix missing SQLite3::SQLite3 target in cpp-static-test

### DIFF
--- a/c/integration/static_test/CMakeLists.txt
+++ b/c/integration/static_test/CMakeLists.txt
@@ -30,6 +30,12 @@ find_package(AdbcDriverPostgreSQL REQUIRED)
 find_package(AdbcDriverSQLite REQUIRED)
 find_package(AdbcDriverSnowflake REQUIRED)
 
+# Alias SQLite::SQLite3 to SQLite3::SQLite3 if needed. SQLite::SQLite3 is
+# deprecated in CMake < 4.3. See
+# https://cmake.org/cmake/help/latest/module/FindSQLite3.html.
+if(NOT TARGET SQLite3::SQLite3)
+  add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
 find_package(fmt REQUIRED)
 find_package(nanoarrow REQUIRED)
 


### PR DESCRIPTION
In e44eea5236767f913218319da6e393bb9925a7e5 I changed the SQLite3 target for newer cmake but I also needed to update cpp-static-test to handle it. The call to `find_depdencny_sqlite(SQLite3)` in `AdbcDriverSQLiteConfig.cmake` creates the now-deprecated SQLite::SQLite3 target so an alias is needed.

See failing CI: https://github.com/apache/arrow-adbc/actions/runs/25006855596/job/73231969203?pr=4273

```
/adbc/build/static-test/build/test /
-- The C compiler identification is Clang 22.1.0
-- The CXX compiler identification is Clang 22.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PostgreSQL: /usr/lib/x86_64-linux-gnu/libpq.so (found version "15.16")  
-- Found SQLite3: /usr/include (found version "3.40.1") 
-- Found nanoarrow: /adbc/build/static-test/local/lib/cmake/nanoarrow/nanoarrow-config.cmake (found version "0.9.0") 
-- Configuring done
CMake Error at CMakeLists.txt:39 (target_link_libraries):
-- Generating done
  Target "static_test" links to:

    SQLite3::SQLite3
```