### PR TITLE
build(c/driver_manager): use lowercase file names in includes

### DIFF
--- a/c/driver_manager/adbc_driver_manager.cc
+++ b/c/driver_manager/adbc_driver_manager.cc
@@ -30,9 +30,13 @@
 #endif
 #include <windows.h>  // Must come first
 
-#include <KnownFolders.h>
-#include <ShlObj.h>
+// Spell these lowercase: the Windows SDK ships them CamelCased, but mingw-w64
+// ships them all-lowercase. Windows filesystems are case-insensitive so the
+// lowercase spelling resolves for both, while the CamelCase spelling breaks
+// cross-compiling from a case-sensitive filesystem.
+#include <knownfolders.h>
 #include <libloaderapi.h>
+#include <shlobj.h>
 #include <string.h>  // _wcsnicmp
 #include <strsafe.h>
 #include <locale>

--- a/go/adbc/drivermgr/adbc_driver_manager.cc
+++ b/go/adbc/drivermgr/adbc_driver_manager.cc
@@ -30,9 +30,13 @@
 #endif
 #include <windows.h>  // Must come first
 
-#include <KnownFolders.h>
-#include <ShlObj.h>
+// Spell these lowercase: the Windows SDK ships them CamelCased, but mingw-w64
+// ships them all-lowercase. Windows filesystems are case-insensitive so the
+// lowercase spelling resolves for both, while the CamelCase spelling breaks
+// cross-compiling from a case-sensitive filesystem.
+#include <knownfolders.h>
 #include <libloaderapi.h>
+#include <shlobj.h>
 #include <string.h>  // _wcsnicmp
 #include <strsafe.h>
 #include <locale>


### PR DESCRIPTION
`<KnownFolders.h>` and `<ShlObj.h>` are spelled the way the Windows SDK ships them.
mingw-w64 ships these headers all-lowercase (`knownfolders.h`, `shlobj.h`).

Windows filesystems are case-insensitive, so the lowercase spelling resolves under both the SDK and mingw-w64, while the CamelCase spelling only resolves when the lookup is case-insensitive.

The practical effect is that the driver manager currently cannot be compiled from a case-sensitive filesystem, which rules out cross-compiling for Windows from Linux.

Verified with https://github.com/mstorsjo/llvm-mingw 20260616 (clang 22.1.8, mingw-w64 15.0), compiling `c/driver_manager/adbc_driver_manager.cc` with no include shims:

```
$ aarch64-w64-mingw32-clang++ -std=gnu++17 -O2 -Wall -DADBC_EXPORT= \
    -Ic/include -Ic -Ic/vendor -c c/driver_manager/adbc_driver_manager.cc

# before
c/driver_manager/adbc_driver_manager.cc:33:10: fatal error: 'KnownFolders.h' file not found

# after
(ok)
```