### PR TITLE
fix(go/adbc/drivermgr): terminate GetObjects table_types with NULL

### DIFF
--- a/go/adbc/drivermgr/wrapper.go
+++ b/go/adbc/drivermgr/wrapper.go
@@ -337,10 +337,10 @@ func (c *cnxn) GetObjects(_ context.Context, depth adbc.ObjectDepth, catalog, db
 	}
 
 	if len(tableType) > 0 {
-		cArr := []*C.char{}
-		for _, tt := range tableType {
+		cArr := make([]*C.char, len(tableType)+1)
+		for i, tt := range tableType {
 			cs := C.CString(tt)
-			cArr = append(cArr, cs)
+			cArr[i] = cs
 			defer C.free(unsafe.Pointer(cs))
 		}
 		tableType_ = &cArr[0]


### PR DESCRIPTION
This seems to have happened only sporadically before but it happened once in CI and this is the best guess as to why.