### PR TITLE
fix(ci): allow Clippy (nightly) step to fail

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -167,6 +167,7 @@ jobs:
           cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings
       - name: Clippy (nightly)
         if: runner.os == 'Linux' && ! matrix.minimal-versions
+        continue-on-error: true
         working-directory: rust
         run: |
           rustup toolchain install nightly --component clippy


### PR DESCRIPTION
Nightly clippy lints can break CI without any code changes on our side, and it can be unstable - recently nightly clippy panicked: https://github.com/apache/arrow-adbc/actions/runs/29331390016/job/87079916638?pr=4514

Mark the step as `continue-on-error` so failures are visible but non-blocking.