### PR TITLE
feat!(ruby): set LoadFlags::DEFAULT on Database.new and allow override in open

### DIFF
--- a/glib/adbc-glib/database.c
+++ b/glib/adbc-glib/database.c
@@ -75,6 +75,12 @@ GADBCDatabase* gadbc_database_new(GError** error) {
   AdbcStatusCode status_code = AdbcDatabaseNew(&(priv->adbc_database), &adbc_error);
   priv->initialized =
       gadbc_error_check(error, status_code, &adbc_error, "[adbc][database][new]");
+  if (priv->initialized) {
+    status_code = AdbcDriverManagerDatabaseSetLoadFlags(
+        &(priv->adbc_database), GADBC_LOAD_FLAGS_DEFAULT, &adbc_error);
+    priv->initialized = gadbc_error_check(error, status_code, &adbc_error,
+                                          "[adbc][database][set-load-flags]");
+  }
   if (!priv->initialized) {
     g_object_unref(database);
     return NULL;

--- a/glib/adbc-glib/database.h
+++ b/glib/adbc-glib/database.h
@@ -48,7 +48,7 @@ typedef enum {
 } GADBCLoadFlags;
 
 /**
- * GADBC_LOAD_FLAGAS_DEFAULT:
+ * GADBC_LOAD_FLAGS_DEFAULT:
  *
  * The default GADBCLoadFlags.
  *

--- a/ruby/lib/adbc/database.rb
+++ b/ruby/lib/adbc/database.rb
@@ -23,7 +23,7 @@ module ADBC
         need_release = true
         begin
           options.each do |key, value|
-            database.set_option(key.to_s, value)
+            database.set_option(key, value)
           end
           database.set_load_flags(load_flags) unless load_flags.nil?
           database.init

--- a/ruby/lib/adbc/database.rb
+++ b/ruby/lib/adbc/database.rb
@@ -18,14 +18,20 @@
 module ADBC
   class Database
     class << self
-      def open(load_flags: LoadFlags::DEFAULT, **options)
+      def new
+        database = super
+        database.set_load_flags(LoadFlags::DEFAULT)
+        database
+      end
+
+      def open(load_flags: nil, **options)
         database = new
         need_release = true
         begin
           options.each do |key, value|
             database.set_option(key.to_s, value)
           end
-          database.set_load_flags(load_flags)
+          database.set_load_flags(load_flags) unless load_flags.nil?
           database.init
           if block_given?
             yield(database)

--- a/ruby/lib/adbc/database.rb
+++ b/ruby/lib/adbc/database.rb
@@ -18,13 +18,14 @@
 module ADBC
   class Database
     class << self
-      def open(**options)
+      def open(load_flags: LoadFlags::DEFAULT, **options)
         database = new
         need_release = true
         begin
           options.each do |key, value|
-            database.set_option(key, value)
+            database.set_option(key.to_s, value)
           end
+          database.set_load_flags(load_flags)
           database.init
           if block_given?
             yield(database)

--- a/ruby/lib/adbc/database.rb
+++ b/ruby/lib/adbc/database.rb
@@ -18,12 +18,6 @@
 module ADBC
   class Database
     class << self
-      def new
-        database = super
-        database.set_load_flags(LoadFlags::DEFAULT)
-        database
-      end
-
       def open(load_flags: nil, **options)
         database = new
         need_release = true

--- a/ruby/test/test-database.rb
+++ b/ruby/test/test-database.rb
@@ -44,8 +44,8 @@ class DatabaseTest < Test::Unit::TestCase
               assert_equal([
                               Arrow::Table.new("1" => Arrow::Int64Array.new([1])),
                               -1,
-                            ],
-                            connection.query("SELECT 1"))
+                           ],
+                           connection.query("SELECT 1"))
           end
         end
       end

--- a/ruby/test/test-database.rb
+++ b/ruby/test/test-database.rb
@@ -51,13 +51,12 @@ class DatabaseTest < Test::Unit::TestCase
       end
 
       def test_no_flags_cannot_find_driver
-        error = assert_raise_kind_of(ADBC::Error) do
+        assert_raise(ADBC::Error::NotFound) do
           ADBC::Database.open(driver: "testdriver",
                               uri: ":memory:",
                               load_flags: ADBC::LoadFlags.new(0)) do |_database|
           end
         end
-        assert_match(/not enabled at run time/, error.message)
       end
     end
   end

--- a/ruby/test/test-database.rb
+++ b/ruby/test/test-database.rb
@@ -35,21 +35,21 @@ class DatabaseTest < Test::Unit::TestCase
 
     sub_test_case("manifest") do
       def setup
-        @tmpdir = Dir.mktmpdir
-        File.write(File.join(@tmpdir, "testdriver.toml"), <<~TOML)
-          name = "test driver"
-          version = "0.1.0"
+        Dir.mktmpdir do |tmpdir|
+          File.write(File.join(tmpdir, "testdriver.toml"), <<~TOML)
+            name = "test driver"
+            version = "0.1.0"
 
-          [Driver]
-          shared = "adbc_driver_sqlite"
-        TOML
-        @original_driver_path = ENV["ADBC_DRIVER_PATH"]
-        ENV["ADBC_DRIVER_PATH"] = @tmpdir
-      end
-
-      def teardown
-        ENV["ADBC_DRIVER_PATH"] = @original_driver_path
-        FileUtils.remove_entry(@tmpdir)
+            [Driver]
+            shared = "adbc_driver_sqlite"
+          TOML
+          driver_path, ENV["ADBC_DRIVER_PATH"] = ENV["ADBC_DRIVER_PATH"], tmpdir
+          begin
+            yield
+          ensure
+            ENV["ADBC_DRIVER_PATH"] = driver_path
+          end
+        end
       end
 
       def test_search_env_finds_driver

--- a/ruby/test/test-database.rb
+++ b/ruby/test/test-database.rb
@@ -17,21 +17,59 @@
 
 class DatabaseTest < Test::Unit::TestCase
   sub_test_case(".open") do
-    test("applies LoadFlags::DEFAULT when load_flags is not passed") do
+    def test_default_load_flags
       assert_nothing_raised do
         ADBC::Database.open(driver: "adbc_driver_sqlite", uri: ":memory:") do |_database|
         end
       end
     end
 
-    test("load_flags: none disables all search paths") do
-      error = assert_raise_kind_of(ADBC::Error) do
+    def test_load_flags_override
+      assert_nothing_raised do
         ADBC::Database.open(driver: "adbc_driver_sqlite",
                             uri: ":memory:",
-                            load_flags: ADBC::LoadFlags.new(0)) do |_database|
+                            load_flags: ADBC::LoadFlags::DEFAULT) do |_database|
         end
       end
-      assert_match(/not enabled at run time/, error.message)
+    end
+
+    sub_test_case("manifest") do
+      def setup
+        @tmpdir = Dir.mktmpdir
+        File.write(File.join(@tmpdir, "testdriver.toml"), <<~TOML)
+          name = "test driver"
+          version = "0.1.0"
+
+          [Driver]
+          shared = "adbc_driver_sqlite"
+        TOML
+        @original_driver_path = ENV["ADBC_DRIVER_PATH"]
+        ENV["ADBC_DRIVER_PATH"] = @tmpdir
+      end
+
+      def teardown
+        ENV["ADBC_DRIVER_PATH"] = @original_driver_path
+        FileUtils.remove_entry(@tmpdir)
+      end
+
+      def test_search_env_finds_driver
+        assert_nothing_raised do
+          ADBC::Database.open(driver: "testdriver",
+                              uri: ":memory:",
+                              load_flags: ADBC::LoadFlags::SEARCH_ENV) do |_database|
+          end
+        end
+      end
+
+      def test_no_flags_cannot_find_driver
+        error = assert_raise_kind_of(ADBC::Error) do
+          ADBC::Database.open(driver: "testdriver",
+                              uri: ":memory:",
+                              load_flags: ADBC::LoadFlags.new(0)) do |_database|
+          end
+        end
+        assert_match(/not enabled at run time/, error.message)
+      end
     end
   end
 end

--- a/ruby/test/test-database.rb
+++ b/ruby/test/test-database.rb
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class DatabaseTest < Test::Unit::TestCase
+  sub_test_case(".open") do
+    test("applies LoadFlags::DEFAULT when load_flags is not passed") do
+      assert_nothing_raised do
+        ADBC::Database.open(driver: "adbc_driver_sqlite", uri: ":memory:") do |_database|
+        end
+      end
+    end
+
+    test("load_flags: none disables all search paths") do
+      error = assert_raise_kind_of(ADBC::Error) do
+        ADBC::Database.open(driver: "adbc_driver_sqlite",
+                            uri: ":memory:",
+                            load_flags: ADBC::LoadFlags.new(0)) do |_database|
+        end
+      end
+      assert_match(/not enabled at run time/, error.message)
+    end
+  end
+end

--- a/ruby/test/test-database.rb
+++ b/ruby/test/test-database.rb
@@ -53,10 +53,15 @@ class DatabaseTest < Test::Unit::TestCase
       end
 
       def test_search_env_finds_driver
-        assert_nothing_raised do
-          ADBC::Database.open(driver: "testdriver",
-                              uri: ":memory:",
-                              load_flags: ADBC::LoadFlags::SEARCH_ENV) do |_database|
+        ADBC::Database.open(driver: "testdriver",
+                            uri: ":memory:",
+                            load_flags: ADBC::LoadFlags::SEARCH_ENV) do |database|
+          database.connect do |connection|                          
+              assert_equal([
+                     Arrow::Table.new("1" => Arrow::Int64Array.new([1])),
+                     -1,
+                   ],
+                   connection.query("SELECT 1"))                    
           end
         end
       end

--- a/ruby/test/test-database.rb
+++ b/ruby/test/test-database.rb
@@ -17,22 +17,6 @@
 
 class DatabaseTest < Test::Unit::TestCase
   sub_test_case(".open") do
-    def test_default_load_flags
-      assert_nothing_raised do
-        ADBC::Database.open(driver: "adbc_driver_sqlite", uri: ":memory:") do |_database|
-        end
-      end
-    end
-
-    def test_load_flags_override
-      assert_nothing_raised do
-        ADBC::Database.open(driver: "adbc_driver_sqlite",
-                            uri: ":memory:",
-                            load_flags: ADBC::LoadFlags::DEFAULT) do |_database|
-        end
-      end
-    end
-
     sub_test_case("manifest") do
       def setup
         Dir.mktmpdir do |tmpdir|

--- a/ruby/test/test-database.rb
+++ b/ruby/test/test-database.rb
@@ -39,13 +39,13 @@ class DatabaseTest < Test::Unit::TestCase
       def test_search_env_finds_driver
         ADBC::Database.open(driver: "testdriver",
                             uri: ":memory:",
-                            load_flags: ADBC::LoadFlags::SEARCH_ENV) do |database|
+                            load_flags: :search_env) do |database|
           database.connect do |connection|
               assert_equal([
-                     Arrow::Table.new("1" => Arrow::Int64Array.new([1])),
-                     -1,
-                   ],
-                   connection.query("SELECT 1"))
+                              Arrow::Table.new("1" => Arrow::Int64Array.new([1])),
+                              -1,
+                            ],
+                            connection.query("SELECT 1"))
           end
         end
       end

--- a/ruby/test/test-database.rb
+++ b/ruby/test/test-database.rb
@@ -54,7 +54,7 @@ class DatabaseTest < Test::Unit::TestCase
         assert_raise(ADBC::Error::NotFound) do
           ADBC::Database.open(driver: "testdriver",
                               uri: ":memory:",
-                              load_flags: ADBC::LoadFlags.new(0)) do |_database|
+                              load_flags: 0) do |_database|
           end
         end
       end

--- a/ruby/test/test-database.rb
+++ b/ruby/test/test-database.rb
@@ -40,12 +40,12 @@ class DatabaseTest < Test::Unit::TestCase
         ADBC::Database.open(driver: "testdriver",
                             uri: ":memory:",
                             load_flags: ADBC::LoadFlags::SEARCH_ENV) do |database|
-          database.connect do |connection|                          
+          database.connect do |connection|
               assert_equal([
                      Arrow::Table.new("1" => Arrow::Int64Array.new([1])),
                      -1,
                    ],
-                   connection.query("SELECT 1"))                    
+                   connection.query("SELECT 1"))
           end
         end
       end


### PR DESCRIPTION
The current way to load an ADBC driver installed via ADBC driver manifest is cumbersome because the user has to do it over multiple calls and can't use the block-based `Database.open` if they need to customize init. This is currently what it looks like to load the sqlite driver installed via manfiest:

```ruby
database = ADBC::Database.new

begin
  database.set_option("driver", "sqlite")
  database.set_option("uri", "games.sqlite")
  database.set_load_flags(ADBC::LoadFlags::DEFAULT)
...
```

It would be better if we could write:

```ruby
ADBC::Database.open(driver: "sqlite", uri: "games.sqlite") do |database|
  ...
end
```

This PR does two things,

1. Set the default value of LoadFlags to ADBC_LOAD_FLAG_DEFAULT. This matches Python.
2. Adds a load_flags keyword arg to Database.open so the user can override it without having to drop down to Database.new

This is a breaking change because existing direct and indirect callers of Database.new will get different driver loading behavior.