### PR TITLE
chore(ci): Restrict trigger push branch for GitHub Workflow

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -19,6 +19,8 @@ name: C#
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - '.github/workflows/csharp.yml'
       - 'ci/scripts/csharp_*'

--- a/.github/workflows/dev_adbc.yml
+++ b/.github/workflows/dev_adbc.yml
@@ -25,6 +25,8 @@ on:
       - "dev/**"
       - ".github/workflows/dev_adbc.yml"
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths:
       - "dev/**"
       - ".github/workflows/dev_adbc.yml"


### PR DESCRIPTION
Feature branches rarely need their own CI runs: the code is already tested when a pull request is opened against a release branch. If the push trigger has no branch restriction and pull_request is also configured, every push to a branch with an open PR runs the workflow twice: once for the push and once for the PR synchronisation.

Always give the push trigger an explicit list of branches: this stops branches created from a release branch from inheriting its workflow runs.

see https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=430408443#GitHubActionsRecommendedPractices-Restrictthepushtriggertospecificbranches