### PR TITLE
chore(c/validation): add RewriteSql quirk to override test queries

### DIFF
--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -163,8 +163,8 @@ class DriverQuirks {
   /// whose SQL dialect differs can override this and switch on \p query_id
   /// to substitute an equivalent query.
   virtual std::string RewriteSql(std::string_view query_id,
-                                 std::string_view default_sql) const {
-    return std::string(default_sql);
+                                 std::string default_sql) const {
+    return default_sql;
   }
 
   /// \brief For a given Arrow type of ingested data, what Arrow type

--- a/c/validation/adbc_validation.h
+++ b/c/validation/adbc_validation.h
@@ -156,6 +156,17 @@ class DriverQuirks {
   /// \brief Return the SQL to reference the bind parameter of the given index
   virtual std::string BindParameter(int index) const { return "?"; }
 
+  /// \brief Rewrite a SQL query used by a validation test, identified by a
+  ///   stable query id.
+  ///
+  /// The default implementation returns \p default_sql unchanged. Drivers
+  /// whose SQL dialect differs can override this and switch on \p query_id
+  /// to substitute an equivalent query.
+  virtual std::string RewriteSql(std::string_view query_id,
+                                 std::string_view default_sql) const {
+    return std::string(default_sql);
+  }
+
   /// \brief For a given Arrow type of ingested data, what Arrow type
   ///   will the database return when that column is selected?
   virtual ArrowType IngestSelectRoundTripType(ArrowType ingest_type) const {

--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -2333,7 +2333,10 @@ void StatementTest::TestSqlQueryInts() {
 
 void StatementTest::TestSqlQueryFloats() {
   ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
-  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT CAST(1.5 AS FLOAT)", &error),
+  std::string query =
+      quirks()->RewriteSql("StatementTest::TestSqlQueryFloats::cast-1.5-as-float",
+                           "SELECT CAST(1.5 AS FLOAT)");
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, query.c_str(), &error),
               IsOkStatus(&error));
 
   {
@@ -2730,7 +2733,10 @@ void StatementTest::TestSqlSchemaFloats() {
   }
 
   ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
-  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT CAST(1.5 AS FLOAT)", &error),
+  std::string query =
+      quirks()->RewriteSql("StatementTest::TestSqlSchemaFloats::cast-1.5-as-float",
+                           "SELECT CAST(1.5 AS FLOAT)");
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, query.c_str(), &error),
               IsOkStatus(&error));
 
   nanoarrow::UniqueSchema schema;


### PR DESCRIPTION
`TestSqlQueryFloats` and `TestSqlSchemaFloats` hardcoded `SELECT CAST(1.5 AS FLOAT)`, whose `FLOAT` type name is not valid in every SQL dialect (GoogleSQL in BigQuery accepts only `FLOAT64` - Spanner also `FLOAT32`).

Add a generic `DriverQuirks::RewriteSql(query_id, default_sql)` hook. It is keyed by a stable query id of the form `<test>::<description>` (e.g. `StatementTest::TestSqlQueryFloats::cast-1.5-as-float`) so driver overrides switch on the id, and takes the default query as an argument so the base method just returns it.

Drivers whose dialect differs can override the whole query. Wire it into the two float-cast select tests to start with to fix the `FLOAT` issue - it can be inserted into other tests on demand.