### PR TITLE
feat(go/adbc): align default trace path with ADBC config layout

### DIFF
--- a/docs/source/driver/flight_sql.rst
+++ b/docs/source/driver/flight_sql.rst
@@ -227,15 +227,9 @@ Database options
     If unset, the ``adbcfile`` exporter writes traces under the user's
     configuration directory in:
 
-    - Windows: ``%APPDATA%\.adbc\traces``
-    - macOS: ``~/Library/Application Support/.adbc/traces``
-    - Linux: ``$XDG_CONFIG_HOME/.adbc/traces`` or ``~/.config/.adbc/traces``
-
-    .. note::
-
-       These default paths reflect the current implementation. See
-       `issue #4501 <https://github.com/apache/arrow-adbc/issues/4501>`_
-       for the planned config-path redesign.
+    - Windows: ``%APPDATA%\ADBC\Traces``
+    - macOS: ``~/Library/Application Support/ADBC/Traces``
+    - Linux: ``$XDG_CONFIG_HOME/adbc/traces`` or ``~/.config/adbc/traces``
 
 ``adbc.telemetry.trace_parent``
     Sets the W3C Trace Context ``traceparent`` value used as the parent

--- a/docs/source/driver/flight_sql.rst
+++ b/docs/source/driver/flight_sql.rst
@@ -224,12 +224,13 @@ Database options
     Overrides the output folder used by the ``adbcfile`` exporter.
     This option is ignored for other exporters.
 
-    If unset, the ``adbcfile`` exporter writes traces under the user's
-    configuration directory in:
+    If unset, the ``adbcfile`` exporter writes traces under a
+    platform-specific directory:
 
-    - Windows: ``%APPDATA%\ADBC\Traces``
+    - Windows: ``%LOCALAPPDATA%\ADBC\Traces``
     - macOS: ``~/Library/Application Support/ADBC/Traces``
-    - Linux: ``$XDG_CONFIG_HOME/adbc/traces`` or ``~/.config/adbc/traces``
+    - Linux: ``$XDG_STATE_HOME/adbc/traces`` or ``~/.local/state/adbc/traces``
+      if ``$XDG_STATE_HOME`` is not set
 
 ``adbc.telemetry.trace_parent``
     Sets the W3C Trace Context ``traceparent`` value used as the parent

--- a/go/adbc/adbc.go
+++ b/go/adbc/adbc.go
@@ -281,8 +281,9 @@ const (
 	// is set, rotated trace files are written to the supplied folder
 	// (which is created if it does not exist) instead of the default
 	// platform-specific ADBC traces path (for example,
-	// "<user-config-dir>/ADBC/Traces" on macOS/Windows, or
-	// "<user-config-dir>/adbc/traces" on Linux). The option is ignored for
+	// "<user-config-dir>/ADBC/Traces" on macOS,
+	// "<local-app-data-dir>/ADBC/Traces" on Windows, or
+	// "<xdg-state-dir>/adbc/traces" on Linux). The option is ignored for
 	// other exporters; it exists so an operator can route trace files
 	// to a location their support workflow already collects (e.g. a
 	// shared diagnostics folder) via the ADBC driver-manager / TOML

--- a/go/adbc/adbc.go
+++ b/go/adbc/adbc.go
@@ -280,7 +280,9 @@ const (
 	// traces exporter. When the exporter is "adbcfile" and this option
 	// is set, rotated trace files are written to the supplied folder
 	// (which is created if it does not exist) instead of the default
-	// "<user-config-dir>/.adbc/traces" path. The option is ignored for
+	// platform-specific ADBC traces path (for example,
+	// "<user-config-dir>/ADBC/Traces" on macOS/Windows, or
+	// "<user-config-dir>/adbc/traces" on Linux). The option is ignored for
 	// other exporters; it exists so an operator can route trace files
 	// to a location their support workflow already collects (e.g. a
 	// shared diagnostics folder) via the ADBC driver-manager / TOML

--- a/go/adbc/driver/internal/driverbase/rotating_file_writer.go
+++ b/go/adbc/driver/internal/driverbase/rotating_file_writer.go
@@ -153,16 +153,29 @@ func NewRotatingFileWriter(options ...rotatingFileWriterOption) (*rotatingFileWr
 }
 
 func getDefaultTracingFolderPath() (string, error) {
-	userConfigDir, err := os.UserConfigDir()
-	if err != nil {
-		return "", err
-	}
-
 	switch runtime.GOOS {
-	case "darwin", "windows":
+	case "darwin":
+		userConfigDir, err := os.UserConfigDir()
+		if err != nil {
+			return "", err
+		}
 		return filepath.Join(userConfigDir, "ADBC", "Traces"), nil
+	case "windows":
+		userCacheDir, err := os.UserCacheDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(userCacheDir, "ADBC", "Traces"), nil
 	default:
-		return filepath.Join(userConfigDir, "adbc", "traces"), nil
+		stateDir := os.Getenv("XDG_STATE_HOME")
+		if strings.TrimSpace(stateDir) == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+			stateDir = filepath.Join(home, ".local", "state")
+		}
+		return filepath.Join(stateDir, "adbc", "traces"), nil
 	}
 }
 

--- a/go/adbc/driver/internal/driverbase/rotating_file_writer.go
+++ b/go/adbc/driver/internal/driverbase/rotating_file_writer.go
@@ -22,6 +22,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -156,8 +157,13 @@ func getDefaultTracingFolderPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	fullPath := filepath.Join(userConfigDir, ".adbc", "traces")
-	return fullPath, nil
+
+	switch runtime.GOOS {
+	case "darwin", "windows":
+		return filepath.Join(userConfigDir, "ADBC", "Traces"), nil
+	default:
+		return filepath.Join(userConfigDir, "adbc", "traces"), nil
+	}
 }
 
 // Closes the rotating file write

--- a/go/adbc/driver/internal/driverbase/rotating_file_writer_test.go
+++ b/go/adbc/driver/internal/driverbase/rotating_file_writer_test.go
@@ -18,15 +18,51 @@
 package driverbase_test
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase"
 	"github.com/stretchr/testify/require"
 )
 
+func TestDefaultTracingFolderPath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	var expected string
+	switch runtime.GOOS {
+	case "windows":
+		appDataDir := filepath.Join(tempDir, "AppData", "Roaming")
+		t.Setenv("APPDATA", appDataDir)
+		expected = filepath.Join(appDataDir, "ADBC", "Traces")
+	case "darwin":
+		t.Setenv("HOME", tempDir)
+		expected = filepath.Join(tempDir, "Library", "Application Support", "ADBC", "Traces")
+	default:
+		configDir := filepath.Join(tempDir, ".config")
+		t.Setenv("XDG_CONFIG_HOME", configDir)
+		t.Setenv("HOME", tempDir)
+		expected = filepath.Join(configDir, "adbc", "traces")
+	}
+
+	fw, err := driverbase.NewRotatingFileWriter()
+	require.NoError(t, err)
+	defer func() {
+		err := fw.Clear()
+		require.NoError(t, err)
+	}()
+
+	require.Equal(t, expected, fw.GetTracingFolderPath())
+	_, err = os.Stat(expected)
+	require.NoError(t, err)
+}
+
 func TestRotatingFileWriter(t *testing.T) {
+	traceDir := t.TempDir()
 
 	fw, err := driverbase.NewRotatingFileWriter(
+		driverbase.WithTracingFolderPath(traceDir),
 		driverbase.WithFileSizeMaxKb(1),
 		driverbase.WithFileCountMax(10),
 	)
@@ -49,7 +85,10 @@ func TestRotatingFileWriter(t *testing.T) {
 }
 
 func TestFileResuse(t *testing.T) {
+	traceDir := t.TempDir()
+
 	fw1, err := driverbase.NewRotatingFileWriter(
+		driverbase.WithTracingFolderPath(traceDir),
 		driverbase.WithFileSizeMaxKb(1000),
 		driverbase.WithFileCountMax(10),
 	)
@@ -70,6 +109,7 @@ func TestFileResuse(t *testing.T) {
 	require.NoError(t, err)
 
 	fw2, err := driverbase.NewRotatingFileWriter(
+		driverbase.WithTracingFolderPath(traceDir),
 		driverbase.WithFileSizeMaxKb(1000),
 		driverbase.WithFileCountMax(10),
 	)

--- a/go/adbc/driver/internal/driverbase/rotating_file_writer_test.go
+++ b/go/adbc/driver/internal/driverbase/rotating_file_writer_test.go
@@ -33,17 +33,17 @@ func TestDefaultTracingFolderPath(t *testing.T) {
 	var expected string
 	switch runtime.GOOS {
 	case "windows":
-		appDataDir := filepath.Join(tempDir, "AppData", "Roaming")
-		t.Setenv("APPDATA", appDataDir)
-		expected = filepath.Join(appDataDir, "ADBC", "Traces")
+		localAppDataDir := filepath.Join(tempDir, "AppData", "Local")
+		t.Setenv("LocalAppData", localAppDataDir)
+		expected = filepath.Join(localAppDataDir, "ADBC", "Traces")
 	case "darwin":
 		t.Setenv("HOME", tempDir)
 		expected = filepath.Join(tempDir, "Library", "Application Support", "ADBC", "Traces")
 	default:
-		configDir := filepath.Join(tempDir, ".config")
-		t.Setenv("XDG_CONFIG_HOME", configDir)
+		stateDir := filepath.Join(tempDir, ".local", "state")
+		t.Setenv("XDG_STATE_HOME", stateDir)
 		t.Setenv("HOME", tempDir)
-		expected = filepath.Join(configDir, "adbc", "traces")
+		expected = filepath.Join(stateDir, "adbc", "traces")
 	}
 
 	fw, err := driverbase.NewRotatingFileWriter()


### PR DESCRIPTION
Update the Go driverbase adbcfile trace writer to use the ADBC config-directory layout
Use temp directories for the existing rotating-file tests

Closes #4501 