### PR TITLE
build(python): remove deprecated cibuildwheel `enable-freethreading`

### DIFF
--- a/ci/scripts/python_wheel_unix_relocate.sh
+++ b/ci/scripts/python_wheel_unix_relocate.sh
@@ -56,7 +56,7 @@ fi
 echo "=== Relocating wheels ==="
 # https://github.com/pypa/pip/issues/7555
 # Get the latest pip so we have in-tree-build by default
-python -m pip install --upgrade pip auditwheel 'cibuildwheel>3' delocate setuptools wheel
+python -m pip install --upgrade pip auditwheel 'cibuildwheel>=4' delocate setuptools wheel
 
 # Build with Cython debug info
 export ADBC_BUILD_TYPE="debug"

--- a/python/adbc_driver_manager/pyproject.toml
+++ b/python/adbc_driver_manager/pyproject.toml
@@ -38,9 +38,6 @@ repository = "https://github.com/apache/arrow-adbc"
 requires = ["Cython >= 3.1.0", "setuptools >= 77.0.0"]
 build-backend = "setuptools.build_meta"
 
-[tool.cibuildwheel]
-enable = ["cpython-freethreading"]
-
 [tool.pytest.ini_options]
 filterwarnings = ["error"]
 markers = [


### PR DESCRIPTION
This is no longer needed as of 4.0.0.