### PR TITLE
fix(c/driver_manager): preserve quoted-key text in profile redefinition errors

### DIFF
--- a/c/driver_manager/adbc_driver_manager_test.cc
+++ b/c/driver_manager/adbc_driver_manager_test.cc
@@ -1731,6 +1731,34 @@ TEST_F(ConnectionProfiles, DotSeparatedKey) {
   UnsetProfilePath();
 }
 
+TEST_F(ConnectionProfiles, DuplicateQuotedKey) {
+  // Regression: a duplicate *quoted* key must report the real key name, not a
+  // copy with its first two characters doubled (vendored toml++ bug, fixed
+  // upstream in marzer/tomlplusplus#300 / PR #302 / commit f22f035).
+  auto filepath = temp_dir / "profile.toml";
+  std::ofstream test_profile_file(filepath);
+  ASSERT_TRUE(test_profile_file.is_open());
+  test_profile_file << "profile_version = 1\n"
+                       "driver = \"adbc_driver_sqlite\"\n"
+                       "[Options]\n"
+                       "\"redshift.db_name\" = \"dev\"\n"
+                       "\"redshift.db_name\" = \"sample_datadev\"\n";
+  test_profile_file.close();
+
+  adbc_validation::Handle<struct AdbcDatabase> database;
+
+  // find profile by name using ADBC_PROFILE_PATH
+  SetProfilePath(temp_dir.string().c_str());
+  ASSERT_THAT(AdbcDatabaseNew(&database.value, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcDatabaseSetOption(&database.value, "profile", "profile", &error),
+              IsOkStatus(&error));
+  ASSERT_THAT(AdbcDatabaseInit(&database.value, &error),
+              IsStatus(ADBC_STATUS_INVALID_ARGUMENT, &error));
+  ASSERT_THAT(error.message, ::testing::HasSubstr("redshift.db_name"));
+  ASSERT_THAT(error.message, ::testing::Not(::testing::HasSubstr("reredshift")));
+  UnsetProfilePath();
+}
+
 TEST_F(ConnectionProfiles, UseEnvVar) {
   auto filepath = temp_dir / "profile.toml";
   toml::table profile = toml::parse(R"|(

--- a/c/vendor/toml++/toml.hpp
+++ b/c/vendor/toml++/toml.hpp
@@ -14130,6 +14130,9 @@ TOML_IMPL_NAMESPACE_START
 			TOML_ASSERT_ASSUME(is_string_delimiter(*cp));
 			push_parse_scope("string"sv);
 
+			// snapshot length so the recording buffer can be rewound alongside go_back(2u) below
+			const auto recording_buffer_rollback_size = recording_buffer.length();
+
 			// get the first three characters to determine the string type
 			const auto first = cp->value;
 			advance_and_return_if_error_or_eof({});
@@ -14160,6 +14163,8 @@ TOML_IMPL_NAMESPACE_START
 				// step back two characters so that the current
 				// character is the string delimiter
 				go_back(2u);
+				if (recording)
+					recording_buffer.resize(recording_buffer_rollback_size);
 
 				return { first == U'\'' ? parse_literal_string(false) : parse_basic_string(false), false };
 			}

--- a/go/adbc/drivermgr/vendored/toml++/toml.hpp
+++ b/go/adbc/drivermgr/vendored/toml++/toml.hpp
@@ -14130,6 +14130,9 @@ TOML_IMPL_NAMESPACE_START
 			TOML_ASSERT_ASSUME(is_string_delimiter(*cp));
 			push_parse_scope("string"sv);
 
+			// snapshot length so the recording buffer can be rewound alongside go_back(2u) below
+			const auto recording_buffer_rollback_size = recording_buffer.length();
+
 			// get the first three characters to determine the string type
 			const auto first = cp->value;
 			advance_and_return_if_error_or_eof({});
@@ -14160,6 +14163,8 @@ TOML_IMPL_NAMESPACE_START
 				// step back two characters so that the current
 				// character is the string delimiter
 				go_back(2u);
+				if (recording)
+					recording_buffer.resize(recording_buffer_rollback_size);
 
 				return { first == U'\'' ? parse_literal_string(false) : parse_basic_string(false), false };
 			}


### PR DESCRIPTION
## What

A duplicate *quoted* key in a connection profile (for example, two
`"redshift.db_name"` entries) produced a confusing parse error that
doubled the first two characters of the key name:

```
cannot redefine existing string '"reredshift.db_name" '
```

instead of naming `redshift.db_name`.

## Root cause

The bug is in the vendored toml++ (v3.4.0). `parse_string()` advances two
characters to detect a `"""` multi-line delimiter and appends them to the
parser's diagnostics `recording_buffer`. When the string turns out to be
single-line, `go_back(2u)` rewinds the read cursor but does **not** trim those
two characters from `recording_buffer`, so the lookahead bytes are duplicated
when a redefinition error renders the key via `to_sv(recording_buffer)`. It
only affects *quoted* keys (the path through the basic/literal string parser);
bare dotted keys are unaffected.

## Fix

Backport the upstream fix into both vendored copies
(`c/vendor/toml++/toml.hpp` and `go/adbc/drivermgr/vendored/toml++/toml.hpp`).
The fix snapshots `recording_buffer.length()` before the lookahead and restores
it after `go_back(2u)`.

- Upstream issue: https://github.com/marzer/tomlplusplus/issues/300
- Upstream PR: https://github.com/marzer/tomlplusplus/pull/302
- Upstream commit: `f22f035fe2d63e2be3d266d8f100e7812a9ab9bd`

The fix is not in any tagged toml++ release yet (latest is v3.4.0), so it is
backported here. It re-applies cleanly when the vendored copy is next updated.

## Testing

Adds `ConnectionProfiles.DuplicateQuotedKey` to
`c/driver_manager/adbc_driver_manager_test.cc`, which writes a profile with a
duplicate quoted key and asserts the resulting error names `redshift.db_name`
and not the doubled `reredshift` form. Passes locally
(`--gtest_filter=ConnectionProfiles.DuplicateQuotedKey`).
