### PR TITLE
ci: fix .NET install in release verification

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -260,30 +260,11 @@ install_dotnet() {
   show_info "dotnet found but it is the wrong version or dotnet not found"
 
   local csharp_bin=${ARROW_TMPDIR}/csharp/bin
-  local dotnet_version=10.0.203
-  local dotnet_platform=
-  case "$(uname)" in
-      Linux)
-          dotnet_platform=linux
-          ;;
-      Darwin)
-          dotnet_platform=macos
-          ;;
-  esac
-  local dotnet_download_thank_you_url=https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-${dotnet_version}-${dotnet_platform}-x64-binaries
-  show_info "Getting .NET download URL from ${dotnet_download_thank_you_url}"
-  curl --fail -L -o "${ARROW_TMPDIR}/dotnetdownload.html" "${dotnet_download_thank_you_url}"
-  local dotnet_download_url=$(grep 'directLink' "${ARROW_TMPDIR}/dotnetdownload.html" | \
-                                  grep -E -o 'https://builds.dotnet[^"]+' | \
-                                  head -n1)
-  if [ -z "${dotnet_download_url}" ]; then
-    echo "Failed to get .NET download URL from ${dotnet_download_thank_you_url}"
-    exit 1
-  fi
-  show_info "Downloading .NET from ${dotnet_download_url}"
+  local dotnet_channel=10.0
   mkdir -p ${csharp_bin}
-  curl -sL ${dotnet_download_url} | \
-      tar xzf - -C ${csharp_bin}
+  show_info "Installing .NET ${dotnet_channel} via dotnet-install.sh"
+  curl --fail -sSL https://dot.net/v1/dotnet-install.sh | \
+      bash /dev/stdin --channel ${dotnet_channel} --install-dir ${csharp_bin}
   PATH=${csharp_bin}:${PATH}
   show_info "Installed C# at $(which csharp) (.NET $(dotnet --version))"
 


### PR DESCRIPTION
`install_dotnet()` in `dev/release/verify-release-candidate.sh` pins a .NET SDK version (10.0.203) and scrapes its Microsoft download page for the binary URL. That page no longer resolves for the pinned version, so nightly release verification fails before the C# checks run (#4421).

Bumping the pinned version fixes it, but the pin goes stale on every SDK release. As an alternative, here's what it looks like to use Microsoft's official install script, which is intended for CI: with `--channel 10.0` it always installs the current 10.0 SDK, so there's no version or URL for us to keep bumping.

This replaces the pinned version, the `download/thank-you/...` page scrape, and the `uname`/`-x64` decode (so the right SDK is also picked on arm64).

Trade-off: the script is more of a black box than the inline code, which is transparent and a quick version bump. I don't feel strongly — happy to just bump the version instead if you'd prefer.

## How to verify

```bash
dir=$(mktemp -d)
curl --fail -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 10.0 --install-dir "$dir"
"$dir/dotnet" --version   # → 10.0.301
```

Microsoft recommends this script for CI [1].

[1]: https://learn.microsoft.com/dotnet/core/tools/dotnet-install-script

Closes #4421.