### PR TITLE
chore(r): regenerate files with roxygen2 8.0.0, and fix some docs and tests

### DIFF
--- a/r/adbcdrivermanager/DESCRIPTION
+++ b/r/adbcdrivermanager/DESCRIPTION
@@ -15,7 +15,6 @@ Description: Provides a developer-facing interface to 'Arrow' Database
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
 Suggests:
     testthat (>= 3.0.0),
     withr
@@ -25,3 +24,4 @@ URL: https://arrow.apache.org/adbc/current/r/adbcdrivermanager/, https://github.
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports:
     nanoarrow (>= 0.3.0)
+Config/roxygen2/version: 8.0.0

--- a/r/adbcdrivermanager/R/adbc.R
+++ b/r/adbcdrivermanager/R/adbc.R
@@ -70,7 +70,7 @@
 #'
 #' Named profiles are located using the driver manager's standard profile
 #' search paths. See the
-#' [ADBC connection profile documentation](https://arrow.apache.org/adbc/current/connection_profiles.html)
+#' [ADBC connection profile documentation](https://arrow.apache.org/adbc/current/format/connection_profiles.html)
 #' for the file format, search locations, option precedence, and environment
 #' variable substitution.
 #'

--- a/r/adbcdrivermanager/man/adbc_database_init.Rd
+++ b/r/adbcdrivermanager/man/adbc_database_init.Rd
@@ -92,7 +92,7 @@ uri = "postgresql://localhost/database"
 
 Named profiles are located using the driver manager's standard profile
 search paths. See the
-\href{https://arrow.apache.org/adbc/current/connection_profiles.html}{ADBC connection profile documentation}
+\href{https://arrow.apache.org/adbc/current/format/connection_profiles.html}{ADBC connection profile documentation}
 for the file format, search locations, option precedence, and environment
 variable substitution.
 }

--- a/r/adbcdrivermanager/man/adbcdrivermanager-package.Rd
+++ b/r/adbcdrivermanager/man/adbcdrivermanager-package.Rd
@@ -22,6 +22,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Dewey Dunnington \email{dewey@dunnington.ca} (\href{https://orcid.org/0000-0002-9415-4582}{ORCID})
   \item Apache Arrow \email{dev@arrow.apache.org} [copyright holder]
 }
 

--- a/r/adbcdrivermanager/tests/testthat/test-profile.R
+++ b/r/adbcdrivermanager/tests/testthat/test-profile.R
@@ -15,12 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# This suite is just a smoke test to make sure connection profiles are hooked
-# up. We make a fake driver and a broken connection profile just to test that
-# the driver manager is producing the right error message as proof connection
-# profiles are hooked up.
+# Smoke tests for loading connection profiles through the R driver manager.
 
-write_profile <- function(dir, name) {
+write_broken_profile <- function(dir, name) {
   content <- paste0(
     'profile_version = 1\n',
     'driver = "/nonexistent/driver.so"\n',
@@ -84,7 +81,7 @@ test_that("can load a profile by absolute path via 'profile' option", {
   dir.create(dir)
   on.exit(unlink(dir, recursive = TRUE))
 
-  profile_path <- write_profile(dir, "myprofile")
+  profile_path <- write_broken_profile(dir, "myprofile")
 
   expect_error(
     adbc_database_init(
@@ -99,7 +96,7 @@ test_that("can load a profile by name via additional_profile_search_path_list", 
   dir.create(dir)
   on.exit(unlink(dir, recursive = TRUE))
 
-  write_profile(dir, "myprofile")
+  write_broken_profile(dir, "myprofile")
 
   expect_error(
     adbc_database_init(
@@ -115,7 +112,7 @@ test_that("can load a profile by name via ADBC_PROFILE_PATH env var", {
   dir.create(dir)
   on.exit(unlink(dir, recursive = TRUE))
 
-  write_profile(dir, "myprofile")
+  write_broken_profile(dir, "myprofile")
 
   withr::with_envvar(
     list(ADBC_PROFILE_PATH = dir),
@@ -133,7 +130,7 @@ test_that("can load a profile via profile:// URI in 'uri' option", {
   dir.create(dir)
   on.exit(unlink(dir, recursive = TRUE))
 
-  profile_path <- write_profile(dir, "myprofile")
+  profile_path <- write_broken_profile(dir, "myprofile")
 
   expect_error(
     adbc_database_init(
@@ -148,25 +145,10 @@ test_that("can load a profile via profile:// URI in 'driver' argument", {
   dir.create(dir)
   on.exit(unlink(dir, recursive = TRUE))
 
-  profile_path <- write_profile(dir, "myprofile")
+  profile_path <- write_broken_profile(dir, "myprofile")
 
   expect_error(
     adbc_database_init(paste0("profile://", profile_path)),
-    regexp = "nonexistent"
-  )
-})
-
-test_that("can load a profile via profile:// URI in 'driver' option", {
-  dir <- tempfile()
-  dir.create(dir)
-  on.exit(unlink(dir, recursive = TRUE))
-
-  profile_path <- write_profile(dir, "myprofile")
-
-  expect_error(
-    adbc_database_init_driver_manager(
-      list(driver = paste0("profile://", profile_path))
-    ),
     regexp = "nonexistent"
   )
 })
@@ -185,9 +167,7 @@ test_that("missing profile returns an error", {
   withr::with_envvar(
     list(ADBC_PROFILE_PATH = dir),
     expect_error(
-      adbc_database_init_driver_manager(
-        list(profile = "does_not_exist")
-      ),
+      adbc_database_init(profile = "does_not_exist"),
       # "does_not_exist" is the profile name; keep in sync with C error message format
       regexp = "does_not_exist"
     )

--- a/r/adbcdrivermanager/tests/testthat/test-profile.R
+++ b/r/adbcdrivermanager/tests/testthat/test-profile.R
@@ -20,13 +20,6 @@
 # the driver manager is producing the right error message as proof connection
 # profiles are hooked up.
 
-adbc_driver_for_profile <- function() {
-  driver <- new.env(parent = emptyenv())
-  driver$load_flags <- adbc_load_flags()
-  class(driver) <- "adbc_driver"
-  driver
-}
-
 write_profile <- function(dir, name) {
   content <- paste0(
     'profile_version = 1\n',
@@ -171,9 +164,8 @@ test_that("can load a profile via profile:// URI in 'driver' option", {
   profile_path <- write_profile(dir, "myprofile")
 
   expect_error(
-    adbc_database_init_default(
-      adbc_driver_for_profile(),
-      list(driver = paste0("profile://", profile_path)) # Wrap in list() to avoid arg names clashing
+    adbc_database_init_driver_manager(
+      list(driver = paste0("profile://", profile_path))
     ),
     regexp = "nonexistent"
   )
@@ -193,8 +185,7 @@ test_that("missing profile returns an error", {
   withr::with_envvar(
     list(ADBC_PROFILE_PATH = dir),
     expect_error(
-      adbc_database_init_default(
-        adbc_driver_for_profile(),
+      adbc_database_init_driver_manager(
         list(profile = "does_not_exist")
       ),
       # "does_not_exist" is the profile name; keep in sync with C error message format

--- a/r/adbcflightsql/DESCRIPTION
+++ b/r/adbcflightsql/DESCRIPTION
@@ -15,7 +15,6 @@ Description: Provides a developer-facing interface to the 'Arrow' Database
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
 Suggests:
     nanoarrow,
     testthat (>= 3.0.0)
@@ -25,3 +24,4 @@ Config/build/bootstrap: TRUE
 URL: https://arrow.apache.org/adbc/current/r/adbcflightsql/, https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports: adbcdrivermanager
+Config/roxygen2/version: 8.0.0

--- a/r/adbcflightsql/man/adbcflightsql-package.Rd
+++ b/r/adbcflightsql/man/adbcflightsql-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{adbcflightsql-package}
 \alias{adbcflightsql-package}
-\alias{_PACKAGE}
 \title{adbcflightsql: 'Arrow' Database Connectivity ('ADBC') 'FlightSQL' Driver}
 \description{
 Provides a developer-facing interface to the 'Arrow' Database Connectivity ('ADBC') 'FlightSQL' driver for the purposes of building high-level database interfaces for users. 'ADBC' \url{https://arrow.apache.org/adbc/} is an API standard for database access libraries that uses 'Arrow' for result sets and query parameters.
@@ -22,6 +21,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Dewey Dunnington \email{dewey@dunnington.ca} (\href{https://orcid.org/0000-0002-9415-4582}{ORCID})
   \item Apache Arrow \email{dev@arrow.apache.org} [copyright holder]
 }
 

--- a/r/adbcflightsql/man/adbcflightsql.Rd
+++ b/r/adbcflightsql/man/adbcflightsql.Rd
@@ -21,7 +21,19 @@ adbcflightsql()
 )
 }
 \arguments{
-\item{driver}{An \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}.}
+\item{driver}{The driver to use. This can be one of the following:
+\itemize{
+\item A non-missing \code{character(1)} containing a driver or manifest name, a
+relative or absolute path to a driver or manifest, or a URI. For a URI,
+the driver manager uses the URI scheme as the driver name and passes the
+URI to that driver. A \verb{profile://} URI loads a connection profile.
+\item \code{NULL}, which leaves driver selection to the driver manager. In this
+case, \code{...} must normally contain \code{uri} or \code{profile}; the driver is
+inferred from the URI or loaded from the connection profile.
+\item An object that inherits from the \code{adbc_driver} class, such as one created
+by \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}. This includes drivers provided by R packages, such as
+\code{adbcsqlite::adbcsqlite()}.
+}}
 
 \item{...}{Extra key/value options passed to the driver.}
 
@@ -40,7 +52,7 @@ autocommit behaviour.}
 \item{adbc.ingest.mode}{Whether to create (the default) or append.}
 }
 \value{
-An \code{\link[adbcdrivermanager:adbc_driver_void]{adbcdrivermanager::adbc_driver()}}
+An \code{\link[adbcdrivermanager:adbc_driver]{adbcdrivermanager::adbc_driver()}}
 }
 \description{
 ADBC FlightSQL Driver

--- a/r/adbcpostgresql/DESCRIPTION
+++ b/r/adbcpostgresql/DESCRIPTION
@@ -15,7 +15,6 @@ Description: Provides a developer-facing interface to the 'Arrow' Database
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
 SystemRequirements: libpq
 Suggests:
     nanoarrow,
@@ -25,3 +24,4 @@ Config/build/bootstrap: TRUE
 URL: https://arrow.apache.org/adbc/current/r/adbcpostgresql/, https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports: adbcdrivermanager
+Config/roxygen2/version: 8.0.0

--- a/r/adbcpostgresql/man/adbcpostgresql-package.Rd
+++ b/r/adbcpostgresql/man/adbcpostgresql-package.Rd
@@ -21,6 +21,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Dewey Dunnington \email{dewey@dunnington.ca} (\href{https://orcid.org/0000-0002-9415-4582}{ORCID})
   \item Apache Arrow \email{dev@arrow.apache.org} [copyright holder]
 }
 

--- a/r/adbcpostgresql/man/adbcpostgresql.Rd
+++ b/r/adbcpostgresql/man/adbcpostgresql.Rd
@@ -22,10 +22,22 @@ adbcpostgresql()
 )
 }
 \arguments{
-\item{driver}{An \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}.}
+\item{driver}{The driver to use. This can be one of the following:
+\itemize{
+\item A non-missing \code{character(1)} containing a driver or manifest name, a
+relative or absolute path to a driver or manifest, or a URI. For a URI,
+the driver manager uses the URI scheme as the driver name and passes the
+URI to that driver. A \verb{profile://} URI loads a connection profile.
+\item \code{NULL}, which leaves driver selection to the driver manager. In this
+case, \code{...} must normally contain \code{uri} or \code{profile}; the driver is
+inferred from the URI or loaded from the connection profile.
+\item An object that inherits from the \code{adbc_driver} class, such as one created
+by \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}. This includes drivers provided by R packages, such as
+\code{adbcsqlite::adbcsqlite()}.
+}}
 
-\item{...}{Driver-specific options. For the default method, these are
-named values that are converted to strings.}
+\item{...}{Driver-specific options. These are generally named values that
+are converted to strings.}
 
 \item{uri}{A URI to a database path (e.g.,
 \verb{postgresql://localhost:1234/postgres?user=user&password=password})}
@@ -44,7 +56,7 @@ autocommit behaviour.}
 \item{adbc.ingest.mode}{Whether to create (the default) or append.}
 }
 \value{
-An \code{\link[adbcdrivermanager:adbc_driver_void]{adbcdrivermanager::adbc_driver()}}
+An \code{\link[adbcdrivermanager:adbc_driver]{adbcdrivermanager::adbc_driver()}}
 }
 \description{
 ADBC PostgreSQL Driver

--- a/r/adbcsqlite/DESCRIPTION
+++ b/r/adbcsqlite/DESCRIPTION
@@ -15,7 +15,6 @@ Description: Provides a developer-facing interface to the 'Arrow' Database
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
 SystemRequirements: SQLite3
 Suggests:
     nanoarrow,
@@ -26,3 +25,4 @@ Config/build/bootstrap: TRUE
 URL: https://arrow.apache.org/adbc/current/r/adbcsqlite/, https://github.com/apache/arrow-adbc
 BugReports: https://github.com/apache/arrow-adbc/issues
 Imports: adbcdrivermanager
+Config/roxygen2/version: 8.0.0

--- a/r/adbcsqlite/man/adbcsqlite-package.Rd
+++ b/r/adbcsqlite/man/adbcsqlite-package.Rd
@@ -21,6 +21,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Dewey Dunnington \email{dewey@dunnington.ca} (\href{https://orcid.org/0000-0002-9415-4582}{ORCID})
   \item Apache Arrow \email{dev@arrow.apache.org} [copyright holder]
 }
 

--- a/r/adbcsqlite/man/adbcsqlite.Rd
+++ b/r/adbcsqlite/man/adbcsqlite.Rd
@@ -23,10 +23,22 @@ adbcsqlite()
 )
 }
 \arguments{
-\item{driver}{An \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}.}
+\item{driver}{The driver to use. This can be one of the following:
+\itemize{
+\item A non-missing \code{character(1)} containing a driver or manifest name, a
+relative or absolute path to a driver or manifest, or a URI. For a URI,
+the driver manager uses the URI scheme as the driver name and passes the
+URI to that driver. A \verb{profile://} URI loads a connection profile.
+\item \code{NULL}, which leaves driver selection to the driver manager. In this
+case, \code{...} must normally contain \code{uri} or \code{profile}; the driver is
+inferred from the URI or loaded from the connection profile.
+\item An object that inherits from the \code{adbc_driver} class, such as one created
+by \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}. This includes drivers provided by R packages, such as
+\code{adbcsqlite::adbcsqlite()}.
+}}
 
-\item{...}{Driver-specific options. For the default method, these are
-named values that are converted to strings.}
+\item{...}{Driver-specific options. These are generally named values that
+are converted to strings.}
 
 \item{uri}{A URI to a database path or ":memory:" for an in-memory database.}
 
@@ -46,7 +58,7 @@ autocommit behaviour.}
 \item{adbc.sqlite.query.batch_rows}{The number of rows per batch to return.}
 }
 \value{
-An \code{\link[adbcdrivermanager:adbc_driver_void]{adbcdrivermanager::adbc_driver()}}
+An \code{\link[adbcdrivermanager:adbc_driver]{adbcdrivermanager::adbc_driver()}}
 }
 \description{
 ADBC SQLite3 Driver


### PR DESCRIPTION
Follow up for #4535

- Documentation updates with the latest roxygen2 (8.0.0).
- Fixing a broken link.
- Simplify tests.