### PR TITLE
docs: update copyright year dynamically in conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import datetime
 import os
 import sys
 from pathlib import Path
@@ -27,9 +28,9 @@ sys.path.append(str(Path("./ext").resolve()))
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "ADBC"
-copyright = """2022–2025 The Apache Software Foundation.  Apache Arrow, Arrow,
-Apache, the Apache logo, and the Apache Arrow project logo are either
-registered trademarks or trademarks of The Apache Software Foundation in the
+copyright = f"""2022–{datetime.date.today().year} The Apache Software Foundation. 
+Apache Arrow, Arrow, Apache, the Apache logo, and the Apache Arrow project logo are 
+either registered trademarks or trademarks of The Apache Software Foundation in the
 United States and other countries."""
 author = "the Apache Arrow Developers"
 release = "24 (dev)"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,8 +28,8 @@ sys.path.append(str(Path("./ext").resolve()))
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "ADBC"
-copyright = f"""2022–{datetime.date.today().year} The Apache Software Foundation. 
-Apache Arrow, Arrow, Apache, the Apache logo, and the Apache Arrow project logo are 
+copyright = f"""2022–{datetime.date.today().year} The Apache Software Foundation.
+Apache Arrow, Arrow, Apache, the Apache logo, and the Apache Arrow project logo are
 either registered trademarks or trademarks of The Apache Software Foundation in the
 United States and other countries."""
 author = "the Apache Arrow Developers"


### PR DESCRIPTION
I was looking at the website after lidavidm said on the mailing list that there had been updates and I noticed the year was wrong in the footer. 