### PR TITLE
chore(java): bump to arrow-java 19.0.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -96,7 +96,7 @@
   </distributionManagement>
 
   <properties>
-    <dep.arrow.version>18.3.0</dep.arrow.version>
+    <dep.arrow.version>19.0.0</dep.arrow.version>
     <dep.org.checkerframework.version>4.0.0</dep.org.checkerframework.version>
     <!-- org.apache:apache overrides -->
     <minimalJavaBuildVersion>11</minimalJavaBuildVersion>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -103,6 +103,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.target>11</maven.compiler.target>
     <surefire.version>3.5.2</surefire.version>
+    <surefireArgLine></surefireArgLine>
     <version.maven-javadoc-plugin>3.11.1</version.maven-javadoc-plugin>
   </properties>
 
@@ -198,7 +199,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
+          <argLine>${surefireArgLine} --add-opens=java.base/java.nio=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
 
@@ -277,6 +278,15 @@
   </reporting>
 
   <profiles>
+    <profile>
+      <id>java-25+</id>
+      <activation>
+        <jdk>[25,)</jdk>
+      </activation>
+      <properties>
+        <surefireArgLine>--sun-misc-unsafe-memory-access=allow</surefireArgLine>
+      </properties>
+    </profile>
     <profile>
       <id>errorprone</id>
       <build>


### PR DESCRIPTION
### Summary

Upgrade the Java modules from Arrow Java 18.3.0 to 19.0.0.

This is intended as a prerequisite for refactoring the Java Flight SQL OAuth implementation to reuse the OAuth abstractions added in Arrow Java 19.0.0.

Follow-up to the discussion in:
https://github.com/apache/arrow-adbc/pull/4272#discussion_r3168399448

### Notes

This PR only updates the Arrow Java dependency version. The Flight SQL OAuth implementation refactor will be submitted separately to keep the dependency upgrade and behavior changes easier to review.
