### PR TITLE
fix(c/driver/postgresql): encode Arrow JSON for JSONB COPY

### DIFF
--- a/c/driver/postgresql/copy/writer.h
+++ b/c/driver/postgresql/copy/writer.h
@@ -818,6 +818,26 @@ class PostgresCopyBinaryFieldWriter : public PostgresCopyFieldWriter {
   }
 };
 
+class PostgresCopyJsonbFieldWriter : public PostgresCopyFieldWriter {
+ public:
+  ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
+    struct ArrowBufferView buffer_view = ArrowArrayViewGetBytesUnsafe(array_view_, index);
+    if (buffer_view.size_bytes >= (std::numeric_limits<int32_t>::max)()) {
+      ArrowErrorSet(error, "[libpq] JSON value at row %" PRId64 " is too large", index);
+      return EOVERFLOW;
+    }
+
+    const int32_t field_size_bytes = static_cast<int32_t>(buffer_view.size_bytes) + 1;
+    constexpr int8_t kJsonbVersion = 1;
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int8_t>(buffer, kJsonbVersion, error));
+    NANOARROW_RETURN_NOT_OK(
+        ArrowBufferAppend(buffer, buffer_view.data.as_uint8, buffer_view.size_bytes));
+
+    return ADBC_STATUS_OK;
+  }
+};
+
 class PostgresCopyBinaryDictFieldWriter : public PostgresCopyFieldWriter {
  public:
   ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
@@ -967,6 +987,25 @@ static inline ArrowErrorCode MakeCopyFieldWriter(
     std::unique_ptr<PostgresCopyFieldWriter>* out, ArrowError* error) {
   struct ArrowSchemaView schema_view;
   NANOARROW_RETURN_NOT_OK(ArrowSchemaViewInit(&schema_view, schema, error));
+
+  const bool is_arrow_json =
+      schema_view.extension_name.data != nullptr &&
+      std::string_view(schema_view.extension_name.data,
+                       schema_view.extension_name.size_bytes) == "arrow.json";
+  if (target_type != nullptr && target_type->type_id() == PostgresTypeId::kJsonb &&
+      is_arrow_json) {
+    switch (schema_view.type) {
+      case NANOARROW_TYPE_STRING:
+      case NANOARROW_TYPE_LARGE_STRING:
+      case NANOARROW_TYPE_STRING_VIEW: {
+        using T = PostgresCopyJsonbFieldWriter;
+        *out = T::Create<T>(array_view);
+        return NANOARROW_OK;
+      }
+      default:
+        break;
+    }
+  }
 
   if (target_type != nullptr && target_type->type_id() == PostgresTypeId::kNumeric) {
     switch (schema_view.type) {

--- a/c/driver/postgresql/postgresql_test.cc
+++ b/c/driver/postgresql/postgresql_test.cc
@@ -1802,12 +1802,22 @@ TEST_F(PostgresStatementTest, SqlIngestJsonb) {
                 IsOkStatus(&error));
     ASSERT_THAT(AdbcStatementBind(&statement, &batch.value, &schema.value, &error),
                 IsOkStatus(&error));
-    // TODO(https://github.com/apache/arrow-adbc/issues/3293): we need a
-    // different extension type for JSONB so the driver can know to generate
-    // the appropriate COPY representation
-    // (JSON-representation-version-prefixed JSON string).
     ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
-                IsStatus(ADBC_STATUS_INVALID_ARGUMENT, &error));
+                IsOkStatus(&error));
+
+    ASSERT_THAT(AdbcStatementSetSqlQuery(
+                    &statement, "SELECT j::text FROM jsontable ORDER BY ctid", &error),
+                IsOkStatus(&error));
+
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_NE(nullptr, reader.array->release);
+    ASSERT_NO_FATAL_FAILURE(adbc_validation::CompareArray<std::string>(
+        reader.array_view->children[0], {R"({"a": 1, "b": [1, 2, 3]})", std::nullopt}));
   }
 }
 


### PR DESCRIPTION
### Summary

PostgreSQL binary COPY represents a `jsonb` field as a version byte followed by
the JSON text. The PostgreSQL driver currently sends the physical string storage
of `extension<arrow.json>` unchanged, so PostgreSQL interprets the first JSON byte
as the version (for example, `{` becomes version 123) and rejects the row.

This adds a target-aware JSONB COPY field writer. When the Arrow source is
`extension<arrow.json>` and the existing PostgreSQL target column is `jsonb`, the
writer prefixes the JSON bytes with version `0x01` and includes that byte in the
field length. Other string inputs and PostgreSQL `json` targets continue to use
the existing writer.

The existing JSONB ingest regression test now verifies a successful round-trip,
including a SQL NULL value.

### Testing

- `pre-commit run --files c/driver/postgresql/copy/writer.h c/driver/postgresql/postgresql_test.cc` (all applicable C/C++ checks passed)
- `adbc-driver-postgresql-test` (242 passed, 6 skipped)
- `adbc-driver-postgresql-copy-test` (73 passed)
- Loaded 100 `extension<arrow.json>` values from the reported sample Parquet file through the locally built driver into a PostgreSQL `jsonb` column without a compatibility shim (100 inserted and validated)

Depends on #4499 for resolving existing PostgreSQL target column types during
COPY writer selection.

Closes #3293
