### PR TITLE
ci: don't force XCode 16

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -153,9 +153,6 @@ jobs:
       - name: Build artifacts (macOS)
         if: matrix.os == 'macOS'
         run: |
-          # XXX(https://github.com/apache/arrow-adbc/issues/3382)
-          sudo xcode-select -s "/Applications/Xcode_16.app"
-
           export ADBC_BUILD_STATIC=ON
           export ADBC_BUILD_TESTS=OFF
           export ADBC_USE_ASAN=OFF

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -833,12 +833,6 @@ jobs:
           cache: false
           cache-dependency-path: adbc/go/adbc/go.sum
 
-      - name: Downgrade XCode
-        if: matrix.os == 'macos-latest'
-        run: |
-          # XXX(https://github.com/apache/arrow-adbc/issues/3382)
-          sudo xcode-select -s "/Applications/Xcode_16.app"
-
       - name: Build wheel
         env:
           ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
We did this due to a build issue, but it seems the runner image has updated and now XCode 16 isn't available.

Previously: https://github.com/apache/arrow-adbc/issues/3382