### PR TITLE
build(c): don't allow combined static/shared build on Windows

### DIFF
--- a/c/cmake_modules/DefineOptions.cmake
+++ b/c/cmake_modules/DefineOptions.cmake
@@ -81,6 +81,13 @@ macro(define_option_string name description default)
   endif()
 endmacro()
 
+# On Windows, we can't build both static and shared (they both generate a .lib), so default static build to off
+if(WIN32)
+  set(_STATIC_BUILD_DEFAULT OFF)
+else()
+  set(_STATIC_BUILD_DEFAULT ON)
+endif()
+
 # Top level cmake dir
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   #----------------------------------------------------------------------
@@ -94,7 +101,7 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   define_option_string(ADBC_GO_BUILD_TAGS
                        "Build tags to append when compiling ADBC Go libraries" "")
 
-  define_option(ADBC_BUILD_STATIC "Build static libraries" ON)
+  define_option(ADBC_BUILD_STATIC "Build static libraries" "${_STATIC_BUILD_DEFAULT}")
 
   define_option(ADBC_BUILD_SHARED "Build shared libraries" ON)
 
@@ -250,8 +257,17 @@ macro(validate_config)
         endif()
       endif()
     endforeach()
-
   endforeach()
+
+  # https://github.com/apache/arrow-adbc/issues/4581
+  # Don't allow building both static and shared libraries on Windows
+  # They both generate a .lib file, and so you get one or the other at random
+  if(WIN32
+     AND ADBC_BUILD_STATIC
+     AND ADBC_BUILD_SHARED)
+    message(FATAL_ERROR "Cannot enable both ADBC_BUILD_STATIC and ADBC_BUILD_SHARED on Windows"
+    )
+  endif()
 endmacro()
 
 macro(config_summary_message)

--- a/ci/linux-packages/debian/rules
+++ b/ci/linux-packages/debian/rules
@@ -39,6 +39,8 @@ override_dh_auto_configure:
 	    --buildsystem=cmake+ninja			\
 	    --						\
 	    -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE)	\
+	    -DADBC_BUILD_SHARED=ON			\
+	    -DADBC_BUILD_STATIC=ON			\
 	    -DADBC_DRIVER_FLIGHTSQL=ON			\
 	    -DADBC_DRIVER_MANAGER=ON			\
 	    -DADBC_DRIVER_POSTGRESQL=ON			\

--- a/ci/linux-packages/yum/apache-arrow-adbc.spec.in
+++ b/ci/linux-packages/yum/apache-arrow-adbc.spec.in
@@ -64,6 +64,8 @@ cd c
 %adbc_cmake \
   -DCMAKE_BUILD_TYPE=${cmake_build_type} \
   -G"Unix Makefiles" \
+  -DADBC_BUILD_SHARED=ON \
+  -DADBC_BUILD_STATIC=ON \
   -DADBC_DRIVER_FLIGHTSQL=ON \
   -DADBC_DRIVER_MANAGER=ON \
   -DADBC_DRIVER_POSTGRESQL=ON \


### PR DESCRIPTION
Try to avoid problems because these two conflict on Windows.

Closes #4581.