### PR TITLE
fix(go/adbc/drivermgr): adjust ingest helper to set target before BindStream

### DIFF
--- a/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_server_test.go
@@ -3047,6 +3047,150 @@ func (suite *BulkIngestTests) TestBulkIngestWithStream() {
 	suite.Equal(int64(5), totalRows)
 }
 
+func (suite *BulkIngestTests) TestBulkIngestBindStreamBeforeOptions() {
+	stmt, err := suite.cnxn.NewStatement()
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), stmt)
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "batch_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer bldr.Release()
+
+	bldr.Field(0).(*array.Int32Builder).AppendValues([]int32{1}, nil)
+	rec1 := bldr.NewRecordBatch()
+	bldr.Field(0).(*array.Int32Builder).AppendValues([]int32{2, 3}, nil)
+	rec2 := bldr.NewRecordBatch()
+	defer rec1.Release()
+	defer rec2.Release()
+
+	rdr, err := array.NewRecordReader(schema, []arrow.RecordBatch{rec1, rec2})
+	suite.Require().NoError(err)
+	defer rdr.Release()
+
+	suite.Require().NoError(stmt.BindStream(context.Background(), rdr))
+
+	suite.Require().NoError(stmt.SetOption(adbc.OptionKeyIngestTargetTable, "bind_first"))
+	suite.Require().NoError(stmt.SetOption(adbc.OptionKeyIngestMode, adbc.OptionValueIngestModeCreate))
+
+	nRows, err := stmt.ExecuteUpdate(context.Background())
+	suite.Require().NoError(err)
+	suite.Equal(int64(3), nRows)
+
+	requests := suite.server.GetIngestRequests()
+	suite.Require().Len(requests, 1)
+	suite.Equal("bind_first", requests[0].GetTable())
+}
+
+func (suite *BulkIngestTests) TestBulkIngestBindBeforeOptions() {
+	stmt, err := suite.cnxn.NewStatement()
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), stmt)
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer bldr.Release()
+
+	bldr.Field(0).(*array.Int32Builder).AppendValues([]int32{10, 20}, nil)
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	suite.Require().NoError(stmt.Bind(context.Background(), rec))
+
+	suite.Require().NoError(stmt.SetOption(adbc.OptionKeyIngestTargetTable, "bind_batch_first"))
+	suite.Require().NoError(stmt.SetOption(adbc.OptionKeyIngestMode, adbc.OptionValueIngestModeCreate))
+
+	nRows, err := stmt.ExecuteUpdate(context.Background())
+	suite.Require().NoError(err)
+	suite.Equal(int64(2), nRows)
+
+	requests := suite.server.GetIngestRequests()
+	suite.Require().Len(requests, 1)
+	suite.Equal("bind_batch_first", requests[0].GetTable())
+}
+
+func (suite *BulkIngestTests) TestBulkIngestBindStreamMissingTarget() {
+	stmt, err := suite.cnxn.NewStatement()
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), stmt)
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "batch_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer bldr.Release()
+
+	bldr.Field(0).(*array.Int32Builder).AppendValues([]int32{1}, nil)
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	rdr, err := array.NewRecordReader(schema, []arrow.RecordBatch{rec})
+	suite.Require().NoError(err)
+	defer rdr.Release()
+
+	suite.Require().NoError(stmt.BindStream(context.Background(), rdr))
+
+	_, err = stmt.ExecuteUpdate(context.Background())
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "must set IngestTargetTable before bulk ingestion")
+}
+
+func (suite *BulkIngestTests) TestBulkIngestBindMissingTarget() {
+	stmt, err := suite.cnxn.NewStatement()
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), stmt)
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer bldr.Release()
+
+	bldr.Field(0).(*array.Int32Builder).AppendValues([]int32{1}, nil)
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	suite.Require().NoError(stmt.Bind(context.Background(), rec))
+
+	_, err = stmt.ExecuteUpdate(context.Background())
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "must set IngestTargetTable before bulk ingestion")
+}
+
+func (suite *BulkIngestTests) TestBulkIngestBindStreamMissingTargetExecuteQuery() {
+	stmt, err := suite.cnxn.NewStatement()
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), stmt)
+
+	schema := arrow.NewSchema([]arrow.Field{
+		{Name: "batch_id", Type: arrow.PrimitiveTypes.Int32, Nullable: false},
+	}, nil)
+
+	bldr := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer bldr.Release()
+
+	bldr.Field(0).(*array.Int32Builder).AppendValues([]int32{1}, nil)
+	rec := bldr.NewRecordBatch()
+	defer rec.Release()
+
+	rdr, err := array.NewRecordReader(schema, []arrow.RecordBatch{rec})
+	suite.Require().NoError(err)
+	defer rdr.Release()
+
+	suite.Require().NoError(stmt.BindStream(context.Background(), rdr))
+
+	_, _, err = stmt.ExecuteQuery(context.Background())
+	suite.Require().Error(err)
+	suite.Contains(err.Error(), "must set IngestTargetTable before bulk ingestion")
+}
+
 func (suite *BulkIngestTests) TestBulkIngestWithoutBind() {
 	stmt, err := suite.cnxn.NewStatement()
 	suite.Require().NoError(err)

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -503,6 +503,14 @@ func (s *statement) ExecuteQuery(ctx context.Context) (rdr array.RecordReader, n
 		return nil, -1, err
 	}
 
+	// Reject staged binds if no ingest target was provided
+	if s.targetTable == "" && s.prepared == nil && (s.bound != nil || s.streamBind != nil) {
+		return nil, -1, adbc.Error{
+			Msg:  "[Flight SQL Statement] must set IngestTargetTable before bulk ingestion",
+			Code: adbc.StatusInvalidState,
+		}
+	}
+
 	// Handle bulk ingest
 	if s.targetTable != "" {
 		nrec, err = s.executeIngest(ctx)
@@ -533,6 +541,14 @@ func (s *statement) ExecuteQuery(ctx context.Context) (rdr array.RecordReader, n
 func (s *statement) ExecuteUpdate(ctx context.Context) (n int64, err error) {
 	if err := s.clearIncrementalQuery(); err != nil {
 		return -1, err
+	}
+
+	// Reject staged binds if no ingest target was provided
+	if s.targetTable == "" && s.prepared == nil && (s.bound != nil || s.streamBind != nil) {
+		return -1, adbc.Error{
+			Msg:  "[Flight SQL Statement] must set IngestTargetTable before bulk ingestion",
+			Code: adbc.StatusInvalidState,
+		}
 	}
 
 	// Handle bulk ingest
@@ -617,9 +633,18 @@ func (s *statement) Bind(_ context.Context, values arrow.RecordBatch) error {
 	}
 
 	if s.prepared == nil {
-		return adbc.Error{
-			Msg:  "[Flight SQL Statement] must call Prepare or set IngestTargetTable before calling Bind",
-			Code: adbc.StatusInvalidState}
+		if s.streamBind != nil {
+			s.streamBind.Release()
+			s.streamBind = nil
+		}
+		if s.bound != nil {
+			s.bound.Release()
+		}
+		s.bound = values
+		if s.bound != nil {
+			s.bound.Retain()
+		}
+		return nil
 	}
 
 	// calls retain
@@ -650,9 +675,18 @@ func (s *statement) BindStream(_ context.Context, stream array.RecordReader) err
 	}
 
 	if s.prepared == nil {
-		return adbc.Error{
-			Msg:  "[Flight SQL Statement] must call Prepare or set IngestTargetTable before calling Bind",
-			Code: adbc.StatusInvalidState}
+		if s.bound != nil {
+			s.bound.Release()
+			s.bound = nil
+		}
+		if s.streamBind != nil {
+			s.streamBind.Release()
+		}
+		s.streamBind = stream
+		if s.streamBind != nil {
+			s.streamBind.Retain()
+		}
+		return nil
 	}
 
 	// calls retain

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -616,40 +616,27 @@ func (s *statement) SetSubstraitPlan(plan []byte) error {
 // but it may not do this until the statement is closed or another
 // record is bound.
 func (s *statement) Bind(_ context.Context, values arrow.RecordBatch) error {
-	// For bulk ingest, bind to the statement
-	if s.targetTable != "" {
-		if s.streamBind != nil {
-			s.streamBind.Release()
-			s.streamBind = nil
-		}
-		if s.bound != nil {
-			s.bound.Release()
-		}
-		s.bound = values
-		if s.bound != nil {
-			s.bound.Retain()
-		}
+	if s.targetTable != "" || s.prepared == nil {
+		s.setBound(values)
 		return nil
 	}
 
-	if s.prepared == nil {
-		if s.streamBind != nil {
-			s.streamBind.Release()
-			s.streamBind = nil
-		}
-		if s.bound != nil {
-			s.bound.Release()
-		}
-		s.bound = values
-		if s.bound != nil {
-			s.bound.Retain()
-		}
-		return nil
-	}
-
-	// calls retain
 	s.prepared.SetParameters(values)
 	return nil
+}
+
+func (s *statement) setBound(values arrow.RecordBatch) {
+	if s.streamBind != nil {
+		s.streamBind.Release()
+		s.streamBind = nil
+	}
+	if s.bound != nil {
+		s.bound.Release()
+	}
+	s.bound = values
+	if s.bound != nil {
+		s.bound.Retain()
+	}
 }
 
 // BindStream uses a record batch stream to bind parameters for this
@@ -658,40 +645,27 @@ func (s *statement) Bind(_ context.Context, values arrow.RecordBatch) error {
 // The driver will call Release on the record reader, but may not do this
 // until Close is called.
 func (s *statement) BindStream(_ context.Context, stream array.RecordReader) error {
-	// For bulk ingest, bind to the statement
-	if s.targetTable != "" {
-		if s.bound != nil {
-			s.bound.Release()
-			s.bound = nil
-		}
-		if s.streamBind != nil {
-			s.streamBind.Release()
-		}
-		s.streamBind = stream
-		if s.streamBind != nil {
-			s.streamBind.Retain()
-		}
+	if s.targetTable != "" || s.prepared == nil {
+		s.setStreamBound(stream)
 		return nil
 	}
 
-	if s.prepared == nil {
-		if s.bound != nil {
-			s.bound.Release()
-			s.bound = nil
-		}
-		if s.streamBind != nil {
-			s.streamBind.Release()
-		}
-		s.streamBind = stream
-		if s.streamBind != nil {
-			s.streamBind.Retain()
-		}
-		return nil
-	}
-
-	// calls retain
 	s.prepared.SetRecordReader(stream)
 	return nil
+}
+
+func (s *statement) setStreamBound(stream array.RecordReader) {
+	if s.bound != nil {
+		s.bound.Release()
+		s.bound = nil
+	}
+	if s.streamBind != nil {
+		s.streamBind.Release()
+	}
+	s.streamBind = stream
+	if s.streamBind != nil {
+		s.streamBind.Retain()
+	}
 }
 
 // GetParameterSchema returns an Arrow schema representation of

--- a/go/adbc/ext.go
+++ b/go/adbc/ext.go
@@ -100,17 +100,17 @@ func IngestStream(ctx context.Context, cnxn Connection, reader array.RecordReade
 		err = errors.Join(err, stmt.Close())
 	}()
 
-	// Bind the record batch stream
-	if err = stmt.BindStream(ctx, reader); err != nil {
-		return -1, fmt.Errorf("error during ingestion: BindStream: %w", err)
-	}
-
-	// Set required options
+	// Set required options before binding
 	if err = stmt.SetOption(OptionKeyIngestTargetTable, targetTable); err != nil {
 		return -1, fmt.Errorf("error during ingestion: SetOption(target_table=%s): %w", targetTable, err)
 	}
 	if err = stmt.SetOption(OptionKeyIngestMode, ingestMode); err != nil {
 		return -1, fmt.Errorf("error during ingestion: SetOption(mode=%s): %w", ingestMode, err)
+	}
+
+	// Bind the record batch stream
+	if err = stmt.BindStream(ctx, reader); err != nil {
+		return -1, fmt.Errorf("error during ingestion: BindStream: %w", err)
 	}
 
 	// Set other options if provided
@@ -167,17 +167,17 @@ func IngestStreamContext(ctx context.Context, cnxn ConnectionWithContext, reader
 		err = errors.Join(err, stmt.Close(ctx))
 	}()
 
-	// Bind the record batch stream
-	if err = stmt.BindStream(ctx, reader); err != nil {
-		return -1, fmt.Errorf("error during ingestion: BindStream: %w", err)
-	}
-
-	// Set required options
+	// Set required options before binding (some drivers require target first)
 	if err = stmt.SetOption(ctx, OptionKeyIngestTargetTable, targetTable); err != nil {
 		return -1, fmt.Errorf("error during ingestion: SetOption(target_table=%s): %w", targetTable, err)
 	}
 	if err = stmt.SetOption(ctx, OptionKeyIngestMode, ingestMode); err != nil {
 		return -1, fmt.Errorf("error during ingestion: SetOption(mode=%s): %w", ingestMode, err)
+	}
+
+	// Bind the record batch stream
+	if err = stmt.BindStream(ctx, reader); err != nil {
+		return -1, fmt.Errorf("error during ingestion: BindStream: %w", err)
 	}
 
 	// Set other options if provided


### PR DESCRIPTION
## Summary

Reorder `IngestStream` and `IngestStreamContext` to set `OptionKeyIngestTargetTable` and `OptionKeyIngestMode` before calling `BindStream`, matching drivers that require ingest targets up front (e.g., FlightSQL).

Keep all other ingest option handling and execution flow unchanged.

Evidence (FlightSQL requirement):

[`go/adbc/driver/flightsql/flightsql_statement.go:630-656`:](https://github.com/apache/arrow-adbc/blob/b4f1e3e08c2413180fef4811e94d7677949da403/go/adbc/driver/flightsql/flightsql_statement.go#L635)

```go
func (s *statement) BindStream(_ context.Context, stream array.RecordReader) error {
	// For bulk ingest, bind to the statement
	if s.targetTable != "" {
		if s.bound != nil {
			s.bound.Release()
			s.bound = nil
		}
		if s.streamBind != nil {
			s.streamBind.Release()
		}
		s.streamBind = stream
		if s.streamBind != nil {
			s.streamBind.Retain()
		}
		return nil
	}

	if s.prepared == nil {
		return adbc.Error{
			Msg:  "[Flight SQL Statement] must call Prepare or set IngestTargetTable before calling Bind",
			Code: adbc.StatusInvalidState}
	}

	// calls retain
	s.prepared.SetRecordReader(stream)
	return nil
}
```

The current non-patched code, raises the error:
```
[Flight SQL Statement] must call Prepare or set IngestTargetTable before calling Bind
```