### PR TITLE
fix(ci/scripts): fix Set-Location syntax

### DIFF
--- a/ci/scripts/csharp_pack.ps1
+++ b/ci/scripts/csharp_pack.ps1
@@ -22,7 +22,7 @@ param (
 
 $csharpFolder = [IO.Path]::Combine($PSScriptRoot, "..", "..", "csharp") | Resolve-Path
 Write-Host "Setting Path: $csharpFolder"
-Set-Location $csharpFolder
+Push-Location $csharpFolder
 
 Write-Host "Running dotnet pack -c Release"
 $packArgs = @{
@@ -45,4 +45,4 @@ if ($noBuild) {
 
 dotnet pack @packArgs
 
-Set-Location -
+Pop-Location


### PR DESCRIPTION
Correct bug introduced in PR https://github.com/apache/arrow-adbc/pull/4304
- Instead uses the Push-Location / Pop-Location pair