### PR TITLE
feat(go/adbc/driver/flightsql): promote safe call headers into FlightSQL spans

### DIFF
--- a/go/adbc/driver/flightsql/flightsql_database.go
+++ b/go/adbc/driver/flightsql/flightsql_database.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/flight"
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
 	"github.com/bluele/gcache"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -506,7 +507,12 @@ type support struct {
 }
 
 func (d *databaseImpl) Open(ctx context.Context) (_ adbc.Connection, err error) {
-	ctx, span := internal.StartSpan(ctx, "FlightSQLDatabase.Open", d)
+	ctx, span := internal.StartSpan(
+		ctx,
+		"FlightSQLDatabase.Open",
+		d,
+		trace.WithAttributes(traceHeaderAttrsWithPrefix(d.hdrs, "rpc.call_header.")...),
+	)
 	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
 	defer func() { internal.EndSpan(span, err) }()
 

--- a/go/adbc/driver/flightsql/flightsql_database.go
+++ b/go/adbc/driver/flightsql/flightsql_database.go
@@ -511,7 +511,7 @@ func (d *databaseImpl) Open(ctx context.Context) (_ adbc.Connection, err error) 
 		ctx,
 		"FlightSQLDatabase.Open",
 		d,
-		trace.WithAttributes(traceHeaderAttrsWithPrefix(d.hdrs, "rpc.call_header.")...),
+		trace.WithAttributes(traceHeaderAttrsWithPrefix(d.hdrs, traceRequestMetadataPrefix)...),
 	)
 	defer internal.EndSpanWithError(span, &err)
 

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/flight/flightsql"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bluele/gcache"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
@@ -531,7 +532,12 @@ func (s *statement) ExecuteQuery(ctx context.Context) (rdr array.RecordReader, n
 		}
 	}
 
-	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecuteQuery", s.cnxn)
+	ctx, span := internal.StartSpan(
+		ctx,
+		"FlightSQLStatement.ExecuteQuery",
+		s.cnxn,
+		trace.WithAttributes(traceHeaderAttrsWithPrefix(s.hdrs, "rpc.call_header.")...),
+	)
 	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
 	defer func() { internal.EndSpan(span, err) }()
 
@@ -607,7 +613,12 @@ func (s *statement) ExecuteUpdate(ctx context.Context) (n int64, err error) {
 		}
 	}
 
-	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecuteUpdate", s.cnxn)
+	ctx, span := internal.StartSpan(
+		ctx,
+		"FlightSQLStatement.ExecuteUpdate",
+		s.cnxn,
+		trace.WithAttributes(traceHeaderAttrsWithPrefix(s.hdrs, "rpc.call_header.")...),
+	)
 	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
 	defer func() { internal.EndSpan(span, err) }()
 
@@ -657,7 +668,12 @@ func (s *statement) ExecuteUpdate(ctx context.Context) (n int64, err error) {
 // Prepare turns this statement into a prepared statement to be executed
 // multiple times. This invalidates any prior result sets.
 func (s *statement) Prepare(ctx context.Context) (err error) {
-	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.Prepare", s.cnxn)
+	ctx, span := internal.StartSpan(
+		ctx,
+		"FlightSQLStatement.Prepare",
+		s.cnxn,
+		trace.WithAttributes(traceHeaderAttrsWithPrefix(s.hdrs, "rpc.call_header.")...),
+	)
 	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
 	defer func() { internal.EndSpan(span, err) }()
 

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -536,7 +536,7 @@ func (s *statement) ExecuteQuery(ctx context.Context) (rdr array.RecordReader, n
 		ctx,
 		"FlightSQLStatement.ExecuteQuery",
 		s.cnxn,
-		trace.WithAttributes(traceHeaderAttrsWithPrefix(s.hdrs, "rpc.call_header.")...),
+		trace.WithAttributes(traceHeaderAttrsWithPrefix(s.hdrs, traceRequestMetadataPrefix)...),
 	)
 	defer internal.EndSpanWithError(span, &err)
 
@@ -616,7 +616,7 @@ func (s *statement) ExecuteUpdate(ctx context.Context) (n int64, err error) {
 		ctx,
 		"FlightSQLStatement.ExecuteUpdate",
 		s.cnxn,
-		trace.WithAttributes(traceHeaderAttrsWithPrefix(s.hdrs, "rpc.call_header.")...),
+		trace.WithAttributes(traceHeaderAttrsWithPrefix(s.hdrs, traceRequestMetadataPrefix)...),
 	)
 	defer internal.EndSpanWithError(span, &err)
 
@@ -670,7 +670,7 @@ func (s *statement) Prepare(ctx context.Context) (err error) {
 		ctx,
 		"FlightSQLStatement.Prepare",
 		s.cnxn,
-		trace.WithAttributes(traceHeaderAttrsWithPrefix(s.hdrs, "rpc.call_header.")...),
+		trace.WithAttributes(traceHeaderAttrsWithPrefix(s.hdrs, traceRequestMetadataPrefix)...),
 	)
 	defer internal.EndSpanWithError(span, &err)
 

--- a/go/adbc/driver/flightsql/tracing.go
+++ b/go/adbc/driver/flightsql/tracing.go
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package flightsql
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"google.golang.org/grpc/metadata"
+)
+
+// traceHeaderAttrsWithPrefix returns OpenTelemetry attributes for
+// allow-listed metadata keys. It emits only curated correlation
+// headers so callers can promote external request IDs into traces
+// without leaking credentials.
+func traceHeaderAttrsWithPrefix(md metadata.MD, prefix string) []attribute.KeyValue {
+	if len(md) == 0 {
+		return nil
+	}
+	out := make([]attribute.KeyValue, 0, 4)
+	for _, k := range wellKnownCorrelationHeaders {
+		if vals := md.Get(k); len(vals) > 0 {
+			out = append(out, attribute.Key(prefix+k).StringSlice(vals))
+		}
+	}
+	return out
+}

--- a/go/adbc/driver/flightsql/tracing.go
+++ b/go/adbc/driver/flightsql/tracing.go
@@ -22,6 +22,8 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+const traceRequestMetadataPrefix = "rpc.request.metadata."
+
 // traceHeaderAttrsWithPrefix returns OpenTelemetry attributes for
 // allow-listed metadata keys. It emits only curated correlation
 // headers so callers can promote external request IDs into traces

--- a/go/adbc/driver/flightsql/tracing_test.go
+++ b/go/adbc/driver/flightsql/tracing_test.go
@@ -1,0 +1,145 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package flightsql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow-adbc/go/adbc/driver/internal"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestTraceHeaderAttrsWithPrefix_AllowAndDeny(t *testing.T) {
+	md := metadata.New(map[string]string{
+		"x-request-id":        "req-1",
+		"activityid":          "act-1",
+		"x-pbi-activity-id":   "pbi-act-1",
+		"x-vendor-request-id": "vreq-1",
+		"authorization":       "Bearer SECRET",
+		"x-random-header":     "noise",
+	})
+
+	got := otelAttrsToMap(traceHeaderAttrsWithPrefix(md, "rpc.call_header."))
+
+	if v := got["rpc.call_header.x-request-id"]; len(v) != 1 || v[0] != "req-1" {
+		t.Fatalf("rpc.call_header.x-request-id = %v, want [req-1]", v)
+	}
+	if v := got["rpc.call_header.activityid"]; len(v) != 1 || v[0] != "act-1" {
+		t.Fatalf("rpc.call_header.activityid = %v, want [act-1]", v)
+	}
+	if v := got["rpc.call_header.x-pbi-activity-id"]; len(v) != 1 || v[0] != "pbi-act-1" {
+		t.Fatalf("rpc.call_header.x-pbi-activity-id = %v, want [pbi-act-1]", v)
+	}
+	if _, ok := got["rpc.call_header.authorization"]; ok {
+		t.Fatalf("authorization header must not be promoted into tracing attrs: %v", got)
+	}
+	if _, ok := got["rpc.call_header.x-random-header"]; ok {
+		t.Fatalf("x-random-header must not be promoted into tracing attrs: %v", got)
+	}
+	if _, ok := got["rpc.call_header.x-vendor-request-id"]; ok {
+		t.Fatalf("x-vendor-request-id must not be promoted into tracing attrs: %v", got)
+	}
+}
+
+func TestTraceHeaderAttrsWithPrefix_EmptyMetadata(t *testing.T) {
+	if got := traceHeaderAttrsWithPrefix(nil, "rpc.call_header."); got != nil {
+		t.Fatalf("traceHeaderAttrsWithPrefix(nil, _) = %v, want nil", got)
+	}
+	if got := traceHeaderAttrsWithPrefix(metadata.MD{}, "rpc.call_header."); got != nil {
+		t.Fatalf("traceHeaderAttrsWithPrefix(empty, _) = %v, want nil", got)
+	}
+}
+
+func TestTraceHeaderAttrsWithPrefix_AppliedToSpan(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() {
+		if err := tp.Shutdown(context.Background()); err != nil {
+			t.Fatalf("TracerProvider shutdown failed: %v", err)
+		}
+	})
+
+	tracing := stubTracing{
+		tracer: tp.Tracer("test.flightsql"),
+		attrs: []attribute.KeyValue{
+			attribute.Key("db.system.name").String("flight_sql"),
+		},
+	}
+
+	ctx, span := internal.StartSpan(
+		context.Background(),
+		"FlightSQLStatement.ExecuteQuery",
+		tracing,
+		trace.WithAttributes(traceHeaderAttrsWithPrefix(metadata.New(map[string]string{
+			"x-request-id":    "req-123",
+			"authorization":   "Bearer SECRET",
+			"x-random-header": "noise",
+		}), "rpc.call_header.")...),
+	)
+	_ = ctx
+	span.End()
+
+	spans := recorder.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("ended spans len = %d, want 1", len(spans))
+	}
+
+	got := otelAttrsToMap(spans[0].Attributes())
+	if v := got["rpc.call_header.x-request-id"]; len(v) != 1 || v[0] != "req-123" {
+		t.Fatalf("rpc.call_header.x-request-id = %v, want [req-123]", v)
+	}
+	if _, ok := got["rpc.call_header.authorization"]; ok {
+		t.Fatalf("authorization header leaked into span attrs: %v", got)
+	}
+	if _, ok := got["rpc.call_header.x-random-header"]; ok {
+		t.Fatalf("x-random-header leaked into span attrs: %v", got)
+	}
+	if v := got["db.operation.name"]; len(v) != 1 || v[0] != "FlightSQLStatement.ExecuteQuery" {
+		t.Fatalf("db.operation.name = %v, want [FlightSQLStatement.ExecuteQuery]", v)
+	}
+}
+
+type stubTracing struct {
+	tracer trace.Tracer
+	attrs  []attribute.KeyValue
+}
+
+func (s stubTracing) SetTraceParent(string)  {}
+func (s stubTracing) GetTraceParent() string { return "" }
+func (s stubTracing) StartSpan(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return s.tracer.Start(ctx, spanName, opts...)
+}
+func (s stubTracing) GetInitialSpanAttributes() []attribute.KeyValue { return s.attrs }
+
+func otelAttrsToMap(attrs []attribute.KeyValue) map[string][]string {
+	out := make(map[string][]string, len(attrs))
+	for _, attr := range attrs {
+		switch attr.Value.Type() {
+		case attribute.STRING:
+			out[string(attr.Key)] = []string{attr.Value.AsString()}
+		case attribute.STRINGSLICE:
+			out[string(attr.Key)] = attr.Value.AsStringSlice()
+		}
+	}
+	return out
+}

--- a/go/adbc/driver/flightsql/tracing_test.go
+++ b/go/adbc/driver/flightsql/tracing_test.go
@@ -39,33 +39,33 @@ func TestTraceHeaderAttrsWithPrefix_AllowAndDeny(t *testing.T) {
 		"x-random-header":     "noise",
 	})
 
-	got := otelAttrsToMap(traceHeaderAttrsWithPrefix(md, "rpc.call_header."))
+	got := otelAttrsToMap(traceHeaderAttrsWithPrefix(md, traceRequestMetadataPrefix))
 
-	if v := got["rpc.call_header.x-request-id"]; len(v) != 1 || v[0] != "req-1" {
-		t.Fatalf("rpc.call_header.x-request-id = %v, want [req-1]", v)
+	if v := got["rpc.request.metadata.x-request-id"]; len(v) != 1 || v[0] != "req-1" {
+		t.Fatalf("rpc.request.metadata.x-request-id = %v, want [req-1]", v)
 	}
-	if v := got["rpc.call_header.activityid"]; len(v) != 1 || v[0] != "act-1" {
-		t.Fatalf("rpc.call_header.activityid = %v, want [act-1]", v)
+	if v := got["rpc.request.metadata.activityid"]; len(v) != 1 || v[0] != "act-1" {
+		t.Fatalf("rpc.request.metadata.activityid = %v, want [act-1]", v)
 	}
-	if v := got["rpc.call_header.x-pbi-activity-id"]; len(v) != 1 || v[0] != "pbi-act-1" {
-		t.Fatalf("rpc.call_header.x-pbi-activity-id = %v, want [pbi-act-1]", v)
+	if v := got["rpc.request.metadata.x-pbi-activity-id"]; len(v) != 1 || v[0] != "pbi-act-1" {
+		t.Fatalf("rpc.request.metadata.x-pbi-activity-id = %v, want [pbi-act-1]", v)
 	}
-	if _, ok := got["rpc.call_header.authorization"]; ok {
+	if _, ok := got["rpc.request.metadata.authorization"]; ok {
 		t.Fatalf("authorization header must not be promoted into tracing attrs: %v", got)
 	}
-	if _, ok := got["rpc.call_header.x-random-header"]; ok {
+	if _, ok := got["rpc.request.metadata.x-random-header"]; ok {
 		t.Fatalf("x-random-header must not be promoted into tracing attrs: %v", got)
 	}
-	if _, ok := got["rpc.call_header.x-vendor-request-id"]; ok {
+	if _, ok := got["rpc.request.metadata.x-vendor-request-id"]; ok {
 		t.Fatalf("x-vendor-request-id must not be promoted into tracing attrs: %v", got)
 	}
 }
 
 func TestTraceHeaderAttrsWithPrefix_EmptyMetadata(t *testing.T) {
-	if got := traceHeaderAttrsWithPrefix(nil, "rpc.call_header."); got != nil {
+	if got := traceHeaderAttrsWithPrefix(nil, traceRequestMetadataPrefix); got != nil {
 		t.Fatalf("traceHeaderAttrsWithPrefix(nil, _) = %v, want nil", got)
 	}
-	if got := traceHeaderAttrsWithPrefix(metadata.MD{}, "rpc.call_header."); got != nil {
+	if got := traceHeaderAttrsWithPrefix(metadata.MD{}, traceRequestMetadataPrefix); got != nil {
 		t.Fatalf("traceHeaderAttrsWithPrefix(empty, _) = %v, want nil", got)
 	}
 }
@@ -94,7 +94,7 @@ func TestTraceHeaderAttrsWithPrefix_AppliedToSpan(t *testing.T) {
 			"x-request-id":    "req-123",
 			"authorization":   "Bearer SECRET",
 			"x-random-header": "noise",
-		}), "rpc.call_header.")...),
+		}), traceRequestMetadataPrefix)...),
 	)
 	_ = ctx
 	span.End()
@@ -105,13 +105,13 @@ func TestTraceHeaderAttrsWithPrefix_AppliedToSpan(t *testing.T) {
 	}
 
 	got := otelAttrsToMap(spans[0].Attributes())
-	if v := got["rpc.call_header.x-request-id"]; len(v) != 1 || v[0] != "req-123" {
-		t.Fatalf("rpc.call_header.x-request-id = %v, want [req-123]", v)
+	if v := got["rpc.request.metadata.x-request-id"]; len(v) != 1 || v[0] != "req-123" {
+		t.Fatalf("rpc.request.metadata.x-request-id = %v, want [req-123]", v)
 	}
-	if _, ok := got["rpc.call_header.authorization"]; ok {
+	if _, ok := got["rpc.request.metadata.authorization"]; ok {
 		t.Fatalf("authorization header leaked into span attrs: %v", got)
 	}
-	if _, ok := got["rpc.call_header.x-random-header"]; ok {
+	if _, ok := got["rpc.request.metadata.x-random-header"]; ok {
 		t.Fatalf("x-random-header leaked into span attrs: %v", got)
 	}
 	if v := got["db.operation.name"]; len(v) != 1 || v[0] != "FlightSQLStatement.ExecuteQuery" {


### PR DESCRIPTION
## Summary

Promotes allowlisted `adbc.flight.sql.rpc.call_header.*` metadata into FlightSQL OpenTelemetry span attributes.

This adds tracing support for safe request metadata on:
- `FlightSQLDatabase.Open`
- `FlightSQLStatement.Prepare`
- `FlightSQLStatement.ExecuteQuery`
- `FlightSQLStatement.ExecuteUpdate`

Headers are exposed as attributes like `rpc.request.metadata.x-request-id`.

## Usage examples

Safe `rpc.call_header.*` values may be configured at connection level:

```python
with dbapi.connect(
    driver=str(driver),
    entrypoint="FlightSqlDriverInit",
    uri=config.ADBC_URI,
    db_kwargs={
        "adbc.flight.sql.rpc.call_header.x-request-id": "deadbeef-dead-beef-dead-beefdeadbeef",
    },
) as conn:
    ...
```

or at statement/cursor level:

```python
with conn.cursor(adbc_stmt_kwargs={
    "adbc.flight.sql.rpc.call_header.x-request-id": "req-1",
}) as cur:
    cur.execute("SELECT 1")
```

```python
cur.adbc_statement.set_options(**{
    "adbc.flight.sql.rpc.call_header.x-request-id": "req-2",
})
cur.execute("SELECT 1")
```

## Why

FlightSQL already sends caller-supplied `rpc.call_header.*` values on outbound RPCs, but those values were not visible in tracing spans. Surfacing allowlisted request metadata makes it easier to connect ADBC client spans with upstream request IDs and external traces.

## Related

- Issue: https://github.com/apache/arrow-adbc/issues/4568
- Discussion: https://github.com/apache/arrow-adbc/discussions/4572

Closes #4568.
