### PR TITLE
ci: pass env vars down into cibuildwheel container

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -697,6 +697,7 @@ jobs:
 
           docker compose run \
             -e SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION \
+            -e CIBW_ENVIRONMENT_PASS_LINUX=SETUPTOOLS_SCM_PRETEND_VERSION \
             python-wheel-manylinux-relocate
           popd
 


### PR DESCRIPTION
This PR makes the filenames of our driver manager wheel nightlies consistent. While nightlies are not official project artifacts and users should never depend on them, it's nice to make them a bit easier to use.

As noticed in https://github.com/apache/arrow-adbc/issues/4578, the manylinux wheels for the driver manager use a `.dev0` prefix whereas all other wheels just use the MAJOR.MINOR.PATCH. The driver manager manylinux wheels are special in that they go through cibuildwheel and cibuildwheel uses an inner container for its build. To get a consistent version, we need let cibuildwheel  pass `SETUPTOOLS_SCM_PRETEND_VERSION` into the container.