### PR TITLE
chore: do not fail PRs that contain emails

### DIFF
--- a/.github/workflows/dev_pr/body_check.py
+++ b/.github/workflows/dev_pr/body_check.py
@@ -22,7 +22,7 @@ import re
 import sys
 import typing
 
-PING_RE = re.compile(r"@([a-zA-Z0-9\-]+)")
+PING_RE = re.compile(r"(?<!\S)@([a-zA-Z0-9\-]+)")
 IGNORED_USERNAMES = {"dependabot"}
 
 

--- a/.github/workflows/dev_pr/body_check.py
+++ b/.github/workflows/dev_pr/body_check.py
@@ -22,7 +22,7 @@ import re
 import sys
 import typing
 
-PING_RE = re.compile(r"(?<!\S)@([a-zA-Z0-9\-]+)")
+PING_RE = re.compile(r"(?<![a-zA-Z0-9])@([a-zA-Z0-9\-]+)")
 IGNORED_USERNAMES = {"dependabot"}
 
 


### PR DESCRIPTION
GitHub doesn't handle `Assisted-by`/`Generated-by` in commits when squash merging is turned on, so they need to be in the PR description, and they shouldn't count as a ping.