### PR TITLE
feat!(java/core): declare close to throw AdbcException

### DIFF
--- a/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcConnection.java
+++ b/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcConnection.java
@@ -459,4 +459,7 @@ public interface AdbcConnection extends AutoCloseable, AdbcOptions {
   default void setIsolationLevel(IsolationLevel level) throws AdbcException {
     throw AdbcException.notImplemented("Connection does not support setting isolation level");
   }
+
+  @Override
+  void close() throws AdbcException;
 }

--- a/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcDatabase.java
+++ b/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcDatabase.java
@@ -27,4 +27,7 @@ package org.apache.arrow.adbc.core;
 public interface AdbcDatabase extends AutoCloseable, AdbcOptions {
   /** Create a new connection to the database. */
   AdbcConnection connect() throws AdbcException;
+
+  @Override
+  void close() throws AdbcException;
 }

--- a/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcStatement.java
+++ b/java/core/src/main/java/org/apache/arrow/adbc/core/AdbcStatement.java
@@ -285,4 +285,7 @@ public interface AdbcStatement extends AutoCloseable, AdbcOptions {
           + '}';
     }
   }
+
+  @Override
+  void close() throws AdbcException;
 }

--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
@@ -204,9 +204,13 @@ public class FlightSqlConnection implements AdbcConnection {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() throws AdbcException {
     clientCache.invalidateAll();
-    AutoCloseables.close(client, allocator);
+    try {
+      AutoCloseables.close(client, allocator);
+    } catch (Exception e) {
+      throw AdbcException.internal("[Flight SQL] Failed to close connection").withCause(e);
+    }
   }
 
   @Override

--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlDatabase.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlDatabase.java
@@ -76,7 +76,7 @@ public final class FlightSqlDatabase implements AdbcDatabase {
   }
 
   @Override
-  public void close() throws Exception {}
+  public void close() throws AdbcException {}
 
   @Override
   public String toString() {

--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlStatement.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlStatement.java
@@ -309,10 +309,15 @@ public class FlightSqlStatement implements AdbcStatement {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() throws AdbcException {
     // TODO(https://github.com/apache/arrow/issues/39814): this is annotated wrongly upstream
     if (preparedStatement != null) {
-      AutoCloseables.close(preparedStatement);
+      try {
+        AutoCloseables.close(preparedStatement);
+      } catch (Exception e) {
+        throw AdbcException.internal("[Flight SQL] Could not close prepared statement")
+            .withCause(e);
+      }
     }
   }
 

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcConnection.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcConnection.java
@@ -508,8 +508,14 @@ public class JdbcConnection implements AdbcConnection {
   }
 
   @Override
-  public void close() throws Exception {
-    AutoCloseables.close(connection, allocator);
+  public void close() throws AdbcException {
+    try {
+      AutoCloseables.close(connection, allocator);
+    } catch (Exception e) {
+      throw AdbcException.internal(
+              JdbcDriverUtil.prefixExceptionMessage("Could not close connection"))
+          .withCause(e);
+    }
   }
 
   private void checkAutoCommit() throws AdbcException, SQLException {

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcDataSourceDatabase.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcDataSourceDatabase.java
@@ -77,9 +77,15 @@ public final class JdbcDataSourceDatabase implements AdbcDatabase {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() throws AdbcException {
     if (connection != null) {
-      connection.close();
+      try {
+        connection.close();
+      } catch (Exception e) {
+        throw AdbcException.internal(
+                JdbcDriverUtil.prefixExceptionMessage("Could not close database"))
+            .withCause(e);
+      }
     }
     connection = null;
   }

--- a/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcStatement.java
+++ b/java/driver/jdbc/src/main/java/org/apache/arrow/adbc/driver/jdbc/JdbcStatement.java
@@ -371,8 +371,14 @@ public class JdbcStatement implements AdbcStatement {
   }
 
   @Override
-  public void close() throws Exception {
-    AutoCloseables.close(reader, resultSet, statement);
+  public void close() throws AdbcException {
+    try {
+      AutoCloseables.close(reader, resultSet, statement);
+    } catch (Exception e) {
+      throw AdbcException.internal(
+              JdbcDriverUtil.prefixExceptionMessage("Could not close statement"))
+          .withCause(e);
+    }
   }
 
   private static final class BulkState {


### PR DESCRIPTION
This makes the API more consistent: you only need to handle one checked exception type.

This is a breaking change.