### PR TITLE
fix(java/driver/flight-sql): include connectionOptions for preparedStatement.close()

### DIFF
--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlConnection.java
@@ -121,7 +121,7 @@ public class FlightSqlConnection implements AdbcConnection {
 
   @Override
   public AdbcStatement createStatement() throws AdbcException {
-    return new FlightSqlStatement(allocator, client, clientCache, quirks);
+    return new FlightSqlStatement(allocator, client, clientCache, quirks, callOptions);
   }
 
   @Override
@@ -152,7 +152,7 @@ public class FlightSqlConnection implements AdbcConnection {
   public AdbcStatement bulkIngest(String targetTableName, BulkIngestMode mode)
       throws AdbcException {
     return FlightSqlStatement.ingestRoot(
-        allocator, client, clientCache, quirks, targetTableName, mode);
+        allocator, client, clientCache, quirks, targetTableName, mode, callOptions);
   }
 
   @Override

--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlStatement.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlStatement.java
@@ -37,7 +37,6 @@ import org.apache.arrow.flight.Location;
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.flight.sql.FlightSqlClient;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -49,7 +48,6 @@ public class FlightSqlStatement implements AdbcStatement {
   private final LoadingCache<Location, FlightSqlClientWithCallOptions> clientCache;
   private final SqlQuirks quirks;
   private final CallOption[] connectionOptions;
-
 
   // State for SQL queries
   private @Nullable String sqlQuery;

--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlStatement.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlStatement.java
@@ -29,6 +29,7 @@ import org.apache.arrow.adbc.core.AdbcStatusCode;
 import org.apache.arrow.adbc.core.BulkIngestMode;
 import org.apache.arrow.adbc.core.PartitionDescriptor;
 import org.apache.arrow.adbc.sql.SqlQuirks;
+import org.apache.arrow.flight.CallOption;
 import org.apache.arrow.flight.FlightEndpoint;
 import org.apache.arrow.flight.FlightInfo;
 import org.apache.arrow.flight.FlightRuntimeException;
@@ -47,6 +48,8 @@ public class FlightSqlStatement implements AdbcStatement {
   private final FlightSqlClientWithCallOptions client;
   private final LoadingCache<Location, FlightSqlClientWithCallOptions> clientCache;
   private final SqlQuirks quirks;
+  private final CallOption[] connectionOptions;
+
 
   // State for SQL queries
   private @Nullable String sqlQuery;
@@ -59,7 +62,8 @@ public class FlightSqlStatement implements AdbcStatement {
       BufferAllocator allocator,
       FlightSqlClientWithCallOptions client,
       LoadingCache<Location, FlightSqlClientWithCallOptions> clientCache,
-      SqlQuirks quirks) {
+      SqlQuirks quirks,
+      CallOption... connectionOptions) {
     this.allocator = allocator;
     this.client = client;
     this.clientCache = clientCache;
@@ -68,6 +72,7 @@ public class FlightSqlStatement implements AdbcStatement {
     this.preparedStatement = null;
     this.bulkOperation = null;
     this.bindRoot = null;
+    this.connectionOptions = connectionOptions;
   }
 
   static FlightSqlStatement ingestRoot(
@@ -76,10 +81,11 @@ public class FlightSqlStatement implements AdbcStatement {
       LoadingCache<Location, FlightSqlClientWithCallOptions> clientCache,
       SqlQuirks quirks,
       String targetTableName,
-      BulkIngestMode mode) {
+      BulkIngestMode mode,
+      CallOption... connectionOptions) {
     Objects.requireNonNull(targetTableName);
     final FlightSqlStatement statement =
-        new FlightSqlStatement(allocator, client, clientCache, quirks);
+        new FlightSqlStatement(allocator, client, clientCache, quirks, connectionOptions);
     statement.bulkOperation = new BulkState(mode, targetTableName);
     return statement;
   }

--- a/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlStatement.java
+++ b/java/driver/flight-sql/src/main/java/org/apache/arrow/adbc/driver/flightsql/FlightSqlStatement.java
@@ -170,7 +170,7 @@ public class FlightSqlStatement implements AdbcStatement {
         statement.setParameters(new NonOwningRoot(bindParams));
         client.executePreparedUpdate(statement);
       } finally {
-        statement.close();
+        statement.close(connectionOptions);
       }
     } catch (FlightRuntimeException e) {
       // XXX: FlightSqlClient.executeUpdate does some extra wrapping that we need to undo
@@ -313,7 +313,7 @@ public class FlightSqlStatement implements AdbcStatement {
     // TODO(https://github.com/apache/arrow/issues/39814): this is annotated wrongly upstream
     if (preparedStatement != null) {
       try {
-        AutoCloseables.close(preparedStatement);
+        preparedStatement.close(connectionOptions);
       } catch (Exception e) {
         throw AdbcException.internal("[Flight SQL] Could not close prepared statement")
             .withCause(e);

--- a/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/HeaderTest.java
+++ b/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/HeaderTest.java
@@ -27,6 +27,7 @@ import org.apache.arrow.adbc.core.AdbcDatabase;
 import org.apache.arrow.adbc.core.AdbcDriver;
 import org.apache.arrow.adbc.core.AdbcException;
 import org.apache.arrow.adbc.core.AdbcInfoCode;
+import org.apache.arrow.adbc.core.AdbcStatement;
 import org.apache.arrow.adbc.core.AdbcStatusCode;
 import org.apache.arrow.adbc.drivermanager.AdbcDriverManager;
 import org.apache.arrow.driver.jdbc.utils.MockFlightSqlProducer;
@@ -55,16 +56,18 @@ public class HeaderTest {
   private AdbcConnection connection;
   private BufferAllocator allocator;
   private HeaderValidator.Factory headerValidatorFactory;
+  private MockFlightSqlProducer producer;
 
   @BeforeEach
   public void setUp() {
     allocator = new RootAllocator(Long.MAX_VALUE);
     headerValidatorFactory = new HeaderValidator.Factory();
+    producer = new MockFlightSqlProducer();
     builder =
         FlightServer.builder()
             .middleware(HeaderValidator.KEY, headerValidatorFactory)
             .location(Location.forGrpcInsecure("localhost", 0))
-            .producer(new MockFlightSqlProducer());
+            .producer(producer);
     params = new HashMap<>();
   }
 
@@ -87,6 +90,40 @@ public class HeaderTest {
 
     CallHeaders headers = headerValidatorFactory.getHeadersReceivedAtRequest(0);
     assertEquals(dummyValue, headers.get(dummyHeaderName));
+  }
+
+  /**
+   * The connection's call options (which carry arbitrary headers, auth, cookies, etc.) must ride on
+   * every RPC the driver issues on that connection's behalf, including the ClosePreparedStatement
+   * call made when a prepared statement is closed. This regression test guards against dropping the
+   * connection options on close.
+   */
+  @Test
+  public void testHeaderSentWhenClosingPreparedStatement() throws Exception {
+    final String dummyValue = "dummy";
+    final String dummyHeaderName = "test-header";
+    final String query = "UPDATE the_table SET x = 1";
+    params.put(FlightSqlConnectionProperties.RPC_CALL_HEADER_PREFIX + dummyHeaderName, dummyValue);
+    producer.addUpdateQuery(query, /*updatedRows=*/ 1L);
+    server = builder.build();
+    server.start();
+    connect();
+
+    // Prepare and then close a statement. Closing triggers a ClosePreparedStatement RPC, which must
+    // still carry the connection header. Before the fix, close() dropped the call options.
+    try (AdbcStatement statement = connection.createStatement()) {
+      statement.setSqlQuery(query);
+      statement.prepare();
+    }
+
+    // The connection header must appear on every RPC, including the final ClosePreparedStatement.
+    final int requestCount = headerValidatorFactory.getRequestCount();
+    assertTrue(requestCount > 0);
+    for (int i = 0; i < requestCount; i++) {
+      CallHeaders headers = headerValidatorFactory.getHeadersReceivedAtRequest(i);
+      assertEquals(
+          dummyValue, headers.get(dummyHeaderName), "connection header missing on RPC #" + i);
+    }
   }
 
   @Test

--- a/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/HeaderTest.java
+++ b/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/HeaderTest.java
@@ -104,7 +104,7 @@ public class HeaderTest {
     final String dummyHeaderName = "test-header";
     final String query = "UPDATE the_table SET x = 1";
     params.put(FlightSqlConnectionProperties.RPC_CALL_HEADER_PREFIX + dummyHeaderName, dummyValue);
-    producer.addUpdateQuery(query, /*updatedRows=*/ 1L);
+    producer.addUpdateQuery(query, /* updatedRows= */ 1L);
     server = builder.build();
     server.start();
     connect();

--- a/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/HeaderValidator.java
+++ b/java/driver/flight-sql/src/test/java/org/apache/arrow/adbc/driver/flightsql/HeaderValidator.java
@@ -52,6 +52,10 @@ public class HeaderValidator implements FlightServerMiddleware {
       return cloneHeaders(headersReceived.get(request));
     }
 
+    public int getRequestCount() {
+      return headersReceived.size();
+    }
+
     private static CallHeaders cloneHeaders(CallHeaders headers) {
       FlightCallHeaders cloneHeaders = new FlightCallHeaders();
       for (String key : headers.keys()) {


### PR DESCRIPTION
Proposed solution for #4512 

Include connection options when calling preparedStatement.close()