### PR TITLE
ci(rust): pinning the nightly tool chain version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,6 +97,12 @@ updates:
           - "arrow-*"
     cooldown:
       default-days: 7
+  - package-ecosystem: "rust-toolchain"
+    directory: "/ci/rust-nightly/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(rust): "
   - package-ecosystem: "cargo"
     directories:
       - "/javascript/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -103,6 +103,8 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(rust): "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "cargo"
     directories:
       - "/javascript/"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,7 @@ on:
       - main
     paths:
       - "c/**"
+      - "ci/rust-nightly/**"
       - "rust/**"
       - ".github/workflows/rust.yml"
   push:
@@ -30,6 +31,7 @@ on:
       - 'dependabot/**'
     paths:
       - "c/**"
+      - "ci/rust-nightly/**"
       - "rust/**"
       - ".github/workflows/rust.yml"
 
@@ -73,10 +75,11 @@ jobs:
           persist-credentials: false
       - name: Cargo update for minimal versions
         if: ${{ matrix.minimal-versions }}
-        working-directory: rust
+        working-directory: ci/rust-nightly
         run: |
-          rustup toolchain install nightly
-          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo +nightly generate-lockfile -Z direct-minimal-versions
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo generate-lockfile \
+            --manifest-path "${GITHUB_WORKSPACE}/rust/Cargo.toml" \
+            -Z direct-minimal-versions
       - name: Use stable Rust
         id: rust
         run: |
@@ -167,14 +170,14 @@ jobs:
           cargo clippy --workspace --all-targets --all-features --locked -- -Dwarnings
       - name: Clippy (nightly)
         if: runner.os == 'Linux' && ! matrix.minimal-versions
-        working-directory: rust
+        working-directory: ci/rust-nightly
         run: |
-          rustup toolchain install nightly --component clippy
           # -Zcrate-attr enables the unstable non_exhaustive_omitted_patterns lint
           # (https://github.com/apache/arrow-adbc/pull/3245).
           # It applies to all workspace packages, so we also allow unused_features for crates that
           # don't use the lint.
-          cargo +nightly clippy --workspace --all-targets --all-features --locked -- -Dwarnings \
+          cargo clippy --manifest-path "${GITHUB_WORKSPACE}/rust/Cargo.toml" \
+            --workspace --all-targets --all-features --locked -- -Dwarnings \
             -Zcrate-attr='feature(non_exhaustive_omitted_patterns_lint)' \
             -Zcrate-attr='allow(unused_features)'
       - name: Test (Default Features)

--- a/ci/rust-nightly/rust-toolchain.toml
+++ b/ci/rust-nightly/rust-toolchain.toml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[toolchain]
+channel = "nightly-2026-07-07"
+profile = "minimal"
+components = ["clippy"]


### PR DESCRIPTION
Related to #4515, #4524

By updating the nightly toolchain version via Dependabot, we can prevent unexpected CI outages.