### PR TITLE
chore: fix R test failures in nightly verification on Ubuntu

### DIFF
--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -32,6 +32,7 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch: {}
 
+
 permissions:
   contents: read
 

--- a/.github/workflows/nightly-verify.yml
+++ b/.github/workflows/nightly-verify.yml
@@ -32,7 +32,6 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch: {}
 
-
 permissions:
   contents: read
 

--- a/ci/scripts/verify_ubuntu.sh
+++ b/ci/scripts/verify_ubuntu.sh
@@ -56,6 +56,7 @@ main() {
         libgtest-dev \
         libpq-dev \
         libsqlite3-dev \
+        libuv1-dev \
         lsb-release \
         ninja-build \
         pkg-config \


### PR DESCRIPTION
The nightly verification job on Ubuntu is failing while verifying the R packages due to missing libuv1-dev. 

https://github.com/apache/arrow-adbc/actions/runs/25074820850/job/73464505942?pr=4284

This is a new breaking change in a dependency used by the R tests so any system that builds and tests the R packages needs this package or an equivalent.

See commits from apache/arrow:

70f8c204cb MINOR: [Dev][CI] Install libuv1-dev in dev.yml lint step for R fs package (#49791)
4feb9bde28 GH-49593: [R][CI] Add libuv-dev to CI jobs due to update to fs package (#49594)