### PR TITLE
chore(javascript): switch Rust to 2024 edition

### DIFF
--- a/javascript/Cargo.toml
+++ b/javascript/Cargo.toml
@@ -16,7 +16,7 @@
 # under the License.
 
 [package]
-edition = "2021"
+edition = "2024"
 name = "adbc_driver_manager_node"
 version = "0.24.0"
 license = "Apache-2.0"

--- a/javascript/src/client.rs
+++ b/javascript/src/client.rs
@@ -17,15 +17,15 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::mpsc;
 use std::sync::Mutex;
+use std::sync::mpsc;
 
 use adbc_core::{
+  Connection, Database, Driver, LOAD_FLAG_DEFAULT, Optionable, Statement,
   options::{
     AdbcVersion, InfoCode, ObjectDepth, OptionConnection, OptionDatabase, OptionStatement,
     OptionValue,
   },
-  Connection, Database, Driver, Optionable, Statement, LOAD_FLAG_DEFAULT,
 };
 use adbc_driver_manager::{ManagedConnection, ManagedDatabase, ManagedDriver, ManagedStatement};
 use arrow_array::RecordBatchReader;


### PR DESCRIPTION
For consistency with the Rust crate itself.