### PR TITLE
fix(rust/ffi): preserve caller's AdbcError private_data on the 1.0.0 path

### DIFF
--- a/rust/ffi/src/driver_exporter.rs
+++ b/rust/ffi/src/driver_exporter.rs
@@ -238,7 +238,7 @@ macro_rules! check_err {
             Err(error) => {
                 let error = adbc_core::error::Error::from(error);
                 let status: adbc_core::error::AdbcStatusCode = error.status.into();
-                unsafe { $crate::set_error_out($err_out, error) };
+                unsafe { $crate::export_error($err_out, error) };
                 return status;
             }
         }
@@ -279,7 +279,7 @@ macro_rules! pointer_as_mut {
                     format!("Passed null pointer for argument {:?}", stringify!($ptr)),
                     adbc_core::error::Status::InvalidArguments,
                 );
-                unsafe { $crate::set_error_out($err_out, error) };
+                unsafe { $crate::export_error($err_out, error) };
                 return adbc_core::error::Status::InvalidArguments.into();
             }
         }
@@ -508,7 +508,7 @@ fn catch_panic<F: FnOnce() -> AdbcStatusCode + std::panic::UnwindSafe>(
                 format!("Uncaught panic in driver: {message}"),
                 Status::Internal,
             );
-            unsafe { crate::set_error_out(error, err) };
+            unsafe { crate::export_error(error, err) };
             Status::Internal.into()
         }
     }

--- a/rust/ffi/src/driver_exporter.rs
+++ b/rust/ffi/src/driver_exporter.rs
@@ -238,12 +238,7 @@ macro_rules! check_err {
             Err(error) => {
                 let error = adbc_core::error::Error::from(error);
                 let status: adbc_core::error::AdbcStatusCode = error.status.into();
-                if !$err_out.is_null() {
-                    let mut ffi_error =
-                        $crate::FFI_AdbcError::try_from(error).unwrap_or_else(Into::into);
-                    ffi_error.private_driver = unsafe { (*$err_out).private_driver };
-                    unsafe { std::ptr::write_unaligned($err_out, ffi_error) };
-                }
+                unsafe { $crate::set_error_out($err_out, error) };
                 return status;
             }
         }
@@ -280,16 +275,11 @@ macro_rules! pointer_as_mut {
         match unsafe { $ptr.as_mut() } {
             Some(p) => p,
             None => {
-                if !$err_out.is_null() {
-                    let error = adbc_core::error::Error::with_message_and_status(
-                        format!("Passed null pointer for argument {:?}", stringify!($ptr)),
-                        adbc_core::error::Status::InvalidArguments,
-                    );
-                    let mut ffi_error =
-                        $crate::FFI_AdbcError::try_from(error).unwrap_or_else(Into::into);
-                    ffi_error.private_driver = unsafe { (*$err_out).private_driver };
-                    unsafe { std::ptr::write_unaligned($err_out, ffi_error) };
-                }
+                let error = adbc_core::error::Error::with_message_and_status(
+                    format!("Passed null pointer for argument {:?}", stringify!($ptr)),
+                    adbc_core::error::Status::InvalidArguments,
+                );
+                unsafe { $crate::set_error_out($err_out, error) };
                 return adbc_core::error::Status::InvalidArguments.into();
             }
         }
@@ -507,22 +497,18 @@ fn catch_panic<F: FnOnce() -> AdbcStatusCode + std::panic::UnwindSafe>(
         Err(cause) => {
             POISON.store(true, std::sync::atomic::Ordering::Release);
 
-            if !error.is_null() {
-                let message = if let Some(s) = cause.downcast_ref::<&str>() {
-                    s.to_string()
-                } else if let Some(s) = cause.downcast_ref::<String>() {
-                    s.clone()
-                } else {
-                    "Unknown panic".to_string()
-                };
-                let err = Error::with_message_and_status(
-                    format!("Uncaught panic in driver: {message}"),
-                    Status::Internal,
-                );
-                let mut ffi_error = FFI_AdbcError::try_from(err).unwrap_or_else(Into::into);
-                ffi_error.private_driver = unsafe { (*error).private_driver };
-                unsafe { std::ptr::write_unaligned(error, ffi_error) };
-            }
+            let message = if let Some(s) = cause.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = cause.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic".to_string()
+            };
+            let err = Error::with_message_and_status(
+                format!("Uncaught panic in driver: {message}"),
+                Status::Internal,
+            );
+            unsafe { crate::set_error_out(error, err) };
             Status::Internal.into()
         }
     }

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -48,5 +48,5 @@ pub mod methods;
 pub(crate) mod types;
 pub use types::{
     FFI_AdbcConnection, FFI_AdbcDatabase, FFI_AdbcDriver, FFI_AdbcDriverInitFunc, FFI_AdbcError,
-    FFI_AdbcErrorDetail, FFI_AdbcPartitions, FFI_AdbcStatement,
+    FFI_AdbcErrorDetail, FFI_AdbcPartitions, FFI_AdbcStatement, set_error_out,
 };

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -48,5 +48,5 @@ pub mod methods;
 pub(crate) mod types;
 pub use types::{
     FFI_AdbcConnection, FFI_AdbcDatabase, FFI_AdbcDriver, FFI_AdbcDriverInitFunc, FFI_AdbcError,
-    FFI_AdbcErrorDetail, FFI_AdbcPartitions, FFI_AdbcStatement, set_error_out,
+    FFI_AdbcErrorDetail, FFI_AdbcPartitions, FFI_AdbcStatement, export_error,
 };

--- a/rust/ffi/src/types.rs
+++ b/rust/ffi/src/types.rs
@@ -776,15 +776,16 @@ mod tests {
         // `private_data` / `private_driver` untouched, even when the error carries
         // details that would otherwise be stashed in `private_data`. This mirrors
         // the C++ validation suite's `StatementTest.ErrorCompatibility`.
-        let canary_data = 0x1234_usize as *mut c_void;
-        let canary_driver = 0x5678_usize as *const FFI_AdbcDriver;
+        let mut canary_data = 0x1234;
+        let canary_ptr = (&raw mut canary_data) as *mut c_void;
+        let canary_driver: FFI_AdbcDriver = Default::default();
         let mut out = FFI_AdbcError {
             message: null_mut(),
             vendor_code: 0,
             sqlstate: [0; 5],
             release: None,
-            private_data: canary_data,
-            private_driver: canary_driver,
+            private_data: canary_ptr,
+            private_driver: &raw const canary_driver,
         };
 
         let error = Error {
@@ -797,8 +798,8 @@ mod tests {
         unsafe { export_error(&mut out, error) };
 
         // The extended fields are untouched.
-        assert_eq!(out.private_data, canary_data);
-        assert_eq!(out.private_driver, canary_driver);
+        assert_eq!(out.private_data, canary_ptr);
+        assert_eq!(out.private_driver, &raw const canary_driver);
         // The message was written and a message-only release installed.
         assert!(!out.message.is_null());
         assert!(out.release.is_some());
@@ -807,8 +808,8 @@ mod tests {
         unsafe { (out.release.unwrap())(&mut out) };
         assert!(out.message.is_null());
         assert!(out.release.is_none());
-        assert_eq!(out.private_data, canary_data);
-        assert_eq!(out.private_driver, canary_driver);
+        assert_eq!(out.private_data, canary_ptr);
+        assert_eq!(out.private_driver, &raw const canary_driver);
         // Drop here is a no-op because release is None.
     }
 
@@ -817,14 +818,14 @@ mod tests {
         // A caller that opted in (vendor_code == sentinel) gets the full struct,
         // including details in `private_data`; `private_driver` is preserved so the
         // driver manager keeps its handle.
-        let canary_driver = 0x5678_usize as *const FFI_AdbcDriver;
+        let canary_driver: FFI_AdbcDriver = Default::default();
         let mut out = FFI_AdbcError {
             message: null_mut(),
             vendor_code: constants::ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA,
             sqlstate: [0; 5],
             release: None,
             private_data: null_mut(),
-            private_driver: canary_driver,
+            private_driver: &raw const canary_driver,
         };
 
         let error = Error {
@@ -838,7 +839,7 @@ mod tests {
 
         assert!(!out.message.is_null());
         assert!(!out.private_data.is_null()); // details stashed here
-        assert_eq!(out.private_driver, canary_driver); // preserved
+        assert_eq!(out.private_driver, &raw const canary_driver); // preserved
         // The sentinel survives: consumers may only read private_data while
         // vendor_code holds it (adbc.h), so the details above stay reachable.
         assert_eq!(

--- a/rust/ffi/src/types.rs
+++ b/rust/ffi/src/types.rs
@@ -47,6 +47,15 @@ pub struct FFI_AdbcError {
 
 #[repr(C)]
 #[derive(Debug)]
+pub struct FFI_AdbcErrorV100 {
+    pub message: *mut c_char,
+    pub vendor_code: i32,
+    pub sqlstate: [c_char; 5],
+    pub release: Option<unsafe extern "C" fn(*mut Self)>,
+}
+
+#[repr(C)]
+#[derive(Debug)]
 pub struct FFI_AdbcErrorDetail {
     /// The metadata key.
     pub key: *const c_char,
@@ -555,6 +564,37 @@ impl TryFrom<Error> for FFI_AdbcError {
     }
 }
 
+impl From<NulError> for FFI_AdbcErrorV100 {
+    fn from(value: NulError) -> Self {
+        let message = CString::new(format!(
+            "Interior null byte was found at position {}",
+            value.nul_position()
+        ))
+        .unwrap();
+        FFI_AdbcErrorV100 {
+            message: message.into_raw(),
+            vendor_code: 0,
+            sqlstate: [0; 5],
+            release: Some(release_ffi_error_v100),
+        }
+    }
+}
+
+impl TryFrom<Error> for FFI_AdbcErrorV100 {
+    type Error = NulError;
+
+    fn try_from(value: Error) -> Result<Self, Self::Error> {
+        // TODO: instead of dying on an interior NUL, just truncate or replace
+        let message = CString::new(value.message)?;
+        Ok(FFI_AdbcErrorV100 {
+            message: message.into_raw(),
+            release: Some(release_ffi_error_v100),
+            vendor_code: value.vendor_code,
+            sqlstate: value.sqlstate,
+        })
+    }
+}
+
 unsafe extern "C" fn release_ffi_error(error: *mut FFI_AdbcError) {
     match error.as_mut() {
         None => (),
@@ -579,10 +619,7 @@ unsafe extern "C" fn release_ffi_error(error: *mut FFI_AdbcError) {
     }
 }
 
-/// Release variant for an error handed back to a caller that did not opt into the
-/// ADBC 1.1.0 layout: it frees only the message and never touches `private_data`,
-/// which belongs to the caller and was left untouched by [`set_error_out`].
-unsafe extern "C" fn release_ffi_error_message_only(error: *mut FFI_AdbcError) {
+unsafe extern "C" fn release_ffi_error_v100(error: *mut FFI_AdbcErrorV100) {
     match error.as_mut() {
         None => (),
         Some(error) => {
@@ -596,68 +633,27 @@ unsafe extern "C" fn release_ffi_error_message_only(error: *mut FFI_AdbcError) {
     }
 }
 
-/// Write `error` into a caller-provided `AdbcError` out-pointer, respecting the
-/// ADBC struct-compatibility rule for `private_data` / `private_driver`.
-///
-/// Those two fields were added in ADBC 1.1.0; a caller opts into them by setting
-/// `vendor_code` to [`ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA`] before the call. Per
-/// `c/include/arrow-adbc/adbc.h`, a driver may touch them only then — otherwise it
-/// must not write past the 1.0.0-sized prefix, since for a 1.0.0 caller the fields
-/// may not exist or may hold caller-owned state. Writing the whole struct
-/// unconditionally (as this exporter did before) clobbers memory the caller owns.
-///
-/// [`ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA`]: adbc_core::constants::ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA
+/// Export an error into an FFI error, accounting for the v1.0.0/v1.1.0 ABI
+/// extension.
 #[doc(hidden)]
-pub unsafe fn set_error_out(err_out: *mut FFI_AdbcError, error: Error) {
+pub unsafe fn export_error(err_out: *mut FFI_AdbcError, error: Error) {
     if err_out.is_null() {
         return;
     }
 
-    // Read the caller's opt-in signal before we overwrite anything.
-    let opted_in = (*err_out).vendor_code == constants::ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA;
-
-    // Release any previous error still held in the struct so that reusing an
-    // error across calls does not leak it, as the C reference implementation
-    // does (`InternalAdbcSetErrorVariadic`, c/driver/common/utils.c).
+    let is_v110 = (*err_out).vendor_code == constants::ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA;
     if let Some(release) = (*err_out).release {
         release(err_out);
     }
-
-    let mut ffi_error = FFI_AdbcError::try_from(error).unwrap_or_else(Into::into);
-
-    if opted_in {
-        // Extended-layout caller: it owns the extended fields. Preserve the
-        // driver handle the driver manager stashed there and overwrite the whole
-        // struct. The sentinel must survive in `vendor_code`: `adbc.h` forbids
-        // consumers from reading `private_data`/`private_driver` unless
-        // `vendor_code` is the sentinel (and this crate's own
-        // `Error::try_from(&FFI_AdbcError)` gates on it), so the driver's own
-        // vendor code is not representable on this path — exactly as in the C
-        // reference, which leaves `vendor_code` untouched.
+    if is_v110 {
+        let mut ffi_error = FFI_AdbcError::try_from(error).unwrap_or_else(Into::into);
         ffi_error.vendor_code = constants::ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA;
         ffi_error.private_driver = (*err_out).private_driver;
         std::ptr::write_unaligned(err_out, ffi_error);
     } else {
-        // 1.0.0-compatible caller: we must not touch `private_data` /
-        // `private_driver`. Drop any structured details (they live in
-        // `private_data`, which we may not expose) and hand back only the
-        // message with a release that frees just the message.
-        if !ffi_error.private_data.is_null() {
-            // SAFETY: a non-null `private_data` here was produced by
-            // `FFI_AdbcError::try_from` via `Box::into_raw` of `ErrorPrivateData`.
-            drop(Box::from_raw(
-                ffi_error.private_data as *mut ErrorPrivateData,
-            ));
-            ffi_error.private_data = null_mut();
-        }
-        let out = &mut *err_out;
-        out.message = ffi_error.message;
-        out.vendor_code = ffi_error.vendor_code;
-        out.sqlstate = ffi_error.sqlstate;
-        out.release = Some(release_ffi_error_message_only);
-        // Prevent `ffi_error`'s `Drop` from freeing the message we just moved.
-        ffi_error.message = null_mut();
-        ffi_error.release = None;
+        let ffi_error = FFI_AdbcErrorV100::try_from(error).unwrap_or_else(Into::into);
+        let out = &mut *(err_out as *mut FFI_AdbcErrorV100);
+        std::ptr::write_unaligned(out, ffi_error);
     }
 }
 
@@ -776,7 +772,7 @@ mod tests {
     #[test]
     fn test_set_error_out_preserves_caller_private_fields() {
         // A caller that did not opt into the 1.1.0 layout leaves `vendor_code` at
-        // something other than the sentinel. `set_error_out` must then leave
+        // something other than the sentinel. `export_error` must then leave
         // `private_data` / `private_driver` untouched, even when the error carries
         // details that would otherwise be stashed in `private_data`. This mirrors
         // the C++ validation suite's `StatementTest.ErrorCompatibility`.
@@ -798,7 +794,7 @@ mod tests {
             sqlstate: [0; 5],
             details: Some(vec![("key".to_string(), b"value".to_vec())]),
         };
-        unsafe { set_error_out(&mut out, error) };
+        unsafe { export_error(&mut out, error) };
 
         // The extended fields are untouched.
         assert_eq!(out.private_data, canary_data);
@@ -838,7 +834,7 @@ mod tests {
             sqlstate: [0; 5],
             details: Some(vec![("key".to_string(), b"value".to_vec())]),
         };
-        unsafe { set_error_out(&mut out, error) };
+        unsafe { export_error(&mut out, error) };
 
         assert!(!out.message.is_null());
         assert!(!out.private_data.is_null()); // details stashed here
@@ -878,11 +874,11 @@ mod tests {
             details: None,
         };
 
-        unsafe { set_error_out(&mut out, error("first")) };
+        unsafe { export_error(&mut out, error("first")) };
         let first_message = out.message;
         assert!(!first_message.is_null());
 
-        unsafe { set_error_out(&mut out, error("second")) };
+        unsafe { export_error(&mut out, error("second")) };
         assert!(!out.message.is_null());
         let message = unsafe { CStr::from_ptr(out.message) };
         assert_eq!(message.to_str().unwrap(), "second");

--- a/rust/ffi/src/types.rs
+++ b/rust/ffi/src/types.rs
@@ -579,6 +579,88 @@ unsafe extern "C" fn release_ffi_error(error: *mut FFI_AdbcError) {
     }
 }
 
+/// Release variant for an error handed back to a caller that did not opt into the
+/// ADBC 1.1.0 layout: it frees only the message and never touches `private_data`,
+/// which belongs to the caller and was left untouched by [`set_error_out`].
+unsafe extern "C" fn release_ffi_error_message_only(error: *mut FFI_AdbcError) {
+    match error.as_mut() {
+        None => (),
+        Some(error) => {
+            if !error.message.is_null() {
+                // SAFETY: `error.message` was necessarily obtained with `CString::into_raw`.
+                drop(CString::from_raw(error.message));
+                error.message = null_mut();
+            }
+            error.release = None;
+        }
+    }
+}
+
+/// Write `error` into a caller-provided `AdbcError` out-pointer, respecting the
+/// ADBC struct-compatibility rule for `private_data` / `private_driver`.
+///
+/// Those two fields were added in ADBC 1.1.0; a caller opts into them by setting
+/// `vendor_code` to [`ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA`] before the call. Per
+/// `c/include/arrow-adbc/adbc.h`, a driver may touch them only then — otherwise it
+/// must not write past the 1.0.0-sized prefix, since for a 1.0.0 caller the fields
+/// may not exist or may hold caller-owned state. Writing the whole struct
+/// unconditionally (as this exporter did before) clobbers memory the caller owns.
+///
+/// [`ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA`]: adbc_core::constants::ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA
+#[doc(hidden)]
+pub unsafe fn set_error_out(err_out: *mut FFI_AdbcError, error: Error) {
+    if err_out.is_null() {
+        return;
+    }
+
+    // Read the caller's opt-in signal before we overwrite anything.
+    let opted_in = (*err_out).vendor_code == constants::ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA;
+
+    // Release any previous error still held in the struct so that reusing an
+    // error across calls does not leak it, as the C reference implementation
+    // does (`InternalAdbcSetErrorVariadic`, c/driver/common/utils.c).
+    if let Some(release) = (*err_out).release {
+        release(err_out);
+    }
+
+    let mut ffi_error = FFI_AdbcError::try_from(error).unwrap_or_else(Into::into);
+
+    if opted_in {
+        // Extended-layout caller: it owns the extended fields. Preserve the
+        // driver handle the driver manager stashed there and overwrite the whole
+        // struct. The sentinel must survive in `vendor_code`: `adbc.h` forbids
+        // consumers from reading `private_data`/`private_driver` unless
+        // `vendor_code` is the sentinel (and this crate's own
+        // `Error::try_from(&FFI_AdbcError)` gates on it), so the driver's own
+        // vendor code is not representable on this path — exactly as in the C
+        // reference, which leaves `vendor_code` untouched.
+        ffi_error.vendor_code = constants::ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA;
+        ffi_error.private_driver = (*err_out).private_driver;
+        std::ptr::write_unaligned(err_out, ffi_error);
+    } else {
+        // 1.0.0-compatible caller: we must not touch `private_data` /
+        // `private_driver`. Drop any structured details (they live in
+        // `private_data`, which we may not expose) and hand back only the
+        // message with a release that frees just the message.
+        if !ffi_error.private_data.is_null() {
+            // SAFETY: a non-null `private_data` here was produced by
+            // `FFI_AdbcError::try_from` via `Box::into_raw` of `ErrorPrivateData`.
+            drop(Box::from_raw(
+                ffi_error.private_data as *mut ErrorPrivateData,
+            ));
+            ffi_error.private_data = null_mut();
+        }
+        let out = &mut *err_out;
+        out.message = ffi_error.message;
+        out.vendor_code = ffi_error.vendor_code;
+        out.sqlstate = ffi_error.sqlstate;
+        out.release = Some(release_ffi_error_message_only);
+        // Prevent `ffi_error`'s `Drop` from freeing the message we just moved.
+        ffi_error.message = null_mut();
+        ffi_error.release = None;
+    }
+}
+
 impl Drop for FFI_AdbcError {
     fn drop(&mut self) {
         if let Some(release) = self.release {
@@ -689,5 +771,123 @@ mod tests {
         assert!(ffi_error.message.is_null());
         assert!(ffi_error.release.is_none());
         // Drop here is a no-op because release is None.
+    }
+
+    #[test]
+    fn test_set_error_out_preserves_caller_private_fields() {
+        // A caller that did not opt into the 1.1.0 layout leaves `vendor_code` at
+        // something other than the sentinel. `set_error_out` must then leave
+        // `private_data` / `private_driver` untouched, even when the error carries
+        // details that would otherwise be stashed in `private_data`. This mirrors
+        // the C++ validation suite's `StatementTest.ErrorCompatibility`.
+        let canary_data = 0x1234_usize as *mut c_void;
+        let canary_driver = 0x5678_usize as *const FFI_AdbcDriver;
+        let mut out = FFI_AdbcError {
+            message: null_mut(),
+            vendor_code: 0,
+            sqlstate: [0; 5],
+            release: None,
+            private_data: canary_data,
+            private_driver: canary_driver,
+        };
+
+        let error = Error {
+            message: "boom".into(),
+            status: Status::Internal,
+            vendor_code: 0,
+            sqlstate: [0; 5],
+            details: Some(vec![("key".to_string(), b"value".to_vec())]),
+        };
+        unsafe { set_error_out(&mut out, error) };
+
+        // The extended fields are untouched.
+        assert_eq!(out.private_data, canary_data);
+        assert_eq!(out.private_driver, canary_driver);
+        // The message was written and a message-only release installed.
+        assert!(!out.message.is_null());
+        assert!(out.release.is_some());
+
+        // Releasing frees only the message and must not touch the canary.
+        unsafe { (out.release.unwrap())(&mut out) };
+        assert!(out.message.is_null());
+        assert!(out.release.is_none());
+        assert_eq!(out.private_data, canary_data);
+        assert_eq!(out.private_driver, canary_driver);
+        // Drop here is a no-op because release is None.
+    }
+
+    #[test]
+    fn test_set_error_out_extended_layout_overwrites() {
+        // A caller that opted in (vendor_code == sentinel) gets the full struct,
+        // including details in `private_data`; `private_driver` is preserved so the
+        // driver manager keeps its handle.
+        let canary_driver = 0x5678_usize as *const FFI_AdbcDriver;
+        let mut out = FFI_AdbcError {
+            message: null_mut(),
+            vendor_code: constants::ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA,
+            sqlstate: [0; 5],
+            release: None,
+            private_data: null_mut(),
+            private_driver: canary_driver,
+        };
+
+        let error = Error {
+            message: "boom".into(),
+            status: Status::Internal,
+            vendor_code: 0,
+            sqlstate: [0; 5],
+            details: Some(vec![("key".to_string(), b"value".to_vec())]),
+        };
+        unsafe { set_error_out(&mut out, error) };
+
+        assert!(!out.message.is_null());
+        assert!(!out.private_data.is_null()); // details stashed here
+        assert_eq!(out.private_driver, canary_driver); // preserved
+        // The sentinel survives: consumers may only read private_data while
+        // vendor_code holds it (adbc.h), so the details above stay reachable.
+        assert_eq!(
+            out.vendor_code,
+            constants::ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA
+        );
+        assert!(out.release.is_some());
+
+        // The full release frees both the message and the details in private_data.
+        unsafe { (out.release.unwrap())(&mut out) };
+        assert!(out.message.is_null());
+        assert!(out.private_data.is_null());
+        // Drop here is a no-op because release is None.
+    }
+
+    #[test]
+    fn test_set_error_out_releases_a_previous_error_on_reuse() {
+        // Writing into a struct that still holds an earlier error releases it
+        // first (as the C reference does), instead of leaking its message.
+        let mut out = FFI_AdbcError {
+            message: null_mut(),
+            vendor_code: 0,
+            sqlstate: [0; 5],
+            release: None,
+            private_data: null_mut(),
+            private_driver: null(),
+        };
+        let error = |msg: &str| Error {
+            message: msg.into(),
+            status: Status::Internal,
+            vendor_code: 0,
+            sqlstate: [0; 5],
+            details: None,
+        };
+
+        unsafe { set_error_out(&mut out, error("first")) };
+        let first_message = out.message;
+        assert!(!first_message.is_null());
+
+        unsafe { set_error_out(&mut out, error("second")) };
+        assert!(!out.message.is_null());
+        let message = unsafe { CStr::from_ptr(out.message) };
+        assert_eq!(message.to_str().unwrap(), "second");
+
+        unsafe { (out.release.unwrap())(&mut out) };
+        assert!(out.message.is_null());
     }
 }


### PR DESCRIPTION
**Disclaimer**: Most of this PR description and all the code here was AI generated. Let me know if there is any issues to dig into or modifications to be made. The code comments are rather verbose, but not obviously unnecessary - let me know if they should be removed/shortened.

The FFI driver exporter wrote the entire `FFI_AdbcError` struct into the caller's out-pointer on every failed method, unconditionally clobbering the `private_data` (and, at two of the three sites, `private_driver`) fields.

The `AdbcError` documentation in `c/include/arrow-adbc/adbc.h` says these fields exist only in the ADBC 1.1.0 layout and that a driver "should read/write these fields if and only if vendor_code is equal to ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA", and "should never touch more than [the 1.0.0-sized] portion of an AdbcError struct" otherwise. Overwriting them corrupts memory an ADBC 1.0.0 caller owns (or does not have at all).

Route all three error-writing sites (check_err!, pointer_as_mut! and the panic handler in catch_panic) through a new `set_error_out()` that:

- reads the caller's `vendor_code` first; when it is not the sentinel, writes only the 1.0.0-sized prefix and installs a message-only release, leaving `private_data`/`private_driver` as the caller set them;
- otherwise behaves as before: preserves `private_driver` and writes the full struct, with structured details carried in `private_data`.

This makes the C++ validation suite's `StatementTest.ErrorCompatibility` pass against an ADBC driving implemented using `adbc_ffi`.

Fixes #4472.