### PR TITLE
ci: unpin python, work around mamba bug

### DIFF
--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-Cython
+cython
 importlib-resources
 # libxml2 broke ABI compatibility
 # https://github.com/conda-forge/arrow-cpp-feedstock/issues/1740

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -569,8 +569,7 @@ test_python() {
 
   # Build and test Python
   maybe_setup_virtualenv cython duckdb pandas polars protobuf pyarrow pytest setuptools_scm setuptools importlib_resources || exit 1
-  # XXX: pin Python for now since various other packages haven't caught up
-  maybe_setup_conda --file "${ADBC_DIR}/ci/conda_env_python.txt" python=3.12 || exit 1
+  maybe_setup_conda --file "${ADBC_DIR}/ci/conda_env_python.txt" || exit 1
 
   if [ "${USE_CONDA}" -gt 0 ]; then
     CMAKE_PREFIX_PATH="${CONDA_BACKUP_CMAKE_PREFIX_PATH}:${CMAKE_PREFIX_PATH}"


### PR DESCRIPTION
- Unpin Python 3.12.
- Lowercase the Cython requirement (https://github.com/mamba-org/mamba/issues/4251)