### PR TITLE
chore(r): Update roxygen generated docs and non-api sentinel

### DIFF
--- a/r/adbcdrivermanager/src/radbc.cc
+++ b/r/adbcdrivermanager/src/radbc.cc
@@ -57,8 +57,8 @@ static int adbc_update_parent_child_count(SEXP xptr, int delta) {
   SEXP child_count_sym = PROTECT(Rf_install(".child_count"));
 #if defined(R_VERSION) && R_VERSION >= R_Version(4, 5, 0)
   SEXP child_count_sexp =
-      PROTECT(R_getVarEx(child_count_sym, parent_env, FALSE, R_UnboundValue));
-  if (child_count_sexp == R_UnboundValue) {
+      PROTECT(R_getVarEx(child_count_sym, parent_env, FALSE, R_MissingArg));
+  if (child_count_sexp == R_MissingArg) {
     Rf_error("Internal error: .child_count not found");
   }
 #else

--- a/r/adbcpostgresql/man/adbcpostgresql.Rd
+++ b/r/adbcpostgresql/man/adbcpostgresql.Rd
@@ -22,22 +22,10 @@ adbcpostgresql()
 )
 }
 \arguments{
-\item{driver}{The driver to use. This can be one of the following:
-\itemize{
-\item A non-missing \code{character(1)} containing a driver or manifest name, a
-relative or absolute path to a driver or manifest, or a URI. For a URI,
-the driver manager uses the URI scheme as the driver name and passes the
-URI to that driver. A \verb{profile://} URI loads a connection profile.
-\item \code{NULL}, which leaves driver selection to the driver manager. In this
-case, \code{...} must normally contain \code{uri} or \code{profile}; the driver is
-inferred from the URI or loaded from the connection profile.
-\item An object that inherits from the \code{adbc_driver} class, such as one created
-by \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}. This includes drivers provided by R packages, such as
-\code{adbcsqlite::adbcsqlite()}.
-}}
+\item{driver}{An \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}.}
 
-\item{...}{Driver-specific options. These are generally named values that
-are converted to strings.}
+\item{...}{Driver-specific options. For the default method, these are
+named values that are converted to strings.}
 
 \item{uri}{A URI to a database path (e.g.,
 \verb{postgresql://localhost:1234/postgres?user=user&password=password})}

--- a/r/adbcsqlite/man/adbcsqlite.Rd
+++ b/r/adbcsqlite/man/adbcsqlite.Rd
@@ -23,22 +23,10 @@ adbcsqlite()
 )
 }
 \arguments{
-\item{driver}{The driver to use. This can be one of the following:
-\itemize{
-\item A non-missing \code{character(1)} containing a driver or manifest name, a
-relative or absolute path to a driver or manifest, or a URI. For a URI,
-the driver manager uses the URI scheme as the driver name and passes the
-URI to that driver. A \verb{profile://} URI loads a connection profile.
-\item \code{NULL}, which leaves driver selection to the driver manager. In this
-case, \code{...} must normally contain \code{uri} or \code{profile}; the driver is
-inferred from the URI or loaded from the connection profile.
-\item An object that inherits from the \code{adbc_driver} class, such as one created
-by \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}. This includes drivers provided by R packages, such as
-\code{adbcsqlite::adbcsqlite()}.
-}}
+\item{driver}{An \code{\link[adbcdrivermanager:adbc_driver]{adbc_driver()}}.}
 
-\item{...}{Driver-specific options. These are generally named values that
-are converted to strings.}
+\item{...}{Driver-specific options. For the default method, these are
+named values that are converted to strings.}
 
 \item{uri}{A URI to a database path or ":memory:" for an in-memory database.}
 


### PR DESCRIPTION
This PR updates `devtools::document()` with a more recent roxygen2 and fixes an R C API issue (the unbound variable sentinel is no longer "public", so we have to use another one).

For the CRAN release I also had to update nanoarrow (fixes gcc16 warnings), but I'll do that separately since nanoarrow is close to an actual release.