### PR TITLE
chore(dev/release): duplicate, not overwrite, yum repo

### DIFF
--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -107,11 +107,12 @@ else
     rc|staging-rc|staging-release)
       suffix=${TYPE%-release}
       sed \
-        -i"" \
+        -e "s,^\\[apache-arrow-,[apache-adbc-,g" \
         -e "s,/almalinux/,/almalinux-${suffix}/,g" \
         -e "s,/centos/,/centos-${suffix}/,g" \
         -e "s,/amazon-linux/,/amazon-linux-${suffix}/,g" \
-        /etc/yum.repos.d/Apache-Arrow.repo
+        /etc/yum.repos.d/Apache-Arrow.repo > \
+        /etc/yum.repos.d/Apache-ADBC.repo
       ;;
   esac
 fi


### PR DESCRIPTION
https://github.com/apache/arrow-adbc/actions/runs/29970729853/job/89092001443

```
  Last metadata expiration check: 0:01:05 ago on Thu Jul 23 01:08:48 2026.
  Error: 
   Problem: package adbc-arrow-glib-devel-24-1.el9.x86_64 from apache-arrow-almalinux requires libadbc-arrow-glib.so.1()(64bit), but none of the providers can be installed
    - package adbc-arrow-glib-devel-24-1.el9.x86_64 from apache-arrow-almalinux requires adbc-arrow-glib1-libs = 24-1.el9, but none of the providers can be installed
    - conflicting requests
    - nothing provides libarrow-glib.so.2500()(64bit) needed by adbc-arrow-glib1-libs-24-1.el9.x86_64 from apache-arrow-almalinux
  (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

I'm not sure how this worked before, but this changes the verification script to add the ADBC Yum repo as an additional repo instead of overwriting the Arrow one.

Generated-by: GPT 5.6 Sol <codex@openai.com>