### PR TITLE
fix(ci/scripts): correct csharp pack powershell script to set arguments correctly

### DIFF
--- a/ci/scripts/csharp_pack.ps1
+++ b/ci/scripts/csharp_pack.ps1
@@ -38,7 +38,11 @@ if ($versionSuffix) {
 }
 if ($noBuild) {
     Write-Host " * Pack without building"
-    $packArgs["-no-build"] = $true
+    # this argument is a flag and has no value, so we set it to an empty string,
+    # not $true or $false, which would be converted to "True" or "False"
+    $packArgs["-no-build"] = ""
 }
 
 dotnet pack @packArgs
+
+Set-Location -


### PR DESCRIPTION
Corrects the command arguments to `dotnet pack` for the `--no-build` flag.
- change the argument's value from $true to '' (empty string) as it is a flag with no argument value.
- add a command to return the working folder back to the original it was called from.