### PR TITLE
chore(ci): fix failure in detecting compilers in clang-tidy job

### DIFF
--- a/ci/scripts/cpp_clang_tidy.sh
+++ b/ci/scripts/cpp_clang_tidy.sh
@@ -44,8 +44,8 @@ build_subproject() {
 
     # XXX(https://github.com/llvm/llvm-project/issues/46804): expand
     # CC and CXX symlinks
-    env CC=$(readlink -f ${CC:-$(which cc)}) \
-        CXX=$(readlink -f ${CXX:-$(which c++)}) \
+    env CC=$(readlink -f $(which ${CC:-cc})) \
+        CXX=$(readlink -f $(which ${CXX:-c++})) \
         cmake "${source_dir}/c" \
         ${ADBC_CMAKE_ARGS} \
         -DADBC_BUILD_SHARED="${ADBC_BUILD_SHARED}" \


### PR DESCRIPTION
The clang-tidy job recently started failing.

Last success: https://github.com/apache/arrow-adbc/actions/runs/30502165159/job/90743952843
First failure: https://github.com/apache/arrow-adbc/actions/runs/30596999777/job/91051511466

The error is,

> `Could not find the compiler specified in the environment variable CC: /home/runner/work/arrow-adbc/arrow-adbc/build/tidy/x86_64-conda-linux-gnu-cc.`

Note that path to `x86_64-conda-linux-gnu-cc` is relative to the CWD which is wrong.

The difference seems to be:

In a successful run, I see:

```
++ readlink -f /home/runner/miniconda3/envs/test/bin/x86_64-conda-linux-gnu-cc
++ readlink -f /home/runner/miniconda3/envs/test/bin/x86_64-conda-linux-gnu-c++
```

In a failed run, I see:

```
++ readlink -f x86_64-conda-linux-gnu-cc
++ readlink -f x86_64-conda-linux-gnu-c++
```

A notable difference between these two environments is that the last working build used `gcc_linux-64=14.3.0` whereas the failures started after `gcc_linux-64=14.4.0` showed up.