### PR TITLE
docs: de-emphasize substrait

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,7 +72,6 @@ Getting Started
 
 
 .. _dbc: https://docs.columnar.tech/dbc
-.. _Substrait: https://substrait.io/
 
 Why ADBC?
 ---------
@@ -117,7 +116,7 @@ Why ADBC?
       :link: format/comparison
       :link-type: doc
 
-      Execute SQL and Substrait, query database catalogs, inspect table
+      Execute SQL, query database catalogs, inspect table
       schemas, and more.  ADBC handles common tasks without having to pull in
       another database client.
 


### PR DESCRIPTION
Removes one text reference to Substrait in the docs and
and orphaned hyperlink target. References to Substrait
in the FAQ and Glossary remaine untouched.

Closes https://github.com/apache/arrow-adbc/issues/4248
