### PR TITLE
fix(python/adbc_driver_manager): pass table_types filter to GetObjects

### DIFF
--- a/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
+++ b/python/adbc_driver_manager/adbc_driver_manager/_lib.pyx
@@ -1016,6 +1016,18 @@ cdef class AdbcConnection(_AdbcHandle):
             column_name = _to_bytes(column_name, "column_name")
             c_column_name = column_name
 
+        cdef c_vector[const char*] c_table_types
+        cdef const char** c_table_types_ptr = NULL
+        if table_types:
+            # Keep the encoded bytes alive while c_table_types points into their buffers
+            table_types = [
+                _to_bytes(table_type, "table_types") for table_type in table_types
+            ]
+            for table_type in table_types:
+                c_table_types.push_back(table_type)
+            c_table_types.push_back(<const char*> NULL)
+            c_table_types_ptr = c_table_types.data()
+
         with nogil:
             status = AdbcConnectionGetObjects(
                 &self.connection,
@@ -1023,7 +1035,7 @@ cdef class AdbcConnection(_AdbcHandle):
                 c_catalog,
                 c_db_schema,
                 c_table_name,
-                NULL,  # TODO: support table_types
+                c_table_types_ptr,
                 c_column_name,
                 &stream.stream,
                 &c_error)

--- a/python/adbc_driver_manager/tests/test_dbapi.py
+++ b/python/adbc_driver_manager/tests/test_dbapi.py
@@ -117,6 +117,30 @@ def test_get_objects(sqlite) -> None:
 
 
 @pytest.mark.sqlite
+def test_get_objects_table_types_filter(sqlite) -> None:
+    with sqlite.cursor() as cur:
+        cur.execute("CREATE TABLE base (ints)")
+        cur.execute("CREATE VIEW derived AS SELECT * FROM base")
+
+    def table_names(table_types_filter):
+        metadata = (
+            sqlite.adbc_get_objects(table_types_filter=table_types_filter)
+            .read_all()
+            .to_pylist()
+        )
+        return sorted(
+            table["table_name"]
+            for catalog in metadata
+            for schema in catalog["catalog_db_schemas"]
+            for table in schema["db_schema_tables"]
+        )
+
+    assert table_names(["table"]) == ["base"]
+    assert table_names(["view"]) == ["derived"]
+    assert table_names(["table", "view"]) == ["base", "derived"]
+
+
+@pytest.mark.sqlite
 def test_get_table_schema(sqlite) -> None:
     with sqlite.cursor() as cur:
         cur.execute("CREATE TABLE temporary (ints)")


### PR DESCRIPTION
The Cython binding accepted table_types but always passed `NULL` to `AdbcConnectionGetObjects`, so the DB-API `table_types_filter` was silently ignored.

Convert the sequence to the null-terminated `const char**` the C API expects, keeping the encoded strings alive for the duration of the call, and add coverage proving multiple table types reach the driver.