### PR TITLE
fix(rust/driver_manager): load with RTLD_NOW

### DIFF
--- a/rust/driver_manager/src/search.rs
+++ b/rust/driver_manager/src/search.rs
@@ -317,7 +317,7 @@ impl<'a> DriverLibrary<'a> {
 
             libloading::os::unix::Library::open(
                 Some(filename.as_ref()),
-                libloading::os::unix::RTLD_LAZY | libloading::os::unix::RTLD_LOCAL | RTLD_NODELETE,
+                libloading::os::unix::RTLD_NOW | libloading::os::unix::RTLD_LOCAL | RTLD_NODELETE,
             )
             .map(Into::into)
             .map_err(libloading_error_to_adbc_error)?


### PR DESCRIPTION
I've omitted tests for now. I think I'd like to build up a suite of cases like this that we can apply across the C++, Rust, and C# driver managers to help ensure consistency.

Closes #4663.