### PR TITLE
fix(java/driver/flight-sql): cache closes primary connection and attempts to re-use it.

### DIFF
--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
@@ -87,6 +87,8 @@ public class FlightSqlConnection implements AdbcConnection {
     this.callOptions = new CallOption[0];
     FlightSqlClient flightSqlClient = new FlightSqlClient(createInitialConnection(location));
     this.client = new FlightSqlClientWithCallOptions(flightSqlClient, callOptions);
+    final Location primaryLocation = location;
+    final FlightSqlClientWithCallOptions primaryClient = this.client;
     this.clientCache =
         Caffeine.newBuilder()
             .expireAfterAccess(5, TimeUnit.MINUTES)
@@ -94,7 +96,7 @@ public class FlightSqlConnection implements AdbcConnection {
                 (@Nullable Location key,
                     @Nullable FlightSqlClientWithCallOptions value,
                     RemovalCause cause) -> {
-                  if (value == null) return;
+                  if (value == null || value == primaryClient) return;
                   try {
                     value.close();
                   } catch (Exception ex) {
@@ -106,6 +108,9 @@ public class FlightSqlConnection implements AdbcConnection {
                 })
             .build(
                 loc -> {
+                  if (loc.equals(primaryLocation)) {
+                    return primaryClient;
+                  }
                   FlightClient client = buildClient(loc);
                   client.handshake(callOptions);
                   return new FlightSqlClientWithCallOptions(


### PR DESCRIPTION
If the cache isn't touched for 5 minutes, it triggers a lazy-evct close of the primary connection, which, could be used by other things, or prevent this from being used in pools.