### PR TITLE
fix(csharp): build net472 on all platforms so the Testing package ships it

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -45,20 +45,26 @@ defaults:
 
 jobs:
   csharp:
-    name: "C# ${{ matrix.os }} ${{ matrix.dotnet }}"
+    name: "C# ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        dotnet: ['8.0.x', '10.0.x']
         os: [ubuntu-latest, windows-2022, macos-15-intel, macos-latest]
     steps:
+      # The test project multi-targets net8.0 and net10.0, so both SDKs must be
+      # installed: the .NET 8 SDK cannot build net10.0, and the net8.0 tests
+      # cannot run without the .NET 8 runtime. Requesting a single version here
+      # and relying on the runner image to supply the other leaves one target
+      # framework silently dependent on the image contents.
       - name: Install C#
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: |
+            8.0.x
+            10.0.x
       - name: Checkout ADBC
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -22,7 +22,27 @@ set -ex
 source_dir=${1}/csharp/test/Apache.Arrow.Adbc.Tests
 
 pushd ${source_dir}
-dotnet test
+
+# The test project targets net472 on every platform so that build is always
+# compiled, but net472 tests can only be *run* on Windows -- there is no .NET
+# Framework test host on Linux or macOS. On those platforms run the remaining
+# target frameworks one at a time. The list is read back from the project so
+# that adding a target framework does not silently drop it from CI.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    dotnet test
+    ;;
+  *)
+    target_frameworks=$(dotnet msbuild Apache.Arrow.Adbc.Testing.csproj \
+                          -getProperty:TargetFrameworks -nologo | tr -d '\r')
+    for target_framework in ${target_frameworks//;/ }; do
+      if [ "${target_framework}" != "net472" ]; then
+        dotnet test -f "${target_framework}"
+      fi
+    done
+    ;;
+esac
+
 popd
 
 # Databricks driver has been moved out of this repo; its tests are kept

--- a/csharp/Benchmarks/Benchmarks.csproj
+++ b/csharp/Benchmarks/Benchmarks.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- A local benchmark harness, not a shipped library. Without this it is
+         packable by default and produces a Benchmarks.nupkg that is built into
+         the release artifacts but never published. -->
+    <IsPackable>false</IsPackable>
     <TargetFrameworks Condition="'$(IsWindows)'=='true'">net8.0;net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -48,7 +48,12 @@
     <PackageVersion Include="System.Text.Json" Version="9.0.9" />
     <PackageVersion Include="System.Threading.Channels" Version="9.0.8" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.runner.visualstudio"
+                    Version="3.1.5"
+                    Condition="'$(TargetFramework)' != 'net472'" />
+    <PackageVersion Include="xunit.runner.visualstudio"
+                    Version="2.8.2"
+                    Condition="'$(TargetFramework)' == 'net472'" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 </Project>

--- a/csharp/test/Apache.Arrow.Adbc.Tests/Apache.Arrow.Adbc.Testing.csproj
+++ b/csharp/test/Apache.Arrow.Adbc.Tests/Apache.Arrow.Adbc.Testing.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(IsWindows)'=='true'">net8.0;net10.0;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)'==''">net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0;net472</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <IsTestProject>true</IsTestProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Apache.Arrow.Adbc.Testing guarded its net472 target framework behind IsWindows. Packaging runs in a Linux container (compose.yaml uses mcr.microsoft.com/dotnet/sdk:10.0), so TargetFrameworks collapsed to net8.0;net10.0 there and the package published to nuget.org has been missing its lib/net472 folder. It is the only test project on the release push list in dev/release/post-07-csharp.sh, so this affects consumers targeting .NET Framework.

Target net472 unconditionally instead, matching what the src/Drivers projects already do, so the package contents no longer depend on which platform packs it.

net472 still cannot be *run* off Windows, as there is no .NET Framework test host there, so csharp_test.sh now runs the other target frameworks individually on Linux and macOS. The list is read back from the project rather than hardcoded, so adding a target framework later cannot silently drop it from CI.

xunit.runner.visualstudio 3.1.5 is used for the .NET targets and 2.8.2 for net472, selected by condition in Directory.Packages.props.

Two related CI fixes:

- csharp.yml requested a single SDK per matrix leg while the project multi-targets net8.0 and net10.0. The .NET 8 SDK cannot build net10.0, so that leg only worked because the runner image happened to preinstall .NET 10. Install both SDKs in every job and drop the now-redundant dotnet axis, which was producing identical jobs.

- Benchmarks is packable by default and produced a Benchmarks.nupkg that was built into the release artifacts but never published. Mark it IsPackable=false.

Closes #4604 