### PR TITLE
feat(rust): make boolean conventions clearer

### DIFF
--- a/rust/core/src/constants.rs
+++ b/rust/core/src/constants.rs
@@ -75,6 +75,9 @@ pub const ADBC_OPTION_URI: &str = "uri";
 pub const ADBC_OPTION_USERNAME: &str = "username";
 pub const ADBC_OPTION_PASSWORD: &str = "password";
 
+pub const ADBC_OPTION_VALUE_ENABLED: &str = "true";
+pub const ADBC_OPTION_VALUE_DISABLED: &str = "false";
+
 pub const ADBC_CONNECTION_OPTION_AUTOCOMMIT: &str = "adbc.connection.autocommit";
 pub const ADBC_CONNECTION_OPTION_READ_ONLY: &str = "adbc.connection.readonly";
 pub const ADBC_CONNECTION_OPTION_CURRENT_CATALOG: &str = "adbc.connection.catalog";

--- a/rust/core/src/options.rs
+++ b/rust/core/src/options.rs
@@ -130,7 +130,10 @@ impl TryFrom<&OptionValue> for bool {
             OptionValue::String(value) if value == ADBC_OPTION_VALUE_ENABLED => Ok(true),
             OptionValue::String(value) if value == ADBC_OPTION_VALUE_DISABLED => Ok(false),
             _ => Err(Error::with_message_and_status(
-                format!("expected \"true\" or \"false\", got {value:?}"),
+                format!(
+                    "expected {ADBC_OPTION_VALUE_ENABLED:?} or {ADBC_OPTION_VALUE_DISABLED:?}, \
+                     got {value:?}"
+                ),
                 Status::InvalidArguments,
             )),
         }

--- a/rust/core/src/options.rs
+++ b/rust/core/src/options.rs
@@ -18,6 +18,7 @@
 //! Various option and configuration types.
 use std::{os::raw::c_int, str::FromStr};
 
+use crate::constants::{ADBC_OPTION_VALUE_DISABLED, ADBC_OPTION_VALUE_ENABLED};
 use crate::{
     constants,
     error::{Error, Status},
@@ -26,6 +27,13 @@ use crate::{
 /// Option value.
 ///
 /// Can be created with various implementations of [From].
+///
+/// # Note: Booleans
+/// ADBC passes booleans as the strings `"true"` ([`ADBC_OPTION_VALUE_ENABLED`])
+/// or `"false"` ([`ADBC_OPTION_VALUE_DISABLED`]).
+///
+/// To reflect this, instead of a special boolean variant, this type implements `From<bool>`
+/// and provides `TryFrom<OptionValue> for bool` which expects [`Self::String`].
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum OptionValue {
@@ -80,6 +88,52 @@ impl<const N: usize> From<[u8; N]> for OptionValue {
 impl<const N: usize> From<&[u8; N]> for OptionValue {
     fn from(value: &[u8; N]) -> Self {
         Self::Bytes(value.into())
+    }
+}
+
+impl From<bool> for OptionValue {
+    /// Convert a boolean to the ADBC string equivalent.
+    ///
+    /// Returns `"true"` ([`ADBC_OPTION_VALUE_ENABLED`]) for `true`
+    /// or `"false"` ([`ADBC_OPTION_VALUE_DISABLED`]) for `false`.
+    fn from(value: bool) -> Self {
+        if value {
+            ADBC_OPTION_VALUE_ENABLED.into()
+        } else {
+            ADBC_OPTION_VALUE_DISABLED.into()
+        }
+    }
+}
+
+impl TryFrom<OptionValue> for bool {
+    type Error = Error;
+
+    /// Expects either `"true"` ([`ADBC_OPTION_VALUE_ENABLED`]) for `true`
+    /// or `"false"` ([`ADBC_OPTION_VALUE_DISABLED`]) for `false`.
+    ///
+    /// Returns an error with [`Status::InvalidArguments`] if any other string or value type.
+    fn try_from(value: OptionValue) -> Result<Self, Self::Error> {
+        // Forward to the borrowed implementation
+        <bool as TryFrom<&OptionValue>>::try_from(&value)
+    }
+}
+
+impl TryFrom<&OptionValue> for bool {
+    type Error = Error;
+
+    /// Expects either `"true"` ([`ADBC_OPTION_VALUE_ENABLED`]) for `true`
+    /// or `"false"` ([`ADBC_OPTION_VALUE_DISABLED`]) for `false`.
+    ///
+    /// Returns an error with [`Status::InvalidArguments`] if any other string or value type.
+    fn try_from(value: &OptionValue) -> Result<Self, Self::Error> {
+        match value {
+            OptionValue::String(value) if value == ADBC_OPTION_VALUE_ENABLED => Ok(true),
+            OptionValue::String(value) if value == ADBC_OPTION_VALUE_DISABLED => Ok(false),
+            _ => Err(Error::with_message_and_status(
+                format!("expected \"true\" or \"false\", got {value:?}"),
+                Status::InvalidArguments,
+            )),
+        }
     }
 }
 


### PR DESCRIPTION
Adds `From<bool> for OptionValue` and `TryFrom<OptionValue> for bool` (and `TryFrom<&OptionValue>`).

Documents boolean conventions on `OptionValue` for clarity/discoverability.

closes #4413