### PR TITLE
docs: update js profile example

### DIFF
--- a/docs/source/connection_profiles.rst
+++ b/docs/source/connection_profiles.rst
@@ -148,7 +148,7 @@ the ``profile://`` scheme:
          import { AdbcDatabase } from '@apache-arrow/adbc-driver-manager';
 
          const db = new AdbcDatabase({
-           driver: 'profile://myprofile',
+           databaseOptions: { uri: 'profile://myprofile' },
          });
 
    .. tab-item:: Python


### PR DESCRIPTION
Update the JS profiles example in the new Connection Profiles docs page after #4533.