### PR TITLE
fix(csharp): Bump OpenTelemetry.Exporter.OpenTelemetryProtocol to 1.15.3

### DIFF
--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -42,7 +42,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="OpenTelemetry" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.6" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Net.Http.WinHttpHandler" Version="8.0.2" />


### PR DESCRIPTION
Bumps OpenTelemetry.Exporter.OpenTelemetryProtocol to 1.15.3 to fix the csharp build. 1.15.3 is the oldest patched version according to https://github.com/advisories/GHSA-4625-4j76-fww9. I see this locally and in CI:

```
$dotnet build
/Users/bryce/src/apache/arrow-adbc/csharp/src/Telemetry/Traces/Exporters/Apache.Arrow.Adbc.Telemetry.Traces.Exporters.csproj : error [NU1902](https://go.microsoft.com/fwlink/?LinkId=NU1902): Warning As Error: Package 'OpenTelemetry.Exporter.OpenTelemetryProtocol' 1.12.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-4625-4j76-fww9

Restore failed with 1 error(s) in 2.6s
```

The changelog for OpenTelemetry.Exporter.OpenTelemetryProtocol is here: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/RELEASENOTES.md#1153. 