### PR TITLE
docs: improve docs around driver init funcs

### DIFF
--- a/c/include/arrow-adbc/adbc.h
+++ b/c/include/arrow-adbc/adbc.h
@@ -2380,12 +2380,14 @@ AdbcStatusCode AdbcStatementExecutePartitions(struct AdbcStatement* statement,
 ///   to load a library and call a function of this type to load the
 ///   driver.
 ///
-/// Although drivers may choose any name for this function, the
-/// recommended name is "AdbcDriverInit", or a name derived from the
-/// name of the driver's shared library as follows: remove the 'lib'
-/// prefix (on Unix systems) and all file extensions, then PascalCase
-/// the driver name, append Init, and prepend Adbc (if not already
-/// there).  For example:
+/// Although drivers may choose any name for this function, it's recommended
+/// that drivers use the name "AdbcDriverInit" for maximum compatibility.
+/// Further, it's recommended to also export an alias for this function using a
+/// name derived from the name of the driver's shared library. This aliasing
+/// makes it easier to statically link multiple drivers into the same program.
+/// The process for naming this alias is as follows: remove the 'lib' prefix (on
+/// Unix systems) and all file extensions, then PascalCase the driver name,
+/// append Init, and prepend Adbc (if not already there).  For example:
 ///
 /// - libadbc_driver_sqlite.so.2.0.0 -> AdbcDriverSqliteInit
 /// - adbc_driver_sqlite.dll -> AdbcDriverSqliteInit

--- a/docs/source/format/driver_manifests.rst
+++ b/docs/source/format/driver_manifests.rst
@@ -228,7 +228,8 @@ Below is an example of a driver manifest:
    unsupported = [] # list of strings such as 'async'
 
    [Driver]
-   entrypoint = 'AdbcDriverInit' # entrypoint to use if not using default
+   entrypoint = 'AdbcDriverInit' # entrypoint to use if not using defaults of
+                                 # either AdbcDriverFooInit or AdbcDriverInit
    # You can provide just a single path
    # shared = '/path/to/libadbc_driver.so'
 

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -94,7 +94,9 @@ Glossary
      In ADBC, the name of a function exported by a driver that the
      :term:`driver manager` calls when a driver is loaded to perform any
      initialization required by the driver. The name follows a convention which
-     is outlined in :c:type:`AdbcDriverInitFunc` but another name may be used.
+     is outlined in :c:type:`AdbcDriverInitFunc`. Any name may be used but, for
+     maximum compatibility, following the convention in
+     :c:type:`AdbcDriverInitFunc` is recommended.
 
    statement
      In the ADBC API, the statement object/struct holds state for executing a

--- a/go/adbc/drivermgr/arrow-adbc/adbc.h
+++ b/go/adbc/drivermgr/arrow-adbc/adbc.h
@@ -2380,12 +2380,14 @@ AdbcStatusCode AdbcStatementExecutePartitions(struct AdbcStatement* statement,
 ///   to load a library and call a function of this type to load the
 ///   driver.
 ///
-/// Although drivers may choose any name for this function, the
-/// recommended name is "AdbcDriverInit", or a name derived from the
-/// name of the driver's shared library as follows: remove the 'lib'
-/// prefix (on Unix systems) and all file extensions, then PascalCase
-/// the driver name, append Init, and prepend Adbc (if not already
-/// there).  For example:
+/// Although drivers may choose any name for this function, it's recommended
+/// that drivers use the name "AdbcDriverInit" for maximum compatibility.
+/// Further, it's recommended to also export an alias for this function using a
+/// name derived from the name of the driver's shared library. This aliasing
+/// makes it easier to statically link multiple drivers into the same program.
+/// The process for naming this alias is as follows: remove the 'lib' prefix (on
+/// Unix systems) and all file extensions, then PascalCase the driver name,
+/// append Init, and prepend Adbc (if not already there).  For example:
 ///
 /// - libadbc_driver_sqlite.so.2.0.0 -> AdbcDriverSqliteInit
 /// - adbc_driver_sqlite.dll -> AdbcDriverSqliteInit


### PR DESCRIPTION
We saw some feedback recently that some of the convention around driver shared library name and driver init func names could be clearer. This PR aims to at least improve our language around init func names.

I think what we basically want to say, informally, is:

> All drivers should export two init functions, `AdbcDriverInit` and `AdbcDriverFooInit`. Drivers must always export `AdbcDriverInit` and drivers should also export `AdbcDriverFooInit`. It is also recommended that drivers support conditionally compiling `AdbcDriverInit` out in order to support static linking of multiple drivers into a single application. Hence our recommendation of exporting `AdbcDriverFooInit`.
