### PR TITLE
fix(go/adbc/driver/flightsql): drain bound-param stream in testserver DoPut

### DIFF
--- a/go/adbc/driver/flightsql/cmd/testserver/main.go
+++ b/go/adbc/driver/flightsql/cmd/testserver/main.go
@@ -452,6 +452,14 @@ func (srv *ExampleServer) DoGetStatement(ctx context.Context, cmd flightsql.Stat
 
 func (srv *ExampleServer) DoPutPreparedStatementQuery(ctx context.Context, cmd flightsql.PreparedStatementQuery, reader flight.MessageReader, writer flight.MetadataWriter) ([]byte, error) {
 	srv.recordHeaders(ctx, "DoPutPreparedStatementQuery")
+	// Drain the bound-parameter stream before returning. gRPC tears the stream
+	// down as soon as this handler returns, so if the server returns without
+	// consuming the client's request messages the client's in-flight parameter
+	// send can race the teardown and surface as a spurious "EOF (Unknown)"
+	// instead of the real response. Draining removes that race and matches
+	// gRPC's contract that a handler consume the full request stream.
+	for reader.Next() {
+	}
 	switch string(cmd.GetPreparedStatementHandle()) {
 	case "error_do_put":
 		return nil, status.Error(codes.Unknown, "expected error (DoPut)")


### PR DESCRIPTION
The FlightSQL test server's `DoPutPreparedStatementQuery` handler returned without consuming the client's bound-parameter request stream. gRPC tears the stream down as soon as the handler returns, so it might happen that (observed on arm64 macOS CI) the client's in-flight parameter send races the teardown and surfaces as a spurious "EOF (Unknown; ExecuteQuery)" instead of the real response, flaking `test_stateless_prepared_statement`.

Drain the reader before returning so the handler consumes the full request stream, per gRPC's contract, removing the race.