### PR TITLE
chore(ci): disable ASan on macos-latest C/C++ job to avoid CI hang

### DIFF
--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -197,6 +197,8 @@ jobs:
           BUILD_DRIVER_POSTGRESQL: "1"
           BUILD_DRIVER_SQLITE: "1"
           ADBC_DRIVER_MANAGER_USER_CONFIG_TEST: "1"
+          # Disable ASan for now on macos-latest (apple silicon) to avoid CI hanging
+          ADBC_USE_ASAN: ${{ matrix.os == 'macos-latest' && 'OFF' || 'ON' }}
         run: |
           # Ensure the CONDA_PREFIX searching in driver manager is tested
           export CONDA_BUILD=1


### PR DESCRIPTION
It seems that [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) (ASan) here hangs CI at:

- `Native Libraries (Unix) / C/C++ (Conda/macos-latest)`

Example run on latest main branch commit at time of writing:

- https://github.com/apache/arrow-adbc/actions/runs/28991039011/job/86030648737

Disable ASan on macos-latest for now to work around that. It still runs on Linux and intel macOS.