### PR TITLE
fix(java/driver/jni): release ADBC resources on Java constructor failure

### DIFF
--- a/java/driver/jni/src/main/cpp/jni_wrapper.cc
+++ b/java/driver/jni/src/main/cpp/jni_wrapper.cc
@@ -344,6 +344,57 @@ const uint8_t* GetJniByteBuffer(JNIEnv* env, jobject bytebuffer,
   // not reachable
 }
 
+jobject MakeNativeQueryResult(JNIEnv* env, jlong rows_affected,
+                              struct ArrowArrayStream* out) {
+  // On any failure, release the C struct so its contents don't leak: the Java
+  // side only takes ownership (via snapshot) once construction succeeds.
+  try {
+    jclass native_result_class = RequireImplClass(env, "NativeQueryResult");
+    jmethodID native_result_ctor =
+        RequireMethod(env, native_result_class, "<init>", "(JJ)V");
+    jobject object =
+        env->NewObject(native_result_class, native_result_ctor, rows_affected,
+                       static_cast<jlong>(reinterpret_cast<uintptr_t>(out)));
+    if (object == nullptr || env->ExceptionCheck()) {
+      if (out->release != nullptr) {
+        out->release(out);
+      }
+      return nullptr;
+    }
+    return object;
+  } catch (...) {
+    if (out->release != nullptr) {
+      out->release(out);
+    }
+    throw;
+  }
+}
+
+jobject MakeNativeSchemaResult(JNIEnv* env, struct ArrowSchema* schema) {
+  // On any failure, release the C struct so its contents don't leak: the Java
+  // side only takes ownership (via snapshot) once construction succeeds.
+  try {
+    jclass native_result_class = RequireImplClass(env, "NativeSchemaResult");
+    jmethodID native_result_ctor =
+        RequireMethod(env, native_result_class, "<init>", "(J)V");
+    jobject object =
+        env->NewObject(native_result_class, native_result_ctor,
+                       static_cast<jlong>(reinterpret_cast<uintptr_t>(schema)));
+    if (object == nullptr || env->ExceptionCheck()) {
+      if (schema->release != nullptr) {
+        schema->release(schema);
+      }
+      return nullptr;
+    }
+    return object;
+  } catch (...) {
+    if (schema->release != nullptr) {
+      schema->release(schema);
+    }
+    throw;
+  }
+}
+
 }  // namespace
 
 extern "C" {
@@ -516,57 +567,6 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_closeStatement(
     delete ptr;
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
-  }
-}
-
-jobject MakeNativeQueryResult(JNIEnv* env, jlong rows_affected,
-                              struct ArrowArrayStream* out) {
-  // On any failure, release the C struct so its contents don't leak: the Java
-  // side only takes ownership (via snapshot) once construction succeeds.
-  try {
-    jclass native_result_class = RequireImplClass(env, "NativeQueryResult");
-    jmethodID native_result_ctor =
-        RequireMethod(env, native_result_class, "<init>", "(JJ)V");
-    jobject object =
-        env->NewObject(native_result_class, native_result_ctor, rows_affected,
-                       static_cast<jlong>(reinterpret_cast<uintptr_t>(out)));
-    if (object == nullptr || env->ExceptionCheck()) {
-      if (out->release != nullptr) {
-        out->release(out);
-      }
-      return nullptr;
-    }
-    return object;
-  } catch (...) {
-    if (out->release != nullptr) {
-      out->release(out);
-    }
-    throw;
-  }
-}
-
-jobject MakeNativeSchemaResult(JNIEnv* env, struct ArrowSchema* schema) {
-  // On any failure, release the C struct so its contents don't leak: the Java
-  // side only takes ownership (via snapshot) once construction succeeds.
-  try {
-    jclass native_result_class = RequireImplClass(env, "NativeSchemaResult");
-    jmethodID native_result_ctor =
-        RequireMethod(env, native_result_class, "<init>", "(J)V");
-    jobject object =
-        env->NewObject(native_result_class, native_result_ctor,
-                       static_cast<jlong>(reinterpret_cast<uintptr_t>(schema)));
-    if (object == nullptr || env->ExceptionCheck()) {
-      if (schema->release != nullptr) {
-        schema->release(schema);
-      }
-      return nullptr;
-    }
-    return object;
-  } catch (...) {
-    if (schema->release != nullptr) {
-      schema->release(schema);
-    }
-    throw;
   }
 }
 

--- a/java/driver/jni/src/main/cpp/jni_wrapper.cc
+++ b/java/driver/jni/src/main/cpp/jni_wrapper.cc
@@ -328,13 +328,19 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openDatabase(
     jobjectArray parameters) {
   AdbcErrorGuard error_guard;
   try {
+    jclass nativeHandleKlass = RequireImplClass(env, "NativeDatabaseHandle");
+    jmethodID nativeHandleCtor = RequireMethod(env, nativeHandleKlass, "<init>", "(J)V");
+
     auto db = std::make_unique<struct AdbcDatabase>();
     std::memset(db.get(), 0, sizeof(struct AdbcDatabase));
 
     CHECK_ADBC_ERROR(AdbcDatabaseNew(db.get(), &error_guard.error), error_guard.error);
-    CHECK_ADBC_ERROR(AdbcDriverManagerDatabaseSetLoadFlags(
-                         db.get(), ADBC_LOAD_FLAG_DEFAULT, &error_guard.error),
-                     error_guard.error);
+    auto result = AdbcDriverManagerDatabaseSetLoadFlags(db.get(), ADBC_LOAD_FLAG_DEFAULT,
+                                                        &error_guard.error);
+    if (result != ADBC_STATUS_OK) {
+      std::ignore = AdbcDatabaseRelease(db.get(), nullptr);
+    }
+    CHECK_ADBC_ERROR(result, error_guard.error);
 
     const jsize num_params = env->GetArrayLength(parameters);
     if (num_params % 2 != 0) {
@@ -351,18 +357,28 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openDatabase(
 
       JniStringView key_str(env, key);
       JniStringView value_str(env, value);
-      CHECK_ADBC_ERROR(AdbcDatabaseSetOption(db.get(), key_str.value, value_str.value,
-                                             &error_guard.error),
-                       error_guard.error);
+      result = AdbcDatabaseSetOption(db.get(), key_str.value, value_str.value,
+                                     &error_guard.error);
+      if (result != ADBC_STATUS_OK) {
+        std::ignore = AdbcDatabaseRelease(db.get(), nullptr);
+      }
+      CHECK_ADBC_ERROR(result, error_guard.error);
     }
 
-    CHECK_ADBC_ERROR(AdbcDatabaseInit(db.get(), &error_guard.error), error_guard.error);
+    result = AdbcDatabaseInit(db.get(), &error_guard.error);
+    if (result != ADBC_STATUS_OK) {
+      std::ignore = AdbcDatabaseRelease(db.get(), nullptr);
+    }
+    CHECK_ADBC_ERROR(result, error_guard.error);
 
-    jclass nativeHandleKlass = RequireImplClass(env, "NativeDatabaseHandle");
-    jmethodID nativeHandleCtor = RequireMethod(env, nativeHandleKlass, "<init>", "(J)V");
     jobject object =
         env->NewObject(nativeHandleKlass, nativeHandleCtor,
                        static_cast<jlong>(reinterpret_cast<uintptr_t>(db.get())));
+    if (object == nullptr || env->ExceptionCheck()) {
+      // Failed to construct Java object: try to release ADBC handle
+      std::ignore = AdbcDatabaseRelease(db.get(), nullptr);
+      return nullptr;
+    }
     // Don't release until after we've constructed the object
     db.release();
     return object;
@@ -390,6 +406,10 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openConnection(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong database_handle) {
   AdbcErrorGuard error_guard;
   try {
+    jclass native_handle_class = RequireImplClass(env, "NativeConnectionHandle");
+    jmethodID native_handle_ctor =
+        RequireMethod(env, native_handle_class, "<init>", "(J)V");
+
     auto conn = std::make_unique<struct AdbcConnection>();
     std::memset(conn.get(), 0, sizeof(struct AdbcConnection));
 
@@ -398,15 +418,20 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openConnection(
 
     CHECK_ADBC_ERROR(AdbcConnectionNew(conn.get(), &error_guard.error),
                      error_guard.error);
-    CHECK_ADBC_ERROR(AdbcConnectionInit(conn.get(), db, &error_guard.error),
-                     error_guard.error);
+    auto result = AdbcConnectionInit(conn.get(), db, &error_guard.error);
+    if (result != ADBC_STATUS_OK) {
+      std::ignore = AdbcConnectionRelease(conn.get(), nullptr);
+    }
+    CHECK_ADBC_ERROR(result, error_guard.error);
 
-    jclass native_handle_class = RequireImplClass(env, "NativeConnectionHandle");
-    jmethodID native_handle_ctor =
-        RequireMethod(env, native_handle_class, "<init>", "(J)V");
     jobject object =
         env->NewObject(native_handle_class, native_handle_ctor,
                        static_cast<jlong>(reinterpret_cast<uintptr_t>(conn.get())));
+    if (object == nullptr || env->ExceptionCheck()) {
+      // Failed to construct Java object: try to release ADBC handle
+      std::ignore = AdbcConnectionRelease(conn.get(), nullptr);
+      return nullptr;
+    }
     // Don't release until after we've constructed the object
     conn.release();
     return object;
@@ -434,6 +459,10 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openStatement(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong connection_handle) {
   AdbcErrorGuard error_guard;
   try {
+    jclass native_handle_class = RequireImplClass(env, "NativeStatementHandle");
+    jmethodID native_handle_ctor =
+        RequireMethod(env, native_handle_class, "<init>", "(J)V");
+
     auto stmt = std::make_unique<struct AdbcStatement>();
     std::memset(stmt.get(), 0, sizeof(struct AdbcStatement));
 
@@ -443,12 +472,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openStatement(
     CHECK_ADBC_ERROR(AdbcStatementNew(conn, stmt.get(), &error_guard.error),
                      error_guard.error);
 
-    jclass native_handle_class = RequireImplClass(env, "NativeStatementHandle");
-    jmethodID native_handle_ctor =
-        RequireMethod(env, native_handle_class, "<init>", "(J)V");
     jobject object =
         env->NewObject(native_handle_class, native_handle_ctor,
                        static_cast<jlong>(reinterpret_cast<uintptr_t>(stmt.get())));
+    if (object == nullptr || env->ExceptionCheck()) {
+      // Failed to construct Java object: try to release ADBC handle
+      std::ignore = AdbcStatementRelease(stmt.get(), nullptr);
+      return nullptr;
+    }
     // Don't release until after we've constructed the object
     stmt.release();
     return object;
@@ -473,19 +504,53 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_closeStatement(
 
 jobject MakeNativeQueryResult(JNIEnv* env, jlong rows_affected,
                               struct ArrowArrayStream* out) {
-  jclass native_result_class = RequireImplClass(env, "NativeQueryResult");
-  jmethodID native_result_ctor =
-      RequireMethod(env, native_result_class, "<init>", "(JJ)V");
-  return env->NewObject(native_result_class, native_result_ctor, rows_affected,
-                        static_cast<jlong>(reinterpret_cast<uintptr_t>(out)));
+  // On any failure, release the C struct so its contents don't leak: the Java
+  // side only takes ownership (via snapshot) once construction succeeds.
+  try {
+    jclass native_result_class = RequireImplClass(env, "NativeQueryResult");
+    jmethodID native_result_ctor =
+        RequireMethod(env, native_result_class, "<init>", "(JJ)V");
+    jobject object =
+        env->NewObject(native_result_class, native_result_ctor, rows_affected,
+                       static_cast<jlong>(reinterpret_cast<uintptr_t>(out)));
+    if (object == nullptr || env->ExceptionCheck()) {
+      if (out->release != nullptr) {
+        out->release(out);
+      }
+      return nullptr;
+    }
+    return object;
+  } catch (...) {
+    if (out->release != nullptr) {
+      out->release(out);
+    }
+    throw;
+  }
 }
 
 jobject MakeNativeSchemaResult(JNIEnv* env, struct ArrowSchema* schema) {
-  jclass native_result_class = RequireImplClass(env, "NativeSchemaResult");
-  jmethodID native_result_ctor =
-      RequireMethod(env, native_result_class, "<init>", "(J)V");
-  return env->NewObject(native_result_class, native_result_ctor,
-                        static_cast<jlong>(reinterpret_cast<uintptr_t>(schema)));
+  // On any failure, release the C struct so its contents don't leak: the Java
+  // side only takes ownership (via snapshot) once construction succeeds.
+  try {
+    jclass native_result_class = RequireImplClass(env, "NativeSchemaResult");
+    jmethodID native_result_ctor =
+        RequireMethod(env, native_result_class, "<init>", "(J)V");
+    jobject object =
+        env->NewObject(native_result_class, native_result_ctor,
+                       static_cast<jlong>(reinterpret_cast<uintptr_t>(schema)));
+    if (object == nullptr || env->ExceptionCheck()) {
+      if (schema->release != nullptr) {
+        schema->release(schema);
+      }
+      return nullptr;
+    }
+    return object;
+  } catch (...) {
+    if (schema->release != nullptr) {
+      schema->release(schema);
+    }
+    throw;
+  }
 }
 
 JNIEXPORT void JNICALL

--- a/java/driver/jni/src/main/cpp/jni_wrapper.cc
+++ b/java/driver/jni/src/main/cpp/jni_wrapper.cc
@@ -35,21 +35,47 @@
 
 namespace {
 
-struct AdbcErrorGuard {
-  AdbcErrorGuard() = default;
-  AdbcErrorGuard(const AdbcErrorGuard&) = delete;
-  AdbcErrorGuard& operator=(const AdbcErrorGuard&) = delete;
-  AdbcErrorGuard(AdbcErrorGuard&&) = delete;
-  AdbcErrorGuard& operator=(AdbcErrorGuard&&) = delete;
+template <typename T>
+struct AdbcGuardImpl {};
 
-  struct AdbcError error = ADBC_ERROR_INIT;
+template <>
+struct AdbcGuardImpl<struct AdbcDatabase> {
+  static struct AdbcDatabase Init() {
+    struct AdbcDatabase value = {};
+    std::memset(&value, 0, sizeof(struct AdbcDatabase));
+    return value;
+  }
 
-  ~AdbcErrorGuard() {
-    if (error.release != nullptr) {
-      error.release(&error);
-      error.release = nullptr;
+  static void Release(struct AdbcDatabase& value) {
+    if (value.private_data != nullptr) {
+      std::ignore = AdbcDatabaseRelease(&value, nullptr);
     }
   }
+};
+
+template <>
+struct AdbcGuardImpl<struct AdbcError> {
+  static struct AdbcError Init() { return ADBC_ERROR_INIT; }
+
+  static void Release(struct AdbcError& value) {
+    if (value.release != nullptr) {
+      value.release(&value);
+      value.release = nullptr;
+    }
+  }
+};
+
+template <typename T>
+struct AdbcGuard {
+  T value;
+
+  AdbcGuard() : value{AdbcGuardImpl<T>::Init()} {}
+  ~AdbcGuard() { AdbcGuardImpl<T>::Release(value); }
+
+  AdbcGuard(const AdbcGuard&) = delete;
+  AdbcGuard& operator=(const AdbcGuard&) = delete;
+  AdbcGuard(AdbcGuard&&) = delete;
+  AdbcGuard& operator=(AdbcGuard&&) = delete;
 };
 
 void ThrowJavaException(JNIEnv* env, const std::string& klass,
@@ -326,22 +352,10 @@ JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openDatabase(
     JNIEnv* env, [[maybe_unused]] jclass self, [[maybe_unused]] jint version,
     jobjectArray parameters) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     jclass nativeHandleKlass = RequireImplClass(env, "NativeDatabaseHandle");
     jmethodID nativeHandleCtor = RequireMethod(env, nativeHandleKlass, "<init>", "(J)V");
-
-    auto db = std::make_unique<struct AdbcDatabase>();
-    std::memset(db.get(), 0, sizeof(struct AdbcDatabase));
-
-    CHECK_ADBC_ERROR(AdbcDatabaseNew(db.get(), &error_guard.error), error_guard.error);
-    auto result = AdbcDriverManagerDatabaseSetLoadFlags(db.get(), ADBC_LOAD_FLAG_DEFAULT,
-                                                        &error_guard.error);
-    if (result != ADBC_STATUS_OK) {
-      std::ignore = AdbcDatabaseRelease(db.get(), nullptr);
-    }
-    CHECK_ADBC_ERROR(result, error_guard.error);
-
     const jsize num_params = env->GetArrayLength(parameters);
     if (num_params % 2 != 0) {
       throw AdbcException{
@@ -349,6 +363,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openDatabase(
           .message = "[JNI] Must provide even number of parameters",
       };
     }
+
+    AdbcGuard<struct AdbcDatabase> db;
+
+    CHECK_ADBC_ERROR(AdbcDatabaseNew(&db.value, &error_guard.value), error_guard.value);
+    CHECK_ADBC_ERROR(AdbcDriverManagerDatabaseSetLoadFlags(
+                         &db.value, ADBC_LOAD_FLAG_DEFAULT, &error_guard.value),
+                     error_guard.value);
+
     for (jsize i = 0; i < num_params; i += 2) {
       // N.B. assuming String because Java side is typed as String[]
       auto key = reinterpret_cast<jstring>(env->GetObjectArrayElement(parameters, i));
@@ -357,30 +379,25 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openDatabase(
 
       JniStringView key_str(env, key);
       JniStringView value_str(env, value);
-      result = AdbcDatabaseSetOption(db.get(), key_str.value, value_str.value,
-                                     &error_guard.error);
-      if (result != ADBC_STATUS_OK) {
-        std::ignore = AdbcDatabaseRelease(db.get(), nullptr);
-      }
-      CHECK_ADBC_ERROR(result, error_guard.error);
+      CHECK_ADBC_ERROR(AdbcDatabaseSetOption(&db.value, key_str.value, value_str.value,
+                                             &error_guard.value),
+                       error_guard.value);
     }
+    CHECK_ADBC_ERROR(AdbcDatabaseInit(&db.value, &error_guard.value), error_guard.value);
 
-    result = AdbcDatabaseInit(db.get(), &error_guard.error);
-    if (result != ADBC_STATUS_OK) {
-      std::ignore = AdbcDatabaseRelease(db.get(), nullptr);
-    }
-    CHECK_ADBC_ERROR(result, error_guard.error);
-
+    // Copy db to a unique_ptr and then "leak" it (JNI side will release it later)
+    auto handle = std::make_unique<struct AdbcDatabase>(db.value);
+    std::memset(&db.value, 0, sizeof(struct AdbcDatabase));  // prevent double release
     jobject object =
         env->NewObject(nativeHandleKlass, nativeHandleCtor,
-                       static_cast<jlong>(reinterpret_cast<uintptr_t>(db.get())));
+                       static_cast<jlong>(reinterpret_cast<uintptr_t>(handle.get())));
     if (object == nullptr || env->ExceptionCheck()) {
       // Failed to construct Java object: try to release ADBC handle
-      std::ignore = AdbcDatabaseRelease(db.get(), nullptr);
+      std::ignore = AdbcDatabaseRelease(handle.get(), nullptr);
       return nullptr;
     }
     // Don't release until after we've constructed the object
-    db.release();
+    handle.release();
     return object;
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -391,10 +408,10 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openDatabase(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_closeDatabase(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* ptr = reinterpret_cast<struct AdbcDatabase*>(static_cast<uintptr_t>(handle));
-    CHECK_ADBC_ERROR(AdbcDatabaseRelease(ptr, &error_guard.error), error_guard.error);
+    CHECK_ADBC_ERROR(AdbcDatabaseRelease(ptr, &error_guard.value), error_guard.value);
     delete ptr;
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -404,7 +421,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_closeDatabase(
 JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openConnection(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong database_handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     jclass native_handle_class = RequireImplClass(env, "NativeConnectionHandle");
     jmethodID native_handle_ctor =
@@ -416,13 +433,13 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openConnection(
     auto* db =
         reinterpret_cast<struct AdbcDatabase*>(static_cast<uintptr_t>(database_handle));
 
-    CHECK_ADBC_ERROR(AdbcConnectionNew(conn.get(), &error_guard.error),
-                     error_guard.error);
-    auto result = AdbcConnectionInit(conn.get(), db, &error_guard.error);
+    CHECK_ADBC_ERROR(AdbcConnectionNew(conn.get(), &error_guard.value),
+                     error_guard.value);
+    auto result = AdbcConnectionInit(conn.get(), db, &error_guard.value);
     if (result != ADBC_STATUS_OK) {
       std::ignore = AdbcConnectionRelease(conn.get(), nullptr);
     }
-    CHECK_ADBC_ERROR(result, error_guard.error);
+    CHECK_ADBC_ERROR(result, error_guard.value);
 
     jobject object =
         env->NewObject(native_handle_class, native_handle_ctor,
@@ -444,10 +461,10 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openConnection(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_closeConnection(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* ptr = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
-    CHECK_ADBC_ERROR(AdbcConnectionRelease(ptr, &error_guard.error), error_guard.error);
+    CHECK_ADBC_ERROR(AdbcConnectionRelease(ptr, &error_guard.value), error_guard.value);
     delete ptr;
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -457,7 +474,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_closeConnection(
 JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openStatement(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong connection_handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     jclass native_handle_class = RequireImplClass(env, "NativeStatementHandle");
     jmethodID native_handle_ctor =
@@ -469,8 +486,8 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openStatement(
     auto* conn = reinterpret_cast<struct AdbcConnection*>(
         static_cast<uintptr_t>(connection_handle));
 
-    CHECK_ADBC_ERROR(AdbcStatementNew(conn, stmt.get(), &error_guard.error),
-                     error_guard.error);
+    CHECK_ADBC_ERROR(AdbcStatementNew(conn, stmt.get(), &error_guard.value),
+                     error_guard.value);
 
     jobject object =
         env->NewObject(native_handle_class, native_handle_ctor,
@@ -492,10 +509,10 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_openStatement(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_closeStatement(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
-    CHECK_ADBC_ERROR(AdbcStatementRelease(ptr, &error_guard.error), error_guard.error);
+    CHECK_ADBC_ERROR(AdbcStatementRelease(ptr, &error_guard.value), error_guard.value);
     delete ptr;
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -556,10 +573,10 @@ jobject MakeNativeSchemaResult(JNIEnv* env, struct ArrowSchema* schema) {
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementCancel(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
   try {
-    CHECK_ADBC_ERROR(AdbcStatementCancel(ptr, &error_guard.error), error_guard.error);
+    CHECK_ADBC_ERROR(AdbcStatementCancel(ptr, &error_guard.value), error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -568,12 +585,12 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementCancel(
 JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementGetParameterSchema(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
   struct ArrowSchema schema = {};
   try {
-    CHECK_ADBC_ERROR(AdbcStatementGetParameterSchema(ptr, &schema, &error_guard.error),
-                     error_guard.error);
+    CHECK_ADBC_ERROR(AdbcStatementGetParameterSchema(ptr, &schema, &error_guard.value),
+                     error_guard.value);
     return MakeNativeSchemaResult(env, &schema);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -584,7 +601,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementGetParameterSchem
 JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementExecutePartitions(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
   struct ArrowSchema schema = {};
   struct AdbcPartitions partitions = {};
@@ -599,8 +616,8 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementExecutePartitions
         RequireMethod(env, native_result_class, "addPartition", "([B)V");
 
     CHECK_ADBC_ERROR(AdbcStatementExecutePartitions(ptr, &schema, &partitions,
-                                                    &rows_affected, &error_guard.error),
-                     error_guard.error);
+                                                    &rows_affected, &error_guard.value),
+                     error_guard.value);
 
     result = env->NewObject(native_result_class, native_result_ctor, rows_affected,
                             static_cast<jlong>(reinterpret_cast<uintptr_t>(&schema)));
@@ -638,14 +655,14 @@ cleanupall:
 JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementExecuteQuery(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
     struct ArrowArrayStream out = {};
     int64_t rows_affected = 0;
     CHECK_ADBC_ERROR(
-        AdbcStatementExecuteQuery(ptr, &out, &rows_affected, &error_guard.error),
-        error_guard.error);
+        AdbcStatementExecuteQuery(ptr, &out, &rows_affected, &error_guard.value),
+        error_guard.value);
 
     return MakeNativeQueryResult(env, rows_affected, &out);
   } catch (const AdbcException& e) {
@@ -657,12 +674,12 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementExecuteQuery(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetSqlQuery(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring query) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView query_str(env, query);
-    CHECK_ADBC_ERROR(AdbcStatementSetSqlQuery(ptr, query_str.value, &error_guard.error),
-                     error_guard.error);
+    CHECK_ADBC_ERROR(AdbcStatementSetSqlQuery(ptr, query_str.value, &error_guard.value),
+                     error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -671,7 +688,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetSqlQuery(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetSubstraitPlan(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jobject plan) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
   std::vector<uint8_t> allocated_plan;
   size_t plan_length = 0;
@@ -682,8 +699,8 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetSubstraitPlan(
     }
     assert(plan_ptr != nullptr);
     CHECK_ADBC_ERROR(
-        AdbcStatementSetSubstraitPlan(ptr, plan_ptr, plan_length, &error_guard.error),
-        error_guard.error);
+        AdbcStatementSetSubstraitPlan(ptr, plan_ptr, plan_length, &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -692,14 +709,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetSubstraitPlan(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementBind(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jlong values, jlong schema) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
     auto* c_batch = reinterpret_cast<struct ArrowArray*>(static_cast<uintptr_t>(values));
     auto* c_schema =
         reinterpret_cast<struct ArrowSchema*>(static_cast<uintptr_t>(schema));
-    CHECK_ADBC_ERROR(AdbcStatementBind(ptr, c_batch, c_schema, &error_guard.error),
-                     error_guard.error);
+    CHECK_ADBC_ERROR(AdbcStatementBind(ptr, c_batch, c_schema, &error_guard.value),
+                     error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -708,13 +725,13 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementBind(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementBindStream(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jlong stream) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
     auto* c_stream =
         reinterpret_cast<struct ArrowArrayStream*>(static_cast<uintptr_t>(stream));
-    CHECK_ADBC_ERROR(AdbcStatementBindStream(ptr, c_stream, &error_guard.error),
-                     error_guard.error);
+    CHECK_ADBC_ERROR(AdbcStatementBindStream(ptr, c_stream, &error_guard.value),
+                     error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -723,13 +740,13 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementBindStream(
 JNIEXPORT jlong JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementExecuteUpdate(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
     int64_t rows_affected = 0;
     CHECK_ADBC_ERROR(AdbcStatementExecuteQuery(ptr, /*out=*/nullptr, &rows_affected,
-                                               &error_guard.error),
-                     error_guard.error);
+                                               &error_guard.value),
+                     error_guard.value);
     return static_cast<jlong>(rows_affected);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -740,10 +757,10 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementExecuteUpdate(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementPrepare(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
-    CHECK_ADBC_ERROR(AdbcStatementPrepare(ptr, &error_guard.error), error_guard.error);
+    CHECK_ADBC_ERROR(AdbcStatementPrepare(ptr, &error_guard.value), error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -752,12 +769,12 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementPrepare(
 JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementExecuteSchema(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* ptr = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
     struct ArrowSchema schema = {};
-    CHECK_ADBC_ERROR(AdbcStatementExecuteSchema(ptr, &schema, &error_guard.error),
-                     error_guard.error);
+    CHECK_ADBC_ERROR(AdbcStatementExecuteSchema(ptr, &schema, &error_guard.value),
+                     error_guard.value);
 
     return MakeNativeSchemaResult(env, &schema);
   } catch (const AdbcException& e) {
@@ -769,7 +786,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementExecuteSchema(
 JNIEXPORT jbyteArray JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementGetOptionBytes(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* stmt = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
 
   std::vector<uint8_t> buf(1024, '\0');
@@ -778,15 +795,15 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementGetOptionBytes(
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
         AdbcStatementGetOptionBytes(stmt, key_str.value, const_cast<uint8_t*>(buf.data()),
-                                    &length, &error_guard.error),
-        error_guard.error);
+                                    &length, &error_guard.value),
+        error_guard.value);
     while (length > buf.size()) {
       // Buffer was too small, resize and try again
       buf.resize(length);
       CHECK_ADBC_ERROR(AdbcStatementGetOptionBytes(stmt, key_str.value,
                                                    const_cast<uint8_t*>(buf.data()),
-                                                   &length, &error_guard.error),
-                       error_guard.error);
+                                                   &length, &error_guard.value),
+                       error_guard.value);
     }
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -801,14 +818,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementGetOptionBytes(
 JNIEXPORT jdouble JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementGetOptionDouble(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* stmt = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
   double value = 0.0;
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
-        AdbcStatementGetOptionDouble(stmt, key_str.value, &value, &error_guard.error),
-        error_guard.error);
+        AdbcStatementGetOptionDouble(stmt, key_str.value, &value, &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
     return 0.0;
@@ -819,14 +836,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementGetOptionDouble(
 JNIEXPORT jlong JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementGetOptionLong(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* stmt = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
   int64_t value = 0;
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
-        AdbcStatementGetOptionInt(stmt, key_str.value, &value, &error_guard.error),
-        error_guard.error);
+        AdbcStatementGetOptionInt(stmt, key_str.value, &value, &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
     return 0;
@@ -837,7 +854,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementGetOptionLong(
 JNIEXPORT jstring JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementGetOptionString(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* stmt = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
 
   std::vector<char> buf(1024, '\0');
@@ -846,15 +863,15 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementGetOptionString(
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
         AdbcStatementGetOption(stmt, key_str.value, const_cast<char*>(buf.data()),
-                               &length, &error_guard.error),
-        error_guard.error);
+                               &length, &error_guard.value),
+        error_guard.value);
     while (length > buf.size()) {
       // Buffer was too small, resize and try again
       buf.resize(length);
       CHECK_ADBC_ERROR(
           AdbcStatementGetOption(stmt, key_str.value, const_cast<char*>(buf.data()),
-                                 &length, &error_guard.error),
-          error_guard.error);
+                                 &length, &error_guard.value),
+          error_guard.value);
     }
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -867,7 +884,7 @@ JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetOptionBytes(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key,
     jbyteArray value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* stmt = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
@@ -876,8 +893,8 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetOptionBytes(
     env->GetByteArrayRegion(value, 0, value_length,
                             reinterpret_cast<jbyte*>(value_buf.data()));
     CHECK_ADBC_ERROR(AdbcStatementSetOptionBytes(stmt, key_str.value, value_buf.data(),
-                                                 value_buf.size(), &error_guard.error),
-                     error_guard.error);
+                                                 value_buf.size(), &error_guard.value),
+                     error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -886,14 +903,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetOptionBytes(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetOptionDouble(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key, jdouble value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* stmt = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
         AdbcStatementSetOptionDouble(stmt, key_str.value, static_cast<double>(value),
-                                     &error_guard.error),
-        error_guard.error);
+                                     &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -902,14 +919,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetOptionDouble(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetOptionLong(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key, jlong value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* stmt = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
         AdbcStatementSetOptionInt(stmt, key_str.value, static_cast<int64_t>(value),
-                                  &error_guard.error),
-        error_guard.error);
+                                  &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -918,20 +935,20 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetOptionLong(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetOptionString(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key, jstring value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* stmt = reinterpret_cast<struct AdbcStatement*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
     if (value == nullptr) {
       CHECK_ADBC_ERROR(
-          AdbcStatementSetOption(stmt, key_str.value, nullptr, &error_guard.error),
-          error_guard.error);
+          AdbcStatementSetOption(stmt, key_str.value, nullptr, &error_guard.value),
+          error_guard.value);
       return;
     }
     JniStringView value_str(env, value);
     CHECK_ADBC_ERROR(
-        AdbcStatementSetOption(stmt, key_str.value, value_str.value, &error_guard.error),
-        error_guard.error);
+        AdbcStatementSetOption(stmt, key_str.value, value_str.value, &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -940,10 +957,10 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_statementSetOptionString(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionCancel(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* ptr = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   try {
-    CHECK_ADBC_ERROR(AdbcConnectionCancel(ptr, &error_guard.error), error_guard.error);
+    CHECK_ADBC_ERROR(AdbcConnectionCancel(ptr, &error_guard.value), error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -954,7 +971,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetObjects(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jint depth, jstring catalog,
     jstring db_schema, jstring table_name, jobjectArray table_types,
     jstring column_name) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
 
@@ -990,8 +1007,8 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetObjects(
             db_schema_str ? db_schema_str->c_str() : nullptr,
             table_name_str ? table_name_str->c_str() : nullptr, c_table_types,
             column_name_str ? column_name_str->c_str() : nullptr, &out,
-            &error_guard.error),
-        error_guard.error);
+            &error_guard.value),
+        error_guard.value);
 
     return MakeNativeQueryResult(env, -1, &out);
   } catch (const AdbcException& e) {
@@ -1003,7 +1020,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetObjects(
 JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetInfo(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jintArray info_codes) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
 
@@ -1023,8 +1040,8 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetInfo(
     struct ArrowArrayStream out = {};
 
     CHECK_ADBC_ERROR(AdbcConnectionGetInfo(conn, c_info_codes, info_codes_length, &out,
-                                           &error_guard.error),
-                     error_guard.error);
+                                           &error_guard.value),
+                     error_guard.value);
 
     return MakeNativeQueryResult(env, -1, &out);
   } catch (const AdbcException& e) {
@@ -1037,7 +1054,7 @@ JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetTableSchema(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring catalog,
     jstring db_schema, jstring table_name) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
 
@@ -1050,8 +1067,8 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetTableSchema(
     CHECK_ADBC_ERROR(
         AdbcConnectionGetTableSchema(conn, catalog_str ? catalog_str->c_str() : nullptr,
                                      db_schema_str ? db_schema_str->c_str() : nullptr,
-                                     table_name_str.value, &schema, &error_guard.error),
-        error_guard.error);
+                                     table_name_str.value, &schema, &error_guard.value),
+        error_guard.value);
 
     return MakeNativeSchemaResult(env, &schema);
   } catch (const AdbcException& e) {
@@ -1063,14 +1080,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetTableSchema(
 JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetTableTypes(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   try {
     auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
 
     struct ArrowArrayStream out = {};
 
-    CHECK_ADBC_ERROR(AdbcConnectionGetTableTypes(conn, &out, &error_guard.error),
-                     error_guard.error);
+    CHECK_ADBC_ERROR(AdbcConnectionGetTableTypes(conn, &out, &error_guard.value),
+                     error_guard.value);
 
     return MakeNativeQueryResult(env, -1, &out);
   } catch (const AdbcException& e) {
@@ -1082,7 +1099,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetTableTypes(
 JNIEXPORT jbyteArray JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetOptionBytes(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
 
   std::vector<uint8_t> buf(1024, '\0');
@@ -1091,15 +1108,15 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetOptionBytes(
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(AdbcConnectionGetOptionBytes(conn, key_str.value,
                                                   const_cast<uint8_t*>(buf.data()),
-                                                  &length, &error_guard.error),
-                     error_guard.error);
+                                                  &length, &error_guard.value),
+                     error_guard.value);
     while (length > buf.size()) {
       // Buffer was too small, resize and try again
       buf.resize(length);
       CHECK_ADBC_ERROR(AdbcConnectionGetOptionBytes(conn, key_str.value,
                                                     const_cast<uint8_t*>(buf.data()),
-                                                    &length, &error_guard.error),
-                       error_guard.error);
+                                                    &length, &error_guard.value),
+                       error_guard.value);
     }
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -1114,14 +1131,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetOptionBytes(
 JNIEXPORT jdouble JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetOptionDouble(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   double value = 0.0;
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
-        AdbcConnectionGetOptionDouble(conn, key_str.value, &value, &error_guard.error),
-        error_guard.error);
+        AdbcConnectionGetOptionDouble(conn, key_str.value, &value, &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
     return 0.0;
@@ -1132,14 +1149,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetOptionDouble(
 JNIEXPORT jlong JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetOptionLong(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   int64_t value = 0;
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
-        AdbcConnectionGetOptionInt(conn, key_str.value, &value, &error_guard.error),
-        error_guard.error);
+        AdbcConnectionGetOptionInt(conn, key_str.value, &value, &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
     return 0;
@@ -1150,7 +1167,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetOptionLong(
 JNIEXPORT jstring JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetOptionString(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
 
   std::vector<char> buf(1024, '\0');
@@ -1159,15 +1176,15 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetOptionString(
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
         AdbcConnectionGetOption(conn, key_str.value, const_cast<char*>(buf.data()),
-                                &length, &error_guard.error),
-        error_guard.error);
+                                &length, &error_guard.value),
+        error_guard.value);
     while (length > buf.size()) {
       // Buffer was too small, resize and try again
       buf.resize(length);
       CHECK_ADBC_ERROR(
           AdbcConnectionGetOption(conn, key_str.value, const_cast<char*>(buf.data()),
-                                  &length, &error_guard.error),
-          error_guard.error);
+                                  &length, &error_guard.value),
+          error_guard.value);
     }
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -1180,7 +1197,7 @@ JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionSetOptionBytes(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key,
     jbyteArray value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
@@ -1189,8 +1206,8 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionSetOptionBytes(
     env->GetByteArrayRegion(value, 0, value_length,
                             reinterpret_cast<jbyte*>(value_buf.data()));
     CHECK_ADBC_ERROR(AdbcConnectionSetOptionBytes(conn, key_str.value, value_buf.data(),
-                                                  value_buf.size(), &error_guard.error),
-                     error_guard.error);
+                                                  value_buf.size(), &error_guard.value),
+                     error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -1199,14 +1216,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionSetOptionBytes(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionSetOptionDouble(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key, jdouble value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
         AdbcConnectionSetOptionDouble(conn, key_str.value, static_cast<double>(value),
-                                      &error_guard.error),
-        error_guard.error);
+                                      &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -1215,14 +1232,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionSetOptionDouble(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionSetOptionLong(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key, jlong value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
         AdbcConnectionSetOptionInt(conn, key_str.value, static_cast<int64_t>(value),
-                                   &error_guard.error),
-        error_guard.error);
+                                   &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -1231,20 +1248,20 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionSetOptionLong(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionSetOptionString(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key, jstring value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
     if (value == nullptr) {
       CHECK_ADBC_ERROR(
-          AdbcConnectionSetOption(conn, key_str.value, nullptr, &error_guard.error),
-          error_guard.error);
+          AdbcConnectionSetOption(conn, key_str.value, nullptr, &error_guard.value),
+          error_guard.value);
       return;
     }
     JniStringView value_str(env, value);
     CHECK_ADBC_ERROR(
-        AdbcConnectionSetOption(conn, key_str.value, value_str.value, &error_guard.error),
-        error_guard.error);
+        AdbcConnectionSetOption(conn, key_str.value, value_str.value, &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -1253,10 +1270,10 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionSetOptionString(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionCommit(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   try {
-    CHECK_ADBC_ERROR(AdbcConnectionCommit(conn, &error_guard.error), error_guard.error);
+    CHECK_ADBC_ERROR(AdbcConnectionCommit(conn, &error_guard.value), error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -1265,10 +1282,10 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionCommit(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionRollback(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   try {
-    CHECK_ADBC_ERROR(AdbcConnectionRollback(conn, &error_guard.error), error_guard.error);
+    CHECK_ADBC_ERROR(AdbcConnectionRollback(conn, &error_guard.value), error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -1277,7 +1294,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionRollback(
 JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionReadPartition(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jobject partition) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   struct ArrowArrayStream out = {};
   size_t serialized_length = 0;
@@ -1292,8 +1309,8 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionReadPartition(
     assert(serialized_partition != nullptr);
     CHECK_ADBC_ERROR(
         AdbcConnectionReadPartition(conn, serialized_partition, serialized_length, &out,
-                                    &error_guard.error),
-        error_guard.error);
+                                    &error_guard.value),
+        error_guard.value);
     return MakeNativeQueryResult(env, -1, &out);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -1304,12 +1321,12 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionReadPartition(
 JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetStatisticNames(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   struct ArrowArrayStream out = {};
   try {
-    CHECK_ADBC_ERROR(AdbcConnectionGetStatisticNames(conn, &out, &error_guard.error),
-                     error_guard.error);
+    CHECK_ADBC_ERROR(AdbcConnectionGetStatisticNames(conn, &out, &error_guard.value),
+                     error_guard.value);
     return MakeNativeQueryResult(env, -1, &out);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -1321,7 +1338,7 @@ JNIEXPORT jobject JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetStatistics(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring catalog,
     jstring schema, jstring table, jboolean approximate) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* conn = reinterpret_cast<struct AdbcConnection*>(static_cast<uintptr_t>(handle));
   struct ArrowArrayStream out = {};
   try {
@@ -1332,8 +1349,8 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetStatistics(
         AdbcConnectionGetStatistics(conn, catalog_str ? catalog_str->c_str() : nullptr,
                                     schema_str ? schema_str->c_str() : nullptr,
                                     table_str ? table_str->c_str() : nullptr, approximate,
-                                    &out, &error_guard.error),
-        error_guard.error);
+                                    &out, &error_guard.value),
+        error_guard.value);
     return MakeNativeQueryResult(env, -1, &out);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -1344,7 +1361,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_connectionGetStatistics(
 JNIEXPORT jbyteArray JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseGetOptionBytes(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* db = reinterpret_cast<struct AdbcDatabase*>(static_cast<uintptr_t>(handle));
 
   std::vector<uint8_t> buf(1024, '\0');
@@ -1353,15 +1370,15 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseGetOptionBytes(
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
         AdbcDatabaseGetOptionBytes(db, key_str.value, const_cast<uint8_t*>(buf.data()),
-                                   &length, &error_guard.error),
-        error_guard.error);
+                                   &length, &error_guard.value),
+        error_guard.value);
     while (length > buf.size()) {
       // Buffer was too small, resize and try again
       buf.resize(length);
       CHECK_ADBC_ERROR(
           AdbcDatabaseGetOptionBytes(db, key_str.value, const_cast<uint8_t*>(buf.data()),
-                                     &length, &error_guard.error),
-          error_guard.error);
+                                     &length, &error_guard.value),
+          error_guard.value);
     }
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -1376,14 +1393,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseGetOptionBytes(
 JNIEXPORT jdouble JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseGetOptionDouble(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* db = reinterpret_cast<struct AdbcDatabase*>(static_cast<uintptr_t>(handle));
   double value = 0.0;
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
-        AdbcDatabaseGetOptionDouble(db, key_str.value, &value, &error_guard.error),
-        error_guard.error);
+        AdbcDatabaseGetOptionDouble(db, key_str.value, &value, &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
     return 0.0;
@@ -1394,14 +1411,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseGetOptionDouble(
 JNIEXPORT jlong JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseGetOptionLong(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* db = reinterpret_cast<struct AdbcDatabase*>(static_cast<uintptr_t>(handle));
   int64_t value = 0;
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
-        AdbcDatabaseGetOptionInt(db, key_str.value, &value, &error_guard.error),
-        error_guard.error);
+        AdbcDatabaseGetOptionInt(db, key_str.value, &value, &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
     return 0;
@@ -1412,7 +1429,7 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseGetOptionLong(
 JNIEXPORT jstring JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseGetOptionString(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* db = reinterpret_cast<struct AdbcDatabase*>(static_cast<uintptr_t>(handle));
 
   std::vector<char> buf(1024, '\0');
@@ -1421,15 +1438,15 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseGetOptionString(
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
         AdbcDatabaseGetOption(db, key_str.value, const_cast<char*>(buf.data()), &length,
-                              &error_guard.error),
-        error_guard.error);
+                              &error_guard.value),
+        error_guard.value);
     while (length > buf.size()) {
       // Buffer was too small, resize and try again
       buf.resize(length);
       CHECK_ADBC_ERROR(
           AdbcDatabaseGetOption(db, key_str.value, const_cast<char*>(buf.data()), &length,
-                                &error_guard.error),
-          error_guard.error);
+                                &error_guard.value),
+          error_guard.value);
     }
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
@@ -1442,7 +1459,7 @@ JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseSetOptionBytes(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key,
     jbyteArray value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* db = reinterpret_cast<struct AdbcDatabase*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
@@ -1451,8 +1468,8 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseSetOptionBytes(
     env->GetByteArrayRegion(value, 0, value_length,
                             reinterpret_cast<jbyte*>(value_buf.data()));
     CHECK_ADBC_ERROR(AdbcDatabaseSetOptionBytes(db, key_str.value, value_buf.data(),
-                                                value_buf.size(), &error_guard.error),
-                     error_guard.error);
+                                                value_buf.size(), &error_guard.value),
+                     error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -1461,14 +1478,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseSetOptionBytes(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseSetOptionDouble(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key, jdouble value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* db = reinterpret_cast<struct AdbcDatabase*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
         AdbcDatabaseSetOptionDouble(db, key_str.value, static_cast<double>(value),
-                                    &error_guard.error),
-        error_guard.error);
+                                    &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -1477,14 +1494,14 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseSetOptionDouble(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseSetOptionLong(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key, jlong value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* db = reinterpret_cast<struct AdbcDatabase*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
     CHECK_ADBC_ERROR(
         AdbcDatabaseSetOptionInt(db, key_str.value, static_cast<int64_t>(value),
-                                 &error_guard.error),
-        error_guard.error);
+                                 &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }
@@ -1493,20 +1510,20 @@ Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseSetOptionLong(
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_adbc_driver_jni_impl_NativeAdbc_databaseSetOptionString(
     JNIEnv* env, [[maybe_unused]] jclass self, jlong handle, jstring key, jstring value) {
-  AdbcErrorGuard error_guard;
+  AdbcGuard<struct AdbcError> error_guard;
   auto* db = reinterpret_cast<struct AdbcDatabase*>(static_cast<uintptr_t>(handle));
   try {
     JniStringView key_str(env, key);
     if (value == nullptr) {
       CHECK_ADBC_ERROR(
-          AdbcDatabaseSetOption(db, key_str.value, nullptr, &error_guard.error),
-          error_guard.error);
+          AdbcDatabaseSetOption(db, key_str.value, nullptr, &error_guard.value),
+          error_guard.value);
       return;
     }
     JniStringView value_str(env, value);
     CHECK_ADBC_ERROR(
-        AdbcDatabaseSetOption(db, key_str.value, value_str.value, &error_guard.error),
-        error_guard.error);
+        AdbcDatabaseSetOption(db, key_str.value, value_str.value, &error_guard.value),
+        error_guard.value);
   } catch (const AdbcException& e) {
     e.ThrowJavaException(env);
   }


### PR DESCRIPTION
When NewObject fails, explicitly call AdbcFooRelease or foo->release instead of implicitly leaking the ADBC handle.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>