### PR TITLE
fix(csharp): address flaky driver manager tests

### DIFF
--- a/csharp/src/Apache.Arrow.Adbc/DriverManager/DriverManagerSecurity.cs
+++ b/csharp/src/Apache.Arrow.Adbc/DriverManager/DriverManagerSecurity.cs
@@ -37,7 +37,19 @@ namespace Apache.Arrow.Adbc.DriverManager
         /// When set, all driver load attempts will be logged.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// This property is thread-safe. Set to <c>null</c> to disable audit logging.
+        /// </para>
+        /// <para>
+        /// <b>Testing note:</b> this is process-wide mutable state. Test classes
+        /// that assign this property -- or that exercise the
+        /// <see cref="AdbcDriverManager"/> load path, which reads it on every
+        /// load -- must join the same xUnit collection
+        /// (<c>DriverManagerSecurityCollection.Name</c>) so they are serialized
+        /// against each other. Otherwise concurrent tests can null out the
+        /// logger between "install" and "load", producing flaky
+        /// <c>Assert.Single</c> failures on captured-attempt lists.
+        /// </para>
         /// </remarks>
         public static IDriverLoadAuditLogger? AuditLogger
         {
@@ -70,6 +82,16 @@ namespace Apache.Arrow.Adbc.DriverManager
         /// <b>Security Note:</b> In production environments, consider using an
         /// allowlist to restrict which drivers can be loaded, preventing
         /// potential arbitrary code execution attacks.
+        /// </para>
+        /// <para>
+        /// <b>Testing note:</b> this is process-wide mutable state. Test classes
+        /// that assign this property -- or that exercise the
+        /// <see cref="AdbcDriverManager"/> load path, which reads it on every
+        /// load -- must join the same xUnit collection
+        /// (<c>DriverManagerSecurityCollection.Name</c>) so they are serialized
+        /// against each other. Otherwise a concurrent test can install a
+        /// restrictive allowlist that rejects an unrelated test's driver path
+        /// with <c>AdbcStatusCode.Unauthorized</c>.
         /// </para>
         /// </remarks>
         public static IDriverAllowlist? Allowlist

--- a/csharp/test/Apache.Arrow.Adbc.Tests/DriverManager/DriverManagerSecurityCollection.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/DriverManager/DriverManagerSecurityCollection.cs
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Xunit;
+
+namespace Apache.Arrow.Adbc.Tests.DriverManager
+{
+    /// <summary>
+    /// Single source of truth for the xUnit collection name shared by every
+    /// test class that touches the process-wide static values on
+    /// <see cref="Apache.Arrow.Adbc.DriverManager.DriverManagerSecurity"/>
+    /// (notably <c>AuditLogger</c> and <c>Allowlist</c>) or that calls
+    /// <see cref="Apache.Arrow.Adbc.DriverManager.AdbcDriverManager.LoadManagedDriver(string, string)"/>
+    /// / <c>LoadDriver</c>, whose hot path reads those same static values.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// xUnit parallelizes across distinct test classes by default. Without a
+    /// shared collection, a test in one class that mutates
+    /// <c>DriverManagerSecurity.AuditLogger</c> or <c>Allowlist</c> can race
+    /// with a load-path test in another class, producing flaky
+    /// <c>Assert.Single(logger.Attempts)</c> failures or spurious
+    /// "not permitted by the configured allowlist" exceptions.
+    /// </para>
+    /// <para>
+    /// Apply <c>[Collection(DriverManagerSecurityCollection.Name)]</c> to any
+    /// new test class that either mutates those static values or invokes
+    /// <c>AdbcDriverManager.LoadManagedDriver</c>/<c>LoadDriver</c>.
+    /// </para>
+    /// </remarks>
+    [CollectionDefinition(Name)]
+    public sealed class DriverManagerSecurityCollection
+    {
+        public const string Name = "DriverManagerSecurity";
+    }
+}

--- a/csharp/test/Apache.Arrow.Adbc.Tests/DriverManager/DriverManagerSecurityIntegrationTests.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/DriverManager/DriverManagerSecurityIntegrationTests.cs
@@ -34,7 +34,7 @@ namespace Apache.Arrow.Adbc.Tests.DriverManager
     /// xUnit's collection serialization keeps these tests off the parallel queue
     /// alongside <see cref="DriverManagerSecurityTests"/>.
     /// </remarks>
-    [Collection("DriverManagerSecurity")]
+    [Collection(DriverManagerSecurityCollection.Name)]
     public sealed class DriverManagerSecurityIntegrationTests : IDisposable
     {
         private readonly List<string> _tempDirs = new List<string>();

--- a/csharp/test/Apache.Arrow.Adbc.Tests/DriverManager/DriverManagerSecurityTests.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/DriverManager/DriverManagerSecurityTests.cs
@@ -26,6 +26,18 @@ namespace Apache.Arrow.Adbc.Tests.DriverManager
     /// <summary>
     /// Tests for <see cref="DriverManagerSecurity"/> functionality.
     /// </summary>
+    /// <remarks>
+    /// Mutates process-wide static values on <see cref="DriverManagerSecurity"/>
+    /// (notably <see cref="DriverManagerSecurity.AuditLogger"/> and
+    /// <see cref="DriverManagerSecurity.Allowlist"/>) and resets them to null
+    /// in <see cref="Dispose"/>. xUnit's collection serialization keeps these
+    /// tests off the parallel queue alongside
+    /// <see cref="DriverManagerSecurityIntegrationTests"/>, which also depends
+    /// on those static values. Without this, a concurrent Dispose here can null out
+    /// an AuditLogger an integration test just installed, causing
+    /// Assert.Single(logger.Attempts) to see an empty list.
+    /// </remarks>
+    [Collection(DriverManagerSecurityCollection.Name)]
     public class DriverManagerSecurityTests : IDisposable
     {
         private readonly List<string> _tempDirs = new List<string>();

--- a/csharp/test/Apache.Arrow.Adbc.Tests/DriverManager/ManagedDriverLoaderTests.cs
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/DriverManager/ManagedDriverLoaderTests.cs
@@ -32,6 +32,18 @@ namespace Apache.Arrow.Adbc.Tests.DriverManager
     /// is verified on .NET Framework and on modern .NET where dependency
     /// resolution goes through <c>AssemblyLoadContext</c>.
     /// </summary>
+    /// <remarks>
+    /// Every call here goes through <c>AdbcDriverManager.LoadManagedDriver</c>,
+    /// which consults the process-wide <see cref="DriverManagerSecurity.Allowlist"/>
+    /// and <see cref="DriverManagerSecurity.AuditLogger"/>. Other test classes
+    /// (notably <c>DriverManagerSecurityTests</c> and
+    /// <c>DriverManagerSecurityIntegrationTests</c>) mutate those static values, so
+    /// we join the same xUnit collection to keep them off the parallel queue.
+    /// Without this, a concurrent test that installs a restrictive
+    /// <c>DirectoryAllowlist</c> would cause loads from our private temp
+    /// directory to fail with "not permitted by the configured allowlist".
+    /// </remarks>
+    [Collection(DriverManagerSecurityCollection.Name)]
     public class ManagedDriverLoaderTests : IDisposable
     {
         private readonly List<string> _tempDirs = new List<string>();


### PR DESCRIPTION
- Addresses the race condition in the driver manager tests that are causing issues with check-ins