### PR TITLE
chore(go/adbc): factor defer-friendly telemetry span helper

### DIFF
--- a/ci/scripts/glib_test.sh
+++ b/ci/scripts/glib_test.sh
@@ -40,7 +40,7 @@ test_subproject() {
     echo "Testing GLib"
 
     if [[ "$(uname)" = "Darwin" ]]; then
-        bundle config build.red-arrow -- \
+        bundle config get build.red-arrow -- \
                --with-cflags=-D_LIBCPP_DISABLE_AVAILABILITY \
                --with-cppflags=-D_LIBCPP_DISABLE_AVAILABILITY
     fi

--- a/ci/scripts/glib_test.sh
+++ b/ci/scripts/glib_test.sh
@@ -46,7 +46,7 @@ test_subproject() {
     fi
 
     bundle config set --local path 'vendor/bundle'
-    bundle install
+    bundle check || bundle install --jobs=4 --retry=5
     bundle exec \
            env DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}" \
            ruby "${source_dir}/glib/test/run.rb"

--- a/ci/scripts/glib_test.sh
+++ b/ci/scripts/glib_test.sh
@@ -40,7 +40,7 @@ test_subproject() {
     echo "Testing GLib"
 
     if [[ "$(uname)" = "Darwin" ]]; then
-        bundle config get build.red-arrow -- \
+        bundle config build.red-arrow -- \
                --with-cflags=-D_LIBCPP_DISABLE_AVAILABILITY \
                --with-cppflags=-D_LIBCPP_DISABLE_AVAILABILITY
     fi

--- a/go/adbc/driver/flightsql/flightsql_database.go
+++ b/go/adbc/driver/flightsql/flightsql_database.go
@@ -507,8 +507,7 @@ type support struct {
 
 func (d *databaseImpl) Open(ctx context.Context) (_ adbc.Connection, err error) {
 	ctx, span := internal.StartSpan(ctx, "FlightSQLDatabase.Open", d)
-	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
-	defer func() { internal.EndSpan(span, err) }()
+	defer internal.EndSpanWithError(span, &err)
 
 	authMiddle := &bearerAuthMiddleware{hdrs: d.hdrs.Copy(), logger: safeLogger(d.Logger)}
 	var cookies flight.CookieMiddleware

--- a/go/adbc/driver/flightsql/flightsql_statement.go
+++ b/go/adbc/driver/flightsql/flightsql_statement.go
@@ -532,8 +532,7 @@ func (s *statement) ExecuteQuery(ctx context.Context) (rdr array.RecordReader, n
 	}
 
 	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecuteQuery", s.cnxn)
-	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
-	defer func() { internal.EndSpan(span, err) }()
+	defer internal.EndSpanWithError(span, &err)
 
 	// Handle bulk ingest
 	if s.targetTable != "" {
@@ -608,8 +607,7 @@ func (s *statement) ExecuteUpdate(ctx context.Context) (n int64, err error) {
 	}
 
 	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.ExecuteUpdate", s.cnxn)
-	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
-	defer func() { internal.EndSpan(span, err) }()
+	defer internal.EndSpanWithError(span, &err)
 
 	// Handle bulk ingest
 	if s.targetTable != "" {
@@ -658,8 +656,7 @@ func (s *statement) ExecuteUpdate(ctx context.Context) (n int64, err error) {
 // multiple times. This invalidates any prior result sets.
 func (s *statement) Prepare(ctx context.Context) (err error) {
 	ctx, span := internal.StartSpan(ctx, "FlightSQLStatement.Prepare", s.cnxn)
-	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
-	defer func() { internal.EndSpan(span, err) }()
+	defer internal.EndSpanWithError(span, &err)
 
 	startTime := time.Now()
 	s.log.InfoContext(ctx, "FlightSQL Prepare start", s.queryAttrs()...)

--- a/go/adbc/driver/internal/driverbase/connection.go
+++ b/go/adbc/driver/internal/driverbase/connection.go
@@ -154,8 +154,7 @@ func (base *ConnectionImplBase) Rollback(context.Context) error {
 
 func (base *ConnectionImplBase) GetInfo(ctx context.Context, infoCodes []adbc.InfoCode) (reader array.RecordReader, err error) {
 	_, span := internal.StartSpan(ctx, "ConnectionImplBase.GetInfo", base)
-	// TODO(apache/arrow-adbc#4494): replace with a shared telemetry helper.
-	defer func() { internal.EndSpan(span, err) }()
+	defer internal.EndSpanWithError(span, &err)
 
 	if len(infoCodes) == 0 {
 		infoCodes = base.DriverInfo.InfoSupportedCodes()

--- a/go/adbc/driver/internal/shared_utils.go
+++ b/go/adbc/driver/internal/shared_utils.go
@@ -774,3 +774,19 @@ func EndSpan(span trace.Span, err error, options ...trace.SpanEndOption) {
 	}
 	span.End(options...)
 }
+
+// Ends the given span. If err is not nil, then the
+// error is recorded and the status is set appropriately.
+// Otherwise, the status is set to Ok.
+func EndSpanWithError(span trace.Span, err *error, options ...trace.SpanEndOption) {
+	if err != nil && *err != nil {
+		span.RecordError(*err)
+		if adbcError, ok := (*err).(adbc.Error); ok {
+			span.SetAttributes(semconv.ErrorTypeKey.String(adbcError.Code.String()))
+		}
+		span.SetStatus(codes.Error, (*err).Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+	span.End(options...)
+}


### PR DESCRIPTION
Refactors telemetry EndSpan helper to use a "defer-friendly" interface so `error` isn't evaluated too soon.
* method EndSpanWithError takes a pointer to the `error` object, instead of the actual object.

closes #4494