### PR TITLE
test(go/adbc/driver/flightsql): bind to any free port

### DIFF
--- a/go/adbc/driver/flightsql/example_usage_test.go
+++ b/go/adbc/driver/flightsql/example_usage_test.go
@@ -126,7 +126,7 @@ func Example() {
 
 	server := flight.NewServerWithMiddleware(nil)
 	server.RegisterFlightService(flightsql.NewFlightServer(srv))
-	err = server.Init("localhost:8080")
+	err = server.Init("localhost:0")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Closes #4592.