### PR TITLE
chore: upgrade Docker image to .NET 10.0 now that there's a build which requires it

### DIFF
--- a/.env
+++ b/.env
@@ -35,7 +35,7 @@ PLATFORM=linux/amd64
 PYTHON=3.13
 GO=1.26.1
 ARROW_MAJOR_VERSION=18
-DOTNET=8.0
+DOTNET=10.0
 
 # Used through compose.yaml and serves as the default version for the
 # ci/scripts/install_vcpkg.sh script. Keep in sync with apache/arrow .env.

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,7 @@ services:
   ############################### C#/.NET ######################################
 
   csharp-dist:
-    image: mcr.microsoft.com/dotnet/sdk:8.0
+    image: mcr.microsoft.com/dotnet/sdk:10.0
     volumes:
       - .:/adbc:delegated
     command: |

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -249,7 +249,7 @@ install_dotnet() {
   if command -v dotnet; then
     show_info "Found $(dotnet --version) at $(which dotnet)"
 
-    if dotnet --version | grep --quiet --fixed-string 8.0; then
+    if dotnet --version | grep --quiet --fixed-string 10.0; then
         local csharp_bin=$(dirname $(which dotnet))
         show_info "Found C# at $(which csharp) (.NET $(dotnet --version))"
         DOTNET_ALREADY_INSTALLED=1
@@ -260,7 +260,7 @@ install_dotnet() {
   show_info "dotnet found but it is the wrong version or dotnet not found"
 
   local csharp_bin=${ARROW_TMPDIR}/csharp/bin
-  local dotnet_version=8.0.204
+  local dotnet_version=10.0.203
   local dotnet_platform=
   case "$(uname)" in
       Linux)


### PR DESCRIPTION
Changes the Docker image to install .NET 10.0 instead of .NET 8.0 to allow us to build both targets. Fixes CI failures.

Closes #4283.