### PR TITLE
build(java/driver/jni): force static linking

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -284,6 +284,7 @@ jobs:
         working-directory: adbc
         env:
           ADBC_BUILD_STATIC: ON
+          ADBC_BUILD_SHARED: OFF
           ADBC_BUILD_TESTS: OFF
           ADBC_USE_ASAN: OFF
           ADBC_USE_UBSAN: OFF


### PR DESCRIPTION
Closes #4580.