### PR TITLE
chore: add eitsupi and Mandukhai-Alimaa as collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -21,6 +21,7 @@ github:
   collaborators:
     - krlmlr
     - nbenn
+    - eitsupi
   enabled_merge_buttons:
     merge: false
     rebase: false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -22,6 +22,7 @@ github:
     - krlmlr
     - nbenn
     - eitsupi
+    - Mandukhai-Alimaa
   enabled_merge_buttons:
     merge: false
     rebase: false


### PR DESCRIPTION
eitsupi often reviews PRs and helps with Rust maintenance, so being able to triage issues and be assigned as a reviewer would be useful. (Disclaimer: I work with him as a contractor of ours.)

Similarly Mandukhai-Alimaa has been helping with the PostgreSQL driver. (And I work with her as a colleague.)