### PR TITLE
fix(dev/release): call conda init before conda activate

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -393,6 +393,7 @@ install_conda() {
 
   # Creating a separate conda environment
   . $prefix/etc/profile.d/conda.sh
+  conda init
   conda activate base
 }
 


### PR DESCRIPTION
Ran into an issue when running `verify-release-candidate.sh` using `USE_CONDA=1`. Got an error specifying that we need to call `conda init` before `conda activate base`. After adding that line the verification was able to continue.