### PR TITLE
chore: fix builds after conda-forge upgrade

### DIFF
--- a/.github/workflows/native-unix.yml
+++ b/.github/workflows/native-unix.yml
@@ -546,10 +546,13 @@ jobs:
           use-mamba: true
       - name: Install Dependencies
         run: |
+          # N.B. explicitly install a compiler package which will cause the
+          # Conda environment to set CC/CXX
           ./ci/scripts/remamba.sh install -c conda-forge \
             python=${{ matrix.python }} \
             --file ci/conda_env_cpp.txt \
-            --file ci/conda_env_python.txt
+            --file ci/conda_env_python.txt \
+            ${{ (runner.os == 'Linux' && 'gcc gxx') || 'clang clangxx' }}
       - name: Work around ASAN issue (GH-1617)
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -16,9 +16,6 @@
 # under the License.
 
 cython
-# libxml2 broke ABI compatibility
-# https://github.com/conda-forge/arrow-cpp-feedstock/issues/1740
-libxml2 <2.14.0
 # nodejs is required by pyright
 nodejs >=13.0.0
 pandas

--- a/compose.yaml
+++ b/compose.yaml
@@ -102,7 +102,7 @@ services:
       CGO_ENABLED: "1"
       R_MAKEVARS_USER: "/adbc/ci/r_makevars_cxx20"
     command: |
-      /bin/bash -c 'git config --global --add safe.directory /adbc && source /opt/conda/etc/profile.d/conda.sh && mamba create -y -n adbc -c conda-forge go --file /adbc/ci/conda_env_cpp.txt --file /adbc/ci/conda_env_docs.txt --file /adbc/ci/conda_env_java.txt --file /adbc/ci/conda_env_python.txt && conda activate adbc && /adbc/ci/scripts/cpp_build.sh /adbc /adbc/build && /adbc/ci/scripts/go_build.sh /adbc /adbc/build && /adbc/ci/scripts/python_build.sh /adbc /adbc/build && /adbc/ci/scripts/r_build.sh /adbc && /adbc/ci/scripts/make_manifests.sh /adbc/build/local && /adbc/ci/scripts/docs_build.sh /adbc'
+      /bin/bash -c 'git config --global --add safe.directory /adbc && source /opt/conda/etc/profile.d/conda.sh && mamba create -y -n adbc -c conda-forge go binutils --file /adbc/ci/conda_env_cpp.txt --file /adbc/ci/conda_env_docs.txt --file /adbc/ci/conda_env_java.txt --file /adbc/ci/conda_env_python.txt && conda activate adbc && /adbc/ci/scripts/cpp_build.sh /adbc /adbc/build && /adbc/ci/scripts/go_build.sh /adbc /adbc/build && /adbc/ci/scripts/python_build.sh /adbc /adbc/build && /adbc/ci/scripts/r_build.sh /adbc && /adbc/ci/scripts/make_manifests.sh /adbc/build/local && /adbc/ci/scripts/docs_build.sh /adbc'
 
   ################################### Java ###################################
 

--- a/docs/source/cpp/recipe/CMakeLists.txt
+++ b/docs/source/cpp/recipe/CMakeLists.txt
@@ -30,7 +30,7 @@ find_package(AdbcDriverManager REQUIRED)
 
 fetchcontent_declare(nanoarrow
                      GIT_REPOSITORY https://github.com/apache/arrow-nanoarrow.git
-                     GIT_TAG apache-arrow-nanoarrow-0.2.0
+                     GIT_TAG apache-arrow-nanoarrow-0.9.0
                      GIT_SHALLOW TRUE
                      EXCLUDE_FROM_ALL)
 fetchcontent_makeavailable(nanoarrow)
@@ -38,6 +38,7 @@ fetchcontent_makeavailable(nanoarrow)
 add_executable(recipe-quickstart quickstart.cc)
 target_include_directories(recipe-quickstart SYSTEM PRIVATE ${nanoarrow_SOURCE_DIR}/dist)
 target_link_libraries(recipe-quickstart
-                      PRIVATE AdbcDriverManager::adbc_driver_manager_shared nanoarrow)
+                      PRIVATE AdbcDriverManager::adbc_driver_manager_shared
+                              nanoarrow::nanoarrow_static)
 add_test(NAME quickstart COMMAND recipe-quickstart)
 install(TARGETS recipe-quickstart)

--- a/docs/source/cpp/recipe/quickstart.cc
+++ b/docs/source/cpp/recipe/quickstart.cc
@@ -83,7 +83,7 @@
 
 #include <arrow-adbc/adbc.h>
 #include <arrow-adbc/adbc_driver_manager.h>
-#include <nanoarrow.h>
+#include <nanoarrow/nanoarrow.h>
 
 /// Then we'll add some (very basic) error checking helpers.
 

--- a/docs/source/cpp/recipe_driver/CMakeLists.txt
+++ b/docs/source/cpp/recipe_driver/CMakeLists.txt
@@ -30,9 +30,10 @@ set(NANOARROW_IPC ON)
 set(NANOARROW_NAMESPACE "DriverExamplePrivate")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 fetchcontent_declare(nanoarrow
-                     URL "https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/apache-arrow-nanoarrow-0.6.0/apache-arrow-nanoarrow-0.6.0.tar.gz"
-                     URL_HASH SHA256=e4a02ac51002ad1875bf09317e70adb959005fad52b240ff59f73b970fa485d1
-)
+                     GIT_REPOSITORY https://github.com/apache/arrow-nanoarrow.git
+                     GIT_TAG apache-arrow-nanoarrow-0.9.0
+                     GIT_SHALLOW TRUE
+                     EXCLUDE_FROM_ALL)
 fetchcontent_makeavailable(nanoarrow)
 
 # TODO: We could allow this to be installed + linked to as a target; however,
@@ -42,7 +43,7 @@ add_library(adbc_driver_framework ../../../../c/driver/framework/utility.cc
                                   ../../../../c/driver/framework/objects.cc)
 target_include_directories(adbc_driver_framework PRIVATE ../../../../c
                                                          ../../../../c/include)
-target_link_libraries(adbc_driver_framework PRIVATE nanoarrow::nanoarrow)
+target_link_libraries(adbc_driver_framework PRIVATE nanoarrow::nanoarrow_static)
 
 add_library(driver_example SHARED driver_example.cc)
 target_include_directories(driver_example PRIVATE ../../../../c ../../../../c/include)


### PR DESCRIPTION
It seems conda-forge compilers no longer includes binutils?
https://github.com/conda-forge/compilers-feedstock/pull/78

Failing: https://github.com/apache/arrow-adbc/actions/runs/31757255697/job/94635721116
Passing: https://github.com/apache/arrow-adbc/actions/runs/31654305086/job/94305293985

Closes #4690.