### PR TITLE
build(java/driver/jni): don't include JNI binaries in sources JAR

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -359,6 +359,24 @@ jobs:
           popd
           cp -a adbc/dist/ ./
 
+      # Basic sanity check; also don't ship binaries in sources JAR to avoid bloat
+      - name: Verify JNI JAR contents
+        run: |
+          sources_jar=$(find dist -maxdepth 1 -name 'adbc-driver-jni-*-sources.jar' -print -quit)
+          runtime_jar=${sources_jar%-sources.jar}.jar
+
+          jar tf "${sources_jar}" > temp_jni_sources_contents.txt
+          if grep -q '^adbc_driver_jni/' temp_jni_sources_contents.txt; then
+            echo "JNI source JAR contains native binaries: ${sources_jar}"
+            exit 1
+          fi
+
+          jar tf "${runtime_jar}" > temp_jni_runtime_contents.txt
+          if ! grep -q '^adbc_driver_jni/' temp_jni_runtime_contents.txt; then
+            echo "JNI runtime JAR does not contain native binaries: ${runtime_jar}"
+            exit 1
+          fi
+
       - name: Archive JARs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/java/driver/jni/pom.xml
+++ b/java/driver/jni/pom.xml
@@ -83,6 +83,15 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>adbc_driver_jni/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration combine.self="append">
           <systemPropertyVariables>


### PR DESCRIPTION
Closes #3691.

Assisted-by: GPT-5.6 Sol <codex@openai.com>