### PR TITLE
feat(go/adbc/driver/flightsql): implement tracing for core Flight SQL operations

### DIFF
--- a/go/adbc/driver/flightsql/flightsql_adbc_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_test.go
@@ -58,6 +58,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
+	_ "modernc.org/sqlite"
 )
 
 type HeaderServerMiddleware struct {
@@ -314,6 +315,56 @@ func TestADBCFlightSQL(t *testing.T) {
 	suite.Run(t, &TLSTests{Quirks: &FlightSQLQuirks{db: db}})
 	suite.Run(t, &ConnectionTests{})
 	suite.Run(t, &DomainSocketTests{db: db})
+}
+
+func TestFlightSQLTracingProducesTraceFiles(t *testing.T) {
+	db, err := sql.Open("sqlite", fmt.Sprintf("file:%s-%d?mode=memory&cache=private", strings.ToLower(t.Name()), time.Now().UnixNano()))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	q := &FlightSQLQuirks{db: db}
+	drv := q.SetupDriver(t)
+	defer q.TearDownDriver(t, drv)
+
+	traceDir := t.TempDir()
+	opts := q.DatabaseOptions()
+	opts[adbc.OptionKeyTelemetryTracesExporter] = string(adbc.TelemetryExporterAdbcFile)
+	opts[adbc.OptionKeyTelemetryTracesFolderPath] = traceDir
+
+	adbcDB, err := drv.NewDatabase(opts)
+	require.NoError(t, err)
+
+	cnxn, err := adbcDB.Open(context.Background())
+	require.NoError(t, err)
+
+	stmt, err := cnxn.NewStatement()
+	require.NoError(t, err)
+	require.NoError(t, stmt.SetSqlQuery("SELECT 1"))
+
+	reader, _, err := stmt.ExecuteQuery(context.Background())
+	require.NoError(t, err)
+	for reader.Next() {
+	}
+	reader.Release()
+
+	validation.CheckedClose(t, stmt)
+	validation.CheckedClose(t, cnxn)
+	validation.CheckedClose(t, adbcDB)
+
+	files, err := filepath.Glob(filepath.Join(traceDir, "*.jsonl"))
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+
+	var traceOutput strings.Builder
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		require.NoError(t, err)
+		traceOutput.Write(data)
+	}
+
+	output := traceOutput.String()
+	require.Contains(t, output, "FlightSQLDatabase.Open")
+	require.Contains(t, output, "FlightSQLStatement.ExecuteQuery")
 }
 
 // Run the test suite, but validating that a header set on the database is ALWAYS passed

--- a/go/adbc/driver/flightsql/flightsql_adbc_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_test.go
@@ -328,7 +328,20 @@ func TestFlightSQLTracingProducesTraceFiles(t *testing.T) {
 	drv := q.SetupDriver(t)
 	defer q.TearDownDriver(t, drv)
 
-	traceDir := t.TempDir()
+	traceDir, err := os.MkdirTemp("", strings.ToLower(t.Name())+"-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		var rmErr error
+		for i := 0; i < 10; i++ {
+			rmErr = os.RemoveAll(traceDir)
+			if rmErr == nil || errors.Is(rmErr, os.ErrNotExist) {
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		require.NoError(t, rmErr)
+	})
+
 	opts := q.DatabaseOptions()
 	opts[adbc.OptionKeyTelemetryTracesExporter] = string(adbc.TelemetryExporterAdbcFile)
 	opts[adbc.OptionKeyTelemetryTracesFolderPath] = traceDir

--- a/go/adbc/driver/flightsql/flightsql_adbc_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_test.go
@@ -297,9 +297,39 @@ func (s *FlightSQLQuirks) SampleTableSchemaMetadata(tblName string, dt arrow.Dat
 func (s *FlightSQLQuirks) Catalog() string  { return "main" }
 func (s *FlightSQLQuirks) DBSchema() string { return "" }
 
-func TestADBCFlightSQL(t *testing.T) {
-	db, err := example.CreateDB()
+func createFlightSQLTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", fmt.Sprintf("file:%s-%d?mode=memory&cache=private", strings.ToLower(t.Name()), time.Now().UnixNano()))
 	require.NoError(t, err)
+
+	_, err = db.Exec(`
+	CREATE TABLE foreignTable (
+		id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+		foreignName varchar(100),
+		value int);
+
+	CREATE TABLE intTable (
+		id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+		keyName varchar(100),
+		value int,
+		foreignId int references foreignTable(id));
+
+	INSERT INTO foreignTable (foreignName, value) VALUES ('keyOne', 1);
+	INSERT INTO foreignTable (foreignName, value) VALUES ('keyTwo', 0);
+	INSERT INTO foreignTable (foreignName, value) VALUES ('keyThree', -1);
+	INSERT INTO intTable (keyName, value, foreignId) VALUES ('one', 1, 1);
+	INSERT INTO intTable (keyName, value, foreignId) VALUES ('zero', 0, 1);
+	INSERT INTO intTable (keyName, value, foreignId) VALUES ('negative one', -1, 1);
+	INSERT INTO intTable (keyName, value, foreignId) VALUES (NULL, NULL, NULL);
+	`)
+	require.NoError(t, err)
+
+	return db
+}
+
+func TestADBCFlightSQL(t *testing.T) {
+	db := createFlightSQLTestDB(t)
 	defer validation.CheckedClose(t, db)
 
 	q := &FlightSQLQuirks{db: db}
@@ -318,9 +348,8 @@ func TestADBCFlightSQL(t *testing.T) {
 }
 
 func TestFlightSQLTracingProducesTraceFiles(t *testing.T) {
-	db, err := sql.Open("sqlite", fmt.Sprintf("file:%s-%d?mode=memory&cache=private", strings.ToLower(t.Name()), time.Now().UnixNano()))
-	require.NoError(t, err)
-	defer func() { require.NoError(t, db.Close()) }()
+	db := createFlightSQLTestDB(t)
+	defer validation.CheckedClose(t, db)
 
 	q := &FlightSQLQuirks{db: db}
 	drv := q.SetupDriver(t)
@@ -331,25 +360,28 @@ func TestFlightSQLTracingProducesTraceFiles(t *testing.T) {
 	opts[adbc.OptionKeyTelemetryTracesExporter] = string(adbc.TelemetryExporterAdbcFile)
 	opts[adbc.OptionKeyTelemetryTracesFolderPath] = traceDir
 
-	adbcDB, err := drv.NewDatabase(opts)
-	require.NoError(t, err)
+	func() {
+		adbcDB, err := drv.NewDatabase(opts)
+		require.NoError(t, err)
+		defer validation.CheckedClose(t, adbcDB)
 
-	cnxn, err := adbcDB.Open(context.Background())
-	require.NoError(t, err)
+		cnxn, err := adbcDB.Open(context.Background())
+		require.NoError(t, err)
+		defer validation.CheckedClose(t, cnxn)
 
-	stmt, err := cnxn.NewStatement()
-	require.NoError(t, err)
-	require.NoError(t, stmt.SetSqlQuery("SELECT 1"))
+		stmt, err := cnxn.NewStatement()
+		require.NoError(t, err)
+		defer validation.CheckedClose(t, stmt)
 
-	reader, _, err := stmt.ExecuteQuery(context.Background())
-	require.NoError(t, err)
-	for reader.Next() {
-	}
-	reader.Release()
+		require.NoError(t, stmt.SetSqlQuery("SELECT 1"))
+		reader, _, err := stmt.ExecuteQuery(context.Background())
+		require.NoError(t, err)
+		defer reader.Release()
 
-	validation.CheckedClose(t, stmt)
-	validation.CheckedClose(t, cnxn)
-	validation.CheckedClose(t, adbcDB)
+		for reader.Next() {
+		}
+		require.NoError(t, reader.Err())
+	}()
 
 	files, err := filepath.Glob(filepath.Join(traceDir, "*.jsonl"))
 	require.NoError(t, err)

--- a/go/adbc/driver/flightsql/flightsql_adbc_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_test.go
@@ -328,20 +328,7 @@ func TestFlightSQLTracingProducesTraceFiles(t *testing.T) {
 	drv := q.SetupDriver(t)
 	defer q.TearDownDriver(t, drv)
 
-	traceDir, err := os.MkdirTemp("", strings.ToLower(t.Name())+"-")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		var rmErr error
-		for i := 0; i < 10; i++ {
-			rmErr = os.RemoveAll(traceDir)
-			if rmErr == nil || errors.Is(rmErr, os.ErrNotExist) {
-				return
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-		require.NoError(t, rmErr)
-	})
-
+	traceDir := t.TempDir()
 	opts := q.DatabaseOptions()
 	opts[adbc.OptionKeyTelemetryTracesExporter] = string(adbc.TelemetryExporterAdbcFile)
 	opts[adbc.OptionKeyTelemetryTracesFolderPath] = traceDir

--- a/go/adbc/driver/flightsql/flightsql_adbc_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_test.go
@@ -297,39 +297,9 @@ func (s *FlightSQLQuirks) SampleTableSchemaMetadata(tblName string, dt arrow.Dat
 func (s *FlightSQLQuirks) Catalog() string  { return "main" }
 func (s *FlightSQLQuirks) DBSchema() string { return "" }
 
-func createFlightSQLTestDB(t *testing.T) *sql.DB {
-	t.Helper()
-
-	db, err := sql.Open("sqlite", fmt.Sprintf("file:%s-%d?mode=memory&cache=private", strings.ToLower(t.Name()), time.Now().UnixNano()))
-	require.NoError(t, err)
-
-	_, err = db.Exec(`
-	CREATE TABLE foreignTable (
-		id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-		foreignName varchar(100),
-		value int);
-
-	CREATE TABLE intTable (
-		id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-		keyName varchar(100),
-		value int,
-		foreignId int references foreignTable(id));
-
-	INSERT INTO foreignTable (foreignName, value) VALUES ('keyOne', 1);
-	INSERT INTO foreignTable (foreignName, value) VALUES ('keyTwo', 0);
-	INSERT INTO foreignTable (foreignName, value) VALUES ('keyThree', -1);
-	INSERT INTO intTable (keyName, value, foreignId) VALUES ('one', 1, 1);
-	INSERT INTO intTable (keyName, value, foreignId) VALUES ('zero', 0, 1);
-	INSERT INTO intTable (keyName, value, foreignId) VALUES ('negative one', -1, 1);
-	INSERT INTO intTable (keyName, value, foreignId) VALUES (NULL, NULL, NULL);
-	`)
-	require.NoError(t, err)
-
-	return db
-}
-
 func TestADBCFlightSQL(t *testing.T) {
-	db := createFlightSQLTestDB(t)
+	db, err := example.CreateDB()
+	require.NoError(t, err)
 	defer validation.CheckedClose(t, db)
 
 	q := &FlightSQLQuirks{db: db}
@@ -348,7 +318,10 @@ func TestADBCFlightSQL(t *testing.T) {
 }
 
 func TestFlightSQLTracingProducesTraceFiles(t *testing.T) {
-	db := createFlightSQLTestDB(t)
+	// TODO: Reuse example.CreateDB() here after apache/arrow-go#916 isolates
+	// the shared in-memory SQLite database per call.
+	db, err := sql.Open("sqlite", fmt.Sprintf("file:%s-%d?mode=memory&cache=private", strings.ToLower(t.Name()), time.Now().UnixNano()))
+	require.NoError(t, err)
 	defer validation.CheckedClose(t, db)
 
 	q := &FlightSQLQuirks{db: db}

--- a/go/adbc/driver/flightsql/flightsql_database.go
+++ b/go/adbc/driver/flightsql/flightsql_database.go
@@ -483,6 +483,7 @@ type support struct {
 
 func (d *databaseImpl) Open(ctx context.Context) (_ adbc.Connection, err error) {
 	ctx, span := internal.StartSpan(ctx, "FlightSQLDatabase.Open", d)
+	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
 	defer func() { internal.EndSpan(span, err) }()
 
 	authMiddle := &bearerAuthMiddleware{hdrs: d.hdrs.Copy(), logger: safeLogger(d.Logger)}

--- a/go/adbc/driver/flightsql/flightsql_database.go
+++ b/go/adbc/driver/flightsql/flightsql_database.go
@@ -481,7 +481,7 @@ type support struct {
 	transactions bool
 }
 
-func (d *databaseImpl) Open(ctx context.Context) (cnxn adbc.Connection, err error) {
+func (d *databaseImpl) Open(ctx context.Context) (_ adbc.Connection, err error) {
 	ctx, span := internal.StartSpan(ctx, "FlightSQLDatabase.Open", d)
 	defer func() { internal.EndSpan(span, err) }()
 
@@ -592,12 +592,11 @@ func (d *databaseImpl) Open(ctx context.Context) (cnxn adbc.Connection, err erro
 		"driver", infoDriverName,
 	)
 
-	cnxn = driverbase.NewConnectionBuilder(conn).
+	return driverbase.NewConnectionBuilder(conn).
 		WithDriverInfoPreparer(conn).
 		WithAutocommitSetter(conn).
 		WithCurrentNamespacer(conn).
-		Connection()
-	return cnxn, nil
+		Connection(), nil
 }
 
 type bearerAuthMiddleware struct {

--- a/go/adbc/driver/flightsql/flightsql_database.go
+++ b/go/adbc/driver/flightsql/flightsql_database.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-adbc/go/adbc/driver/internal"
 	"github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/flight"
@@ -373,7 +374,7 @@ func (d *databaseImpl) Close() error {
 			"target", d.uri.String(),
 		)
 	}
-	return nil
+	return d.DatabaseImplBase.Close()
 }
 
 func getFlightClient(ctx context.Context, loc string, d *databaseImpl, authMiddle *bearerAuthMiddleware, cookies flight.CookieMiddleware) (*flightsql.Client, error) {
@@ -480,7 +481,10 @@ type support struct {
 	transactions bool
 }
 
-func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
+func (d *databaseImpl) Open(ctx context.Context) (cnxn adbc.Connection, err error) {
+	ctx, span := internal.StartSpan(ctx, "FlightSQLDatabase.Open", d)
+	defer func() { internal.EndSpan(span, err) }()
+
 	authMiddle := &bearerAuthMiddleware{hdrs: d.hdrs.Copy(), logger: safeLogger(d.Logger)}
 	var cookies flight.CookieMiddleware
 	if d.enableCookies {
@@ -588,11 +592,12 @@ func (d *databaseImpl) Open(ctx context.Context) (adbc.Connection, error) {
 		"driver", infoDriverName,
 	)
 
-	return driverbase.NewConnectionBuilder(conn).
+	cnxn = driverbase.NewConnectionBuilder(conn).
 		WithDriverInfoPreparer(conn).
 		WithAutocommitSetter(conn).
 		WithCurrentNamespacer(conn).
-		Connection(), nil
+		Connection()
+	return cnxn, nil
 }
 
 type bearerAuthMiddleware struct {

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -532,6 +532,7 @@ func (s *statement) ExecuteQuery(ctx context.Context) (rdr array.RecordReader, n
 	}
 
 	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecuteQuery", s.cnxn)
+	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
 	defer func() { internal.EndSpan(span, err) }()
 
 	// Handle bulk ingest
@@ -607,6 +608,7 @@ func (s *statement) ExecuteUpdate(ctx context.Context) (n int64, err error) {
 	}
 
 	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecuteUpdate", s.cnxn)
+	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
 	defer func() { internal.EndSpan(span, err) }()
 
 	// Handle bulk ingest
@@ -656,6 +658,7 @@ func (s *statement) ExecuteUpdate(ctx context.Context) (n int64, err error) {
 // multiple times. This invalidates any prior result sets.
 func (s *statement) Prepare(ctx context.Context) (err error) {
 	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.Prepare", s.cnxn)
+	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
 	defer func() { internal.EndSpan(span, err) }()
 
 	startTime := time.Now()

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -29,6 +29,7 @@ import (
 	"unsafe"
 
 	"github.com/apache/arrow-adbc/go/adbc"
+	"github.com/apache/arrow-adbc/go/adbc/driver/internal"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/flight"
@@ -530,6 +531,9 @@ func (s *statement) ExecuteQuery(ctx context.Context) (rdr array.RecordReader, n
 		}
 	}
 
+	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecuteQuery", s.cnxn)
+	defer func() { internal.EndSpan(span, err) }()
+
 	// Handle bulk ingest
 	if s.targetTable != "" {
 		nrec, err = s.executeIngest(ctx)
@@ -602,6 +606,9 @@ func (s *statement) ExecuteUpdate(ctx context.Context) (n int64, err error) {
 		}
 	}
 
+	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecuteUpdate", s.cnxn)
+	defer func() { internal.EndSpan(span, err) }()
+
 	// Handle bulk ingest
 	if s.targetTable != "" {
 		return s.executeIngest(ctx)
@@ -647,7 +654,10 @@ func (s *statement) ExecuteUpdate(ctx context.Context) (n int64, err error) {
 
 // Prepare turns this statement into a prepared statement to be executed
 // multiple times. This invalidates any prior result sets.
-func (s *statement) Prepare(ctx context.Context) error {
+func (s *statement) Prepare(ctx context.Context) (err error) {
+	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.Prepare", s.cnxn)
+	defer func() { internal.EndSpan(span, err) }()
+
 	startTime := time.Now()
 	s.log.InfoContext(ctx, "FlightSQL Prepare start", s.queryAttrs()...)
 
@@ -799,15 +809,15 @@ func (s *statement) GetParameterSchema() (*arrow.Schema, error) {
 //
 // If the driver does not support partitioned results, this will return
 // an error with a StatusNotImplemented code.
-func (s *statement) ExecutePartitions(ctx context.Context) (*arrow.Schema, adbc.Partitions, int64, error) {
+func (s *statement) ExecutePartitions(ctx context.Context) (sc *arrow.Schema, out adbc.Partitions, nrec int64, err error) {
+	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecutePartitions", s.cnxn)
+	defer func() { internal.EndSpan(span, err) }()
+
 	ctx = metadata.NewOutgoingContext(ctx, s.hdrs)
 
 	var (
 		info *flight.FlightInfo
 		poll *flight.PollInfo
-		out  adbc.Partitions
-		sc   *arrow.Schema
-		err  error
 	)
 
 	var header, trailer metadata.MD
@@ -921,6 +931,9 @@ func (s *statement) ExecutePartitions(ctx context.Context) (*arrow.Schema, adbc.
 
 // ExecuteSchema gets the schema of the result set of a query without executing it.
 func (s *statement) ExecuteSchema(ctx context.Context) (schema *arrow.Schema, err error) {
+	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecuteSchema", s.cnxn)
+	defer func() { internal.EndSpan(span, err) }()
+
 	ctx = metadata.NewOutgoingContext(ctx, s.hdrs)
 
 	if s.prepared != nil {

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -809,15 +809,15 @@ func (s *statement) GetParameterSchema() (*arrow.Schema, error) {
 //
 // If the driver does not support partitioned results, this will return
 // an error with a StatusNotImplemented code.
-func (s *statement) ExecutePartitions(ctx context.Context) (sc *arrow.Schema, out adbc.Partitions, nrec int64, err error) {
-	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecutePartitions", s.cnxn)
-	defer func() { internal.EndSpan(span, err) }()
-
+func (s *statement) ExecutePartitions(ctx context.Context) (*arrow.Schema, adbc.Partitions, int64, error) {
 	ctx = metadata.NewOutgoingContext(ctx, s.hdrs)
 
 	var (
 		info *flight.FlightInfo
 		poll *flight.PollInfo
+		out  adbc.Partitions
+		sc   *arrow.Schema
+		err  error
 	)
 
 	var header, trailer metadata.MD
@@ -931,9 +931,6 @@ func (s *statement) ExecutePartitions(ctx context.Context) (sc *arrow.Schema, ou
 
 // ExecuteSchema gets the schema of the result set of a query without executing it.
 func (s *statement) ExecuteSchema(ctx context.Context) (schema *arrow.Schema, err error) {
-	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecuteSchema", s.cnxn)
-	defer func() { internal.EndSpan(span, err) }()
-
 	ctx = metadata.NewOutgoingContext(ctx, s.hdrs)
 
 	if s.prepared != nil {

--- a/go/adbc/driver/internal/driverbase/connection.go
+++ b/go/adbc/driver/internal/driverbase/connection.go
@@ -154,6 +154,7 @@ func (base *ConnectionImplBase) Rollback(context.Context) error {
 
 func (base *ConnectionImplBase) GetInfo(ctx context.Context, infoCodes []adbc.InfoCode) (reader array.RecordReader, err error) {
 	_, span := internal.StartSpan(ctx, "ConnectionImplBase.GetInfo", base)
+	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
 	defer internal.EndSpan(span, err)
 
 	if len(infoCodes) == 0 {

--- a/go/adbc/driver/internal/driverbase/connection.go
+++ b/go/adbc/driver/internal/driverbase/connection.go
@@ -155,7 +155,7 @@ func (base *ConnectionImplBase) Rollback(context.Context) error {
 func (base *ConnectionImplBase) GetInfo(ctx context.Context, infoCodes []adbc.InfoCode) (reader array.RecordReader, err error) {
 	_, span := internal.StartSpan(ctx, "ConnectionImplBase.GetInfo", base)
 	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
-	defer internal.EndSpan(span, err)
+	defer func() { internal.EndSpan(span, err) }()
 
 	if len(infoCodes) == 0 {
 		infoCodes = base.DriverInfo.InfoSupportedCodes()

--- a/go/adbc/driver/internal/driverbase/database.go
+++ b/go/adbc/driver/internal/driverbase/database.go
@@ -20,6 +20,7 @@ package driverbase
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -423,7 +424,24 @@ func newOtlpTraceExporters(ctx context.Context) ([]sdktrace.SpanExporter, error)
 	return []sdktrace.SpanExporter{grpcExporter, httpExporter}, nil
 }
 
-func newAdbcFileExporter(driverName, folderPath string) (*stdouttrace.Exporter, error) {
+type closableSpanExporter struct {
+	exporter sdktrace.SpanExporter
+	closer   io.Closer
+}
+
+func (e *closableSpanExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	return e.exporter.ExportSpans(ctx, spans)
+}
+
+func (e *closableSpanExporter) Shutdown(ctx context.Context) error {
+	err := e.exporter.Shutdown(ctx)
+	if e.closer != nil {
+		err = errors.Join(err, e.closer.Close())
+	}
+	return err
+}
+
+func newAdbcFileExporter(driverName, folderPath string) (sdktrace.SpanExporter, error) {
 	fullyQualifiedDriverName := strings.ToLower(driverNamespace + "." + driverName)
 	writerOpts := []rotatingFileWriterOption{WithLogNamePrefix(fullyQualifiedDriverName)}
 	if strings.TrimSpace(folderPath) != "" {
@@ -433,7 +451,12 @@ func newAdbcFileExporter(driverName, folderPath string) (*stdouttrace.Exporter, 
 	if err != nil {
 		return nil, err
 	}
-	return stdouttrace.New(stdouttrace.WithWriter(fileWriter))
+	exporter, err := stdouttrace.New(stdouttrace.WithWriter(fileWriter))
+	if err != nil {
+		_ = fileWriter.Close()
+		return nil, err
+	}
+	return &closableSpanExporter{exporter: exporter, closer: fileWriter}, nil
 }
 
 func newTracerProvider(exporters ...sdktrace.SpanExporter) (*sdktrace.TracerProvider, error) {


### PR DESCRIPTION
## Summary
This change wires OpenTelemetry tracing into the core Flight SQL execution path and ensures configured trace exporters are flushed when the database is closed.

Before this change, the Flight SQL driver accepted tracing configuration but did not emit trace data for the main open/query path. The Flight SQL database close path also did not delegate to the shared database close implementation, so tracer shutdown and exporter flush did not run.

## Changes
- add tracing spans for `FlightSQLDatabase.Open`
- add tracing spans for `FlightSQLStatement.Prepare`
- add tracing spans for `FlightSQLStatement.ExecuteQuery`
- add tracing spans for `FlightSQLStatement.ExecuteUpdate`
- call `DatabaseImplBase.Close()` from Flight SQL database close handling
- add a regression test that verifies the `adbcfile` exporter produces trace output for the Flight SQL query path

## Validation
- `go test ./driver/flightsql -run TestFlightSQLTracingProducesTraceFiles -count=1`
- `go test ./driver/flightsql -count=1`

Closes #4487
