### PR TITLE
fix(ruby): correct open_statement typo in Connection#ingest

### DIFF
--- a/ruby/lib/adbc/connection-operations.rb
+++ b/ruby/lib/adbc/connection-operations.rb
@@ -24,7 +24,7 @@ module ADBC
     end
 
     def ingest(table_name, values, mode: :create)
-      open_statment do |statement|
+      open_statement do |statement|
         statement.ingest(table_name, values, mode: mode)
       end
     end

--- a/ruby/test/test-connection.rb
+++ b/ruby/test/test-connection.rb
@@ -53,6 +53,53 @@ class ConnectionTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("#ingest") do
+    def test_record_batch
+      numbers = Arrow::Int64Array.new([10, 20, 30])
+      record_batch = Arrow::RecordBatch.new(number: numbers)
+      @connection.ingest("data", record_batch)
+      table, n_rows_affected = @connection.query("SELECT * FROM data")
+      assert_equal([
+                     Arrow::Table.new(number: numbers),
+                     -1,
+                   ],
+                   [
+                     table,
+                     n_rows_affected,
+                   ])
+    end
+
+    def test_record_batch_reader
+      numbers = Arrow::Int64Array.new([10, 20, 30])
+      record_batch = Arrow::RecordBatch.new(number: numbers)
+      @connection.ingest("data", Arrow::RecordBatchReader.new([record_batch]))
+      table, n_rows_affected = @connection.query("SELECT * FROM data")
+      assert_equal([
+                     Arrow::Table.new(number: numbers),
+                     -1,
+                   ],
+                   [
+                     table,
+                     n_rows_affected,
+                   ])
+    end
+
+    def test_arrow_table
+      numbers = Arrow::Int64Array.new([10, 20, 30])
+      input_table = Arrow::Table.new(number: numbers)
+      @connection.ingest("data", input_table)
+      table, n_rows_affected = @connection.query("SELECT * FROM data")
+      assert_equal([
+                     input_table,
+                     -1,
+                   ],
+                   [
+                     table,
+                     n_rows_affected,
+                   ])
+    end
+  end
+
   sub_test_case("#info") do
     def test_all
       info = @connection.info


### PR DESCRIPTION
`Connection#ingest` called `open_statment`, which is undefined,so it always raised NoMethodError.
The typo went unnoticed because only Statement#ingest had a test.

```diff
- open_statment
+ open_statement
```

Closes GH-4417.