### PR TITLE
docs: link to drivers anchor on installation page

### DIFF
--- a/docs/source/driver/index.rst
+++ b/docs/source/driver/index.rst
@@ -173,7 +173,7 @@ details.
 
 Some drivers are also published to language-specific package registries.
 Apache-maintained drivers are on
-:doc:`PyPI, conda-forge, CRAN, and more </installation>`; some vendor
+:ref:`PyPI, conda-forge, CRAN, and more <driver-releases>`; some vendor
 drivers list their own packages in each driver's documentation, linked from its
 name in the table above.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -56,6 +56,8 @@ Compilation instructions can be found in `CONTRIBUTING.md`_.
 .. _instructions: https://www.apache.org/info/verification.html
 .. _KEYS: https://downloads.apache.org/arrow/KEYS
 
+.. _driver-releases:
+
 Driver Releases
 ===============
 


### PR DESCRIPTION
Points a link on the drivers page to the correct anchor on the installation page.