### PR TITLE
chore(c/validation): add FloatCastTypeName quirk for CAST(... AS FLOAT)

### DIFF
--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -156,6 +156,9 @@ class DriverQuirks {
   /// \brief Return the SQL to reference the bind parameter of the given index
   virtual std::string BindParameter(int index) const { return "?"; }
 
+  /// \brief SQL type name for a 64-bit floating-point CAST target.
+  virtual std::string FloatCastTypeName() const { return "FLOAT"; }
+
   /// \brief For a given Arrow type of ingested data, what Arrow type
   ///   will the database return when that column is selected?
   virtual ArrowType IngestSelectRoundTripType(ArrowType ingest_type) const {

--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -2333,7 +2333,8 @@ void StatementTest::TestSqlQueryInts() {
 
 void StatementTest::TestSqlQueryFloats() {
   ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
-  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT CAST(1.5 AS FLOAT)", &error),
+  std::string query = "SELECT CAST(1.5 AS " + quirks()->FloatCastTypeName() + ")";
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, query.c_str(), &error),
               IsOkStatus(&error));
 
   {
@@ -2730,7 +2731,8 @@ void StatementTest::TestSqlSchemaFloats() {
   }
 
   ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
-  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT CAST(1.5 AS FLOAT)", &error),
+  std::string query = "SELECT CAST(1.5 AS " + quirks()->FloatCastTypeName() + ")";
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, query.c_str(), &error),
               IsOkStatus(&error));
 
   nanoarrow::UniqueSchema schema;


### PR DESCRIPTION
`TestSqlQueryFloats` and `TestSqlSchemaFloats` hardcoded `SELECT CAST(1.5 AS FLOAT)`, whose `FLOAT` type name is not valid in every SQL dialect (GoogleSQL in BigQuery supports only `FLOAT64` - Spanner also `FLOAT32`).

Introduce a `DriverQuirks::FloatCastTypeName()` quirk defaulting to `FLOAT` and build the cast SQL from it, so existing drivers run byte-identical SQL while other dialects can override the type name. The tests assert only the returned Arrow type and value (1.5), which are unaffected.