### PR TITLE
feat(c/driver): bump vcpkg (and libpq/sqlite) version

### DIFF
--- a/.env
+++ b/.env
@@ -41,7 +41,7 @@ DOTNET=10.0
 # ci/scripts/install_vcpkg.sh script. Keep in sync with apache/arrow .env.
 # When updating, also update the docs, which list the version of libpq/SQLite
 # that vcpkg (and hence our wheels) ship
-VCPKG="66c0373dc7fca549e5803087b9487edfe3aca0a1"    # 2026.01.16 Release
+VCPKG="9b965a116838c6cdcd36bca60d1b81b030c8ab8d"    # 2026.05.27 Release
 
 # These are used to tell tests where to find services for integration testing.
 # They are valid if the services are started with the compose config.

--- a/docs/source/driver/postgresql.rst
+++ b/docs/source/driver/postgresql.rst
@@ -320,7 +320,7 @@ Software Versions
 =================
 
 For Python wheels, the shipped version of the PostgreSQL client libraries is
-16.9.  For conda-forge packages, the version of libpq is the same as the
+18.4.  For conda-forge packages, the version of libpq is the same as the
 version of libpq in your Conda environment.
 
 The PostgreSQL driver is tested against PostgreSQL versions 14 through 18.

--- a/docs/source/driver/sqlite.rst
+++ b/docs/source/driver/sqlite.rst
@@ -263,6 +263,6 @@ Driver-specific options:
 Software Versions
 =================
 
-For Python wheels, the shipped version of SQLite is 3.51.2.  For conda-forge
+For Python wheels, the shipped version of SQLite is 3.53.1.  For conda-forge
 packages, the version of sqlite is the same as the version of sqlite in your
 Conda environment.


### PR DESCRIPTION
Closes #4491.