### PR TITLE
build(rust): use cargo feature resolver version 3

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,7 @@
 
 [workspace]
 members = ["core", "driver_manager", "ffi", "driver/*"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 version = "0.24.0"


### PR DESCRIPTION
Since we are using Rust 2024, we can enable version 3 of the resolver, which takes MSRV into account.