### PR TITLE
fix(ruby): declare Apache Arrow repository in red-adbc.gemspec

### DIFF
--- a/ruby/red-adbc.gemspec
+++ b/ruby/red-adbc.gemspec
@@ -60,9 +60,24 @@ Gem::Specification.new do |spec|
   end
 
   required_adbc_glib_version = version_components[0, 3].join(".")
+  repository_url_prefix = "https://packages.apache.org/artifactory/arrow"
   [
+    # Try without additional repository
     ["debian", "libadbc-glib-dev"],
+    # Retry with the Apache Arrow APT repository (it provides libadbc-glib-dev)
+    ["debian",
+     "#{repository_url_prefix}/%{distribution}/" +
+     "apache-arrow-apt-source-latest-%{code_name}.deb"],
+    ["debian", "libadbc-glib-dev"],
+
+    # Try without additional repository
     ["rhel", "adbc-glib-devel"],
+    # Retry with the Apache Arrow release repository (it provides adbc-glib-devel)
+    ["rhel",
+     "#{repository_url_prefix}/almalinux/%{major_version}/" +
+     "apache-arrow-release-latest.rpm"],
+    ["rhel", "adbc-glib-devel"],
+
     ["homebrew", "apache-arrow-adbc-glib"],
   ].each do |platform, package|
     spec.requirements <<


### PR DESCRIPTION
## What this changes

red-adbc.gemspec declares its Debian/RHEL package ( libadbc-glib-dev /
adbc-glib-devel) but not the Apache Arrow repository the package comes from, so
installing red-adbc relied on red-arrow registering that shared repository first.
Bundler 4.0's install-order change broke that assumption.

This mirrors what red-arrow.gemspec already does — try -> install
apache-arrow-apt-source -> retry for debian and rhel — so red-adbc declares the
repository for its own package and no longer depends on install order. Metadata
only; homebrew is unchanged.

## Verifying the fix

Same setup as the reproduction in GH-4392, but with
red-adbc pointed at this branch instead of the released gem — bundle install
now succeeds. Only the red-adbc source line of the Gemfile changes:

```shell
#!/bin/bash
#
# repro-fix.sh
set -u
cp -r /src /repro && cd /repro/ruby
sed -i 's/1\.12\.0-SNAPSHOT/1.11.0/' lib/adbc/version.rb
cd /repro
cat > Gemfile <<'GEMFILE'
source "https://rubygems.org/"
plugin "rubygems-requirements-system"
gem "red-adbc", path: "ruby"
GEMFILE
bundle install --jobs=4
```
```console
$ docker run --rm --platform=linux/amd64 \
    -v "$PWD":/src:ro -v "$PWD/repro-fix.sh":/repro.sh:ro ruby:4.0 bash /repro.sh
...
Bundle complete! 1 Gemfile dependency, 11 gems now installed.
```

Under Bundler 4.0 red-adbc still installs before red-arrow, but it now self-registers
the Apache Arrow repo and finds libadbc-glib-dev. repro-fix.sh builds red-adbc from the branch and pins the version to the　published adbc-glib 1.11.0; amd64 required.

Closes #4392.