### PR TITLE
feat(go/adbc/driver/flightsql): add support for flightsql:// uri format

### DIFF
--- a/docs/source/driver/flight_sql.rst
+++ b/docs/source/driver/flight_sql.rst
@@ -48,7 +48,7 @@ the :c:struct:`AdbcDatabase`.
          struct AdbcDatabase database;
          AdbcDatabaseNew(&database, nullptr);
          AdbcDatabaseSetOption(&database, "driver", "adbc_driver_flightsql", nullptr);
-         AdbcDatabaseSetOption(&database, "uri", "grpc://localhost:8080", nullptr);
+         AdbcDatabaseSetOption(&database, "uri", "flightsql://localhost:8080?transport=tcp", nullptr);
          AdbcDatabaseInit(&database, nullptr);
 
    .. tab-item:: Python
@@ -64,7 +64,7 @@ the :c:struct:`AdbcDatabase`.
          headers = {"foo": "bar"}
 
          with connect(
-             "grpc+tls://localhost:8080",
+             "flightsql://localhost:8080",
              db_kwargs={
                  DatabaseOptions.AUTHORIZATION_HEADER.value: "Bearer <token>",
                  DatabaseOptions.TLS_SKIP_VERIFY.value: "true",
@@ -80,6 +80,45 @@ the :c:struct:`AdbcDatabase`.
       :sync: go
 
       .. recipe:: ../../../go/adbc/driver/flightsql/example_usage_test.go
+
+URI Format
+----------
+
+The "uri" option accepts URIs using the ``flightsql://`` scheme.  The
+transport is selected with the ``transport`` query parameter, which is
+matched case-insensitively:
+
+``flightsql://<host>:<port>``
+    Connect over gRPC with TLS (secure).  This is the default when no
+    ``transport`` query parameter is given.
+
+``flightsql://<host>:<port>?transport=tls``
+    Same as above; an explicit way to request TLS (secure).
+
+``flightsql://<host>:<port>?transport=tcp``
+    Connect over gRPC without TLS (plaintext).
+
+``flightsql:///<path/to/socket>?transport=unix``
+    Connect over gRPC via a Unix domain socket at the given path.
+
+An unrecognized ``transport`` value (anything other than ``tls``,
+``tcp``, or ``unix``) is rejected with an error rather than silently
+falling back to a default.  Similarly, supplying a host with
+``transport=unix``, or a socket path with ``transport=tcp`` or the
+default TLS transport, is rejected as an invalid combination.
+
+.. note:: For backwards compatibility, the driver also still accepts
+          the following legacy schemes, each equivalent to a
+          ``flightsql://`` URI with the given ``transport``:
+
+          =====================  =========================
+          Legacy scheme           Equivalent ``transport``
+          =====================  =========================
+          ``grpc://``              ``tcp``
+          ``grpc+tcp://``          ``tcp``
+          ``grpc+tls://``          ``tls`` (default)
+          ``grpc+unix://``         ``unix``
+          =====================  =========================
 
 Supported Features
 ==================

--- a/go/adbc/driver/flightsql/flightsql_adbc_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_test.go
@@ -945,6 +945,32 @@ func (suite *TLSTests) TestSimpleQuery() {
 	suite.NoError(reader.Err())
 }
 
+func (suite *TLSTests) TestFlightSQLSchemeDefaultTLS() {
+	db, err := suite.Driver.NewDatabase(map[string]string{
+		adbc.OptionKeyURI: "flightsql://" + suite.Quirks.s.Addr().String(),
+		"adbc.flight.sql.client_option.tls_skip_verify": "true",
+	})
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), db)
+
+	cnxn, err := db.Open(suite.ctx)
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), cnxn)
+}
+
+func (suite *TLSTests) TestFlightSQLSchemeExplicitTLS() {
+	db, err := suite.Driver.NewDatabase(map[string]string{
+		adbc.OptionKeyURI: "flightsql://" + suite.Quirks.s.Addr().String() + "?transport=tls",
+		"adbc.flight.sql.client_option.tls_skip_verify": "true",
+	})
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), db)
+
+	cnxn, err := db.Open(suite.ctx)
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), cnxn)
+}
+
 func (suite *TLSTests) TestInvalidOptions() {
 	db, err := suite.Driver.NewDatabase(map[string]string{
 		adbc.OptionKeyURI: "grpc+tls://" + suite.Quirks.s.Addr().String(),
@@ -1046,6 +1072,18 @@ func (suite *ConnectionTests) TestGetInfo() {
 	suite.Require().True(driverArrowVersion)
 }
 
+func (suite *ConnectionTests) TestFlightSQLSchemeTCP() {
+	db, err := suite.Driver.NewDatabase(map[string]string{
+		adbc.OptionKeyURI: "flightsql://" + suite.server.Addr().String() + "?transport=tcp",
+	})
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), db)
+
+	cnxn, err := db.Open(suite.ctx)
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), cnxn)
+}
+
 type DomainSocketTests struct {
 	suite.Suite
 
@@ -1132,4 +1170,74 @@ func (suite *DomainSocketTests) TestSimpleQueryDomainSocket() {
 	for reader.Next() {
 	}
 	suite.NoError(reader.Err())
+}
+
+func TestFlightSQLSchemeUnixSocket(t *testing.T) {
+	// See DomainSocketTests.SetupSuite for why this is skipped on Windows.
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+
+	tempDir, err := os.MkdirTemp("", "adbc-flight-sql-tests-*")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tempDir))
+	}()
+
+	listenSocket := filepath.Join(tempDir, "adbc.sock")
+	listener, err := net.Listen("unix", listenSocket)
+	require.NoError(t, err)
+
+	server := flight.NewServerWithMiddleware(nil)
+	server.RegisterFlightService(&flight.BaseFlightServer{})
+	server.InitListener(listener)
+	go func() {
+		// Explicitly ignore error
+		_ = server.Serve()
+	}()
+	defer server.Shutdown()
+
+	drv := driver.NewDriver(alloc)
+	db, err := drv.NewDatabase(map[string]string{
+		adbc.OptionKeyURI: "flightsql://" + listenSocket + "?transport=unix",
+	})
+	require.NoError(t, err)
+	defer validation.CheckedClose(t, db)
+
+	cnxn, err := db.Open(context.Background())
+	require.NoError(t, err)
+	defer validation.CheckedClose(t, cnxn)
+}
+
+func TestFlightSQLSchemeInvalidURIs(t *testing.T) {
+	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer alloc.AssertSize(t, 0)
+	drv := driver.NewDriver(alloc)
+
+	tests := []struct {
+		name string
+		uri  string
+	}{
+		{"unrecognized transport", "flightsql://localhost:1234?transport=bogus"},
+		{"host with unix transport", "flightsql://localhost:1234/socket?transport=unix"},
+		{"path with tcp transport", "flightsql://localhost:1234/socket?transport=tcp"},
+		{"path with default (tls) transport", "flightsql://localhost:1234/socket"},
+		{"unix transport without a path", "flightsql://?transport=unix"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, err := drv.NewDatabase(map[string]string{
+				adbc.OptionKeyURI: tt.uri,
+			})
+			require.NoError(t, err)
+			defer validation.CheckedClose(t, db)
+
+			_, err = db.Open(context.Background())
+			require.Error(t, err)
+		})
+	}
 }

--- a/go/adbc/driver/flightsql/flightsql_adbc_test.go
+++ b/go/adbc/driver/flightsql/flightsql_adbc_test.go
@@ -1172,44 +1172,16 @@ func (suite *DomainSocketTests) TestSimpleQueryDomainSocket() {
 	suite.NoError(reader.Err())
 }
 
-func TestFlightSQLSchemeUnixSocket(t *testing.T) {
-	// See DomainSocketTests.SetupSuite for why this is skipped on Windows.
-	if runtime.GOOS == "windows" {
-		t.Skip()
-	}
-
-	alloc := memory.NewCheckedAllocator(memory.DefaultAllocator)
-	defer alloc.AssertSize(t, 0)
-
-	tempDir, err := os.MkdirTemp("", "adbc-flight-sql-tests-*")
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, os.RemoveAll(tempDir))
-	}()
-
-	listenSocket := filepath.Join(tempDir, "adbc.sock")
-	listener, err := net.Listen("unix", listenSocket)
-	require.NoError(t, err)
-
-	server := flight.NewServerWithMiddleware(nil)
-	server.RegisterFlightService(&flight.BaseFlightServer{})
-	server.InitListener(listener)
-	go func() {
-		// Explicitly ignore error
-		_ = server.Serve()
-	}()
-	defer server.Shutdown()
-
-	drv := driver.NewDriver(alloc)
-	db, err := drv.NewDatabase(map[string]string{
-		adbc.OptionKeyURI: "flightsql://" + listenSocket + "?transport=unix",
+func (suite *DomainSocketTests) TestFlightSQLSchemeUnixSocket() {
+	db, err := suite.Driver.NewDatabase(map[string]string{
+		adbc.OptionKeyURI: "flightsql://" + suite.server.Addr().String() + "?transport=unix",
 	})
-	require.NoError(t, err)
-	defer validation.CheckedClose(t, db)
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), db)
 
-	cnxn, err := db.Open(context.Background())
-	require.NoError(t, err)
-	defer validation.CheckedClose(t, cnxn)
+	cnxn, err := db.Open(suite.ctx)
+	suite.Require().NoError(err)
+	defer validation.CheckedClose(suite.T(), cnxn)
 }
 
 func TestFlightSQLSchemeInvalidURIs(t *testing.T) {

--- a/go/adbc/driver/flightsql/flightsql_database.go
+++ b/go/adbc/driver/flightsql/flightsql_database.go
@@ -428,7 +428,7 @@ func getFlightClient(ctx context.Context, loc string, d *databaseImpl, authMiddl
 			creds = insecure.NewCredentials()
 			target = "unix:" + uri.Path
 		default:
-			return nil, adbc.Error{Msg: fmt.Sprintf("Invalid URI '%s': unrecognized transport %q (expected \"tls\", \"tcp\", or \"unix\")", loc, transport), Code: adbc.StatusInvalidArgument}
+			return nil, adbc.Error{Msg: fmt.Sprintf("Invalid URI '%s': unrecognized transport '%s' (expected 'tls', 'tcp', or 'unix')", loc, transport), Code: adbc.StatusInvalidArgument}
 		}
 	}
 

--- a/go/adbc/driver/flightsql/flightsql_database.go
+++ b/go/adbc/driver/flightsql/flightsql_database.go
@@ -406,6 +406,30 @@ func getFlightClient(ctx context.Context, loc string, d *databaseImpl, authMiddl
 	case "grpc+unix":
 		creds = insecure.NewCredentials()
 		target = "unix:" + uri.Path
+	case "flightsql":
+		transport := strings.ToLower(uri.Query().Get("transport"))
+		switch transport {
+		case "", "tls":
+			if uri.Path != "" {
+				return nil, adbc.Error{Msg: fmt.Sprintf("Invalid URI '%s': a socket path is only valid with transport=unix", loc), Code: adbc.StatusInvalidArgument}
+			}
+		case "tcp":
+			if uri.Path != "" {
+				return nil, adbc.Error{Msg: fmt.Sprintf("Invalid URI '%s': a socket path is only valid with transport=unix", loc), Code: adbc.StatusInvalidArgument}
+			}
+			creds = insecure.NewCredentials()
+		case "unix":
+			if uri.Host != "" {
+				return nil, adbc.Error{Msg: fmt.Sprintf("Invalid URI '%s': a host is not valid with transport=unix", loc), Code: adbc.StatusInvalidArgument}
+			}
+			if uri.Path == "" {
+				return nil, adbc.Error{Msg: fmt.Sprintf("Invalid URI '%s': transport=unix requires a socket path", loc), Code: adbc.StatusInvalidArgument}
+			}
+			creds = insecure.NewCredentials()
+			target = "unix:" + uri.Path
+		default:
+			return nil, adbc.Error{Msg: fmt.Sprintf("Invalid URI '%s': unrecognized transport %q (expected \"tls\", \"tcp\", or \"unix\")", loc, transport), Code: adbc.StatusInvalidArgument}
+		}
 	}
 
 	dv, _ := d.DriverInfo.GetInfoForInfoCode(adbc.InfoDriverVersion)

--- a/go/adbc/driver/flightsql/flightsql_driver.go
+++ b/go/adbc/driver/flightsql/flightsql_driver.go
@@ -28,7 +28,14 @@
 //
 //	db, err := sql.Open("flightsql", "uri=<flight sql db url>")
 //
-// The URI passed *must* contain a scheme, most likely "grpc+tcp://"
+// The URI passed *must* contain a scheme, most likely "flightsql://"
+// (secure TLS by default; add "?transport=tcp" for plaintext or
+// "?transport=unix" for a Unix domain socket, whose path is always
+// insecure/plaintext). The "transport" value is matched
+// case-insensitively, and an unrecognized value is rejected rather
+// than silently falling back to a default. The legacy "grpc://",
+// "grpc+tcp://", "grpc+tls://", and "grpc+unix://" schemes are also
+// still accepted.
 package flightsql
 
 import (

--- a/go/adbc/sqldriver/flightsql/README.md
+++ b/go/adbc/sqldriver/flightsql/README.md
@@ -49,7 +49,7 @@ import (
 )
 
 func main() {
-	db, err := sql.Open("flightsql", "uri=grpc://localhost:12345")
+	db, err := sql.Open("flightsql", "uri=flightsql://localhost:12345?transport=tcp")
 	if err != nil {
 		panic(err)
 	}

--- a/r/adbcflightsql/README.Rmd
+++ b/r/adbcflightsql/README.Rmd
@@ -69,7 +69,8 @@ This is a basic example which shows you how to solve a common problem.
 library(adbcdrivermanager)
 
 # Use the driver manager to connect to a database. This example URI is
-# grpc://localhost:8080 and uses a Go FlightSQL/SQLite server docker image
+# flightsql://localhost:8080?transport=tcp and uses a Go FlightSQL/SQLite
+# server docker image
 uri <- Sys.getenv("ADBC_FLIGHTSQL_TEST_URI")
 db <- adbc_database_init(adbcflightsql::adbcflightsql(), uri = uri)
 con <- adbc_connection_init(db)

--- a/r/adbcflightsql/README.md
+++ b/r/adbcflightsql/README.md
@@ -59,7 +59,8 @@ This is a basic example which shows you how to solve a common problem.
 library(adbcdrivermanager)
 
 # Use the driver manager to connect to a database. This example URI is
-# grpc://localhost:8080 and uses a Go FlightSQL/SQLite server docker image
+# flightsql://localhost:8080?transport=tcp and uses a Go FlightSQL/SQLite
+# server docker image
 uri <- Sys.getenv("ADBC_FLIGHTSQL_TEST_URI")
 db <- adbc_database_init(adbcflightsql::adbcflightsql(), uri = uri)
 con <- adbc_connection_init(db)


### PR DESCRIPTION
This PR adds support for `flightsql:// `uri format

Closes #4460.