### PR TITLE
build(c): automatically copy deps to output on Windows with vcpkg

### DIFF
--- a/c/CMakePresets.json
+++ b/c/CMakePresets.json
@@ -38,7 +38,6 @@
                 "ADBC_BUILD_STATIC": "OFF",
                 "ADBC_USE_ASAN": "OFF",
                 "ADBC_USE_UBSAN": "OFF",
-                "ADBC_BUILD_VCPKG": "ON",
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
                 "CMAKE_C_COMPILER": "cl.exe",
                 "CMAKE_CXX_COMPILER": "cl.exe"

--- a/c/cmake_modules/BuildUtils.cmake
+++ b/c/cmake_modules/BuildUtils.cmake
@@ -302,8 +302,7 @@ function(ADD_ARROW_LIB LIB_NAME)
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
     # If we're building on Windows using vcpkg, ensure the runtime dependencies of binaries are copied to the install folder.
-    # TODO(https://github.com/apache/arrow-adbc/issues/3826): auto-detect this
-    if(ADBC_BUILD_VCPKG)
+    if(WIN32 AND VCPKG_TOOLCHAIN)
       install(TARGETS ${LIB_NAME}_shared
                       RUNTIME_DEPENDENCIES
                       PRE_EXCLUDE_REGEXES

--- a/c/cmake_modules/DefineOptions.cmake
+++ b/c/cmake_modules/DefineOptions.cmake
@@ -237,10 +237,6 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   define_option(ADBC_DRIVER_SQLITE "Build the SQLite driver" OFF)
 
   define_option(ADBC_INTEGRATION_DUCKDB "Build the test suite for DuckDB" OFF)
-
-  define_option(ADBC_BUILD_VCPKG
-                "Build on Windows using vcpkg for dependencies and Visual Studio generator."
-                OFF)
 endif()
 
 macro(validate_config)


### PR DESCRIPTION
This is necessary so tests can find their dependencies. Right now you have to explicitly tell the build scripts to do this with a build option, but we can easily infer this from within CMake, so do that instead.

Closes #3826.

Assisted-by: GPT-5.6 Sol <codex@openai.com>