### PR TITLE
feat!(c/driver/postgresql): remove Redshift support

### DIFF
--- a/c/driver/postgresql/connection.cc
+++ b/c/driver/postgresql/connection.cc
@@ -187,13 +187,6 @@ class PostgresGetObjectsHelper : public adbc::driver::GetObjectsHelper {
         all_constraints_(conn, kConstraintsQueryAll),
         some_constraints_(conn, ConstraintsQuery()) {}
 
-  // Allow Redshift to execute this query without constraints
-  // TODO(paleolimbot): Investigate to see if we can simplify the constraints query so
-  // that it works on both!
-  void SetEnableConstraints(bool enable_constraints) {
-    enable_constraints_ = enable_constraints;
-  }
-
   Status Load(adbc::driver::GetObjectsDepth depth,
               std::optional<std::string_view> catalog_filter,
               std::optional<std::string_view> schema_filter,
@@ -288,16 +281,13 @@ class PostgresGetObjectsHelper : public adbc::driver::GetObjectsHelper {
       next_column_ = all_columns_.Row(-1);
     }
 
-    if (enable_constraints_) {
-      if (column_filter.has_value()) {
-        UNWRAP_STATUS(some_constraints_.Execute(
-            {std::string(schema), std::string(table), std::string(*column_filter)}))
-        next_constraint_ = some_constraints_.Row(-1);
-      } else {
-        UNWRAP_STATUS(
-            all_constraints_.Execute({std::string(schema), std::string(table)}));
-        next_constraint_ = all_constraints_.Row(-1);
-      }
+    if (column_filter.has_value()) {
+      UNWRAP_STATUS(some_constraints_.Execute(
+          {std::string(schema), std::string(table), std::string(*column_filter)}))
+      next_constraint_ = some_constraints_.Row(-1);
+    } else {
+      UNWRAP_STATUS(all_constraints_.Execute({std::string(schema), std::string(table)}));
+      next_constraint_ = all_constraints_.Row(-1);
     }
 
     return Status::Ok();
@@ -375,9 +365,6 @@ class PostgresGetObjectsHelper : public adbc::driver::GetObjectsHelper {
   PqResultHelper some_columns_;
   PqResultHelper all_constraints_;
   PqResultHelper some_constraints_;
-
-  // On Redshift, the constraints query fails
-  bool enable_constraints_{true};
 
   // Iterator state for the catalogs/schema/table/column queries
   PqResultRow next_catalog_;
@@ -520,28 +507,18 @@ AdbcStatusCode PostgresConnection::GetInfo(struct AdbcConnection* connection,
         infos.push_back({info_codes[i], std::string(VendorName())});
         break;
       case ADBC_INFO_VENDOR_VERSION: {
-        if (VendorName() == "Redshift") {
-          const std::array<int, 3>& version = VendorVersion();
-          std::string version_string = std::to_string(version[0]) + "." +
-                                       std::to_string(version[1]) + "." +
-                                       std::to_string(version[2]);
-          infos.push_back({info_codes[i], std::move(version_string)});
-
-        } else {
-          // Gives a version in the form 140000 instead of 14.0.0
-          const char* stmt = "SHOW server_version_num";
-          auto result_helper = PqResultHelper{conn_, std::string(stmt)};
-          RAISE_STATUS(error, result_helper.Execute());
-          auto it = result_helper.begin();
-          if (it == result_helper.end()) {
-            InternalAdbcSetError(error, "[libpq] PostgreSQL returned no rows for '%s'",
-                                 stmt);
-            return ADBC_STATUS_INTERNAL;
-          }
-          const char* server_version_num = (*it)[0].data;
-          infos.push_back({info_codes[i], server_version_num});
+        // Gives a version in the form 140000 instead of 14.0.0
+        const char* stmt = "SHOW server_version_num";
+        auto result_helper = PqResultHelper{conn_, std::string(stmt)};
+        RAISE_STATUS(error, result_helper.Execute());
+        auto it = result_helper.begin();
+        if (it == result_helper.end()) {
+          InternalAdbcSetError(error, "[libpq] PostgreSQL returned no rows for '%s'",
+                               stmt);
+          return ADBC_STATUS_INTERNAL;
         }
-
+        const char* server_version_num = (*it)[0].data;
+        infos.push_back({info_codes[i], server_version_num});
         break;
       }
       case ADBC_INFO_DRIVER_NAME:
@@ -572,7 +549,6 @@ AdbcStatusCode PostgresConnection::GetObjects(
     const char* db_schema, const char* table_name, const char** table_type,
     const char* column_name, struct ArrowArrayStream* out, struct AdbcError* error) {
   PostgresGetObjectsHelper helper(conn_);
-  helper.SetEnableConstraints(VendorName() != "Redshift");
 
   const auto catalog_filter =
       catalog ? std::make_optional(std::string_view(catalog)) : std::nullopt;

--- a/c/driver/postgresql/database.cc
+++ b/c/driver/postgresql/database.cc
@@ -211,13 +211,9 @@ Status PostgresDatabase::InitVersions(PGconn* conn) {
 
   std::string_view version_info = helper.Row(0)[0].value();
   postgres_server_version_ = ParsePrefixedVersion(version_info, "PostgreSQL");
-  redshift_server_version_ = ParsePrefixedVersion(version_info, "Redshift");
 
   return Status::Ok();
 }
-
-// Helpers for building the type resolver from queries
-static std::string BuildPgTypeQuery(bool has_typarray);
 
 static Status InsertPgAttributeResult(
     const PqResultHelper& result, const std::shared_ptr<PostgresTypeResolver>& resolver);
@@ -246,7 +242,9 @@ ORDER BY
   // handle range types because those rows don't have child OID information. Arrays types
   // are inserted after a successful insert of the element type.
   std::string type_query =
-      BuildPgTypeQuery(/*has_typarray*/ redshift_server_version_[0] == 0);
+      "SELECT oid, typname, typreceive, typbasetype, typrelid, typarray FROM "
+      "pg_catalog.pg_type WHERE (typreceive != 0 OR typsend != 0) AND typtype != 'r' AND "
+      "typreceive::TEXT != 'array_recv'";
 
   // Create a new type resolver (this instance's type_resolver_ member
   // will be updated at the end if this succeeds).
@@ -267,20 +265,6 @@ ORDER BY
 
   type_resolver_ = std::move(resolver);
   return Status::Ok();
-}
-
-static std::string BuildPgTypeQuery(bool has_typarray) {
-  std::string maybe_typarray_col;
-  std::string maybe_array_recv_filter;
-  if (has_typarray) {
-    maybe_typarray_col = ", typarray";
-    maybe_array_recv_filter = "AND typreceive::TEXT != 'array_recv'";
-  }
-
-  return std::string() + "SELECT oid, typname, typreceive, typbasetype, typrelid" +
-         maybe_typarray_col + " FROM pg_catalog.pg_type " +
-         " WHERE (typreceive != 0 OR typsend != 0) AND typtype != 'r' " +
-         maybe_array_recv_filter;
 }
 
 static Status InsertPgAttributeResult(

--- a/c/driver/postgresql/database.h
+++ b/c/driver/postgresql/database.h
@@ -64,26 +64,13 @@ class PostgresDatabase {
 
   Status InitVersions(PGconn* conn);
   Status RebuildTypeResolver(PGconn* conn);
-  std::string_view VendorName() {
-    if (redshift_server_version_[0] != 0) {
-      return "Redshift";
-    } else {
-      return "PostgreSQL";
-    }
-  }
-  const std::array<int, 3>& VendorVersion() {
-    if (redshift_server_version_[0] != 0) {
-      return redshift_server_version_;
-    } else {
-      return postgres_server_version_;
-    }
-  }
+  std::string_view VendorName() { return "PostgreSQL"; }
+  const std::array<int, 3>& VendorVersion() { return postgres_server_version_; }
 
  private:
   int32_t open_connections_;
   std::string uri_;
   std::shared_ptr<PostgresTypeResolver> type_resolver_;
   std::array<int, 3> postgres_server_version_{};
-  std::array<int, 3> redshift_server_version_{};
 };
 }  // namespace adbcpq

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -919,12 +919,6 @@ void PostgresStatement::ClearResult() {
   reader_->batch_size_hint_bytes_ = batch_size_hint_bytes_;
 }
 
-int PostgresStatement::UseCopy() {
-  if (use_copy_ == -1) {
-    return connection_->VendorName() != "Redshift";
-  } else {
-    return use_copy_;
-  }
-}
+int PostgresStatement::UseCopy() { return use_copy_; }
 
 }  // namespace adbcpq

--- a/docs/source/driver/postgresql.rst
+++ b/docs/source/driver/postgresql.rst
@@ -31,12 +31,11 @@ overall approach.
 .. _libpq: https://www.postgresql.org/docs/current/libpq.html
 .. _pgeon: https://github.com/0x0L/pgeon
 
-.. note:: This driver has experimental support for Amazon Redshift.  As
-          Redshift does not support reading or writing COPY in PostgreSQL
-          binary format, however, the optimizations that accelerate queries
-          are not enabled when connecting to Redshift.  There may also be
-          other differences in functionality; please file a bug report if
-          problems are encountered.
+.. note:: Older versions (<=1.11.0) of this driver had experimental support for
+          Amazon Redshift. As Redshift does not support reading or writing COPY
+          in PostgreSQL binary format, however, the optimizations that
+          accelerate queries are not enabled when connecting to Redshift. There
+          may also be other differences in functionality.
 
 Installation
 ============


### PR DESCRIPTION
Redshift support was always experimental; now that a dedicated third-party Redshift ADBC driver is available, remove the hooks in the current driver.

Closes #4151.