### PR TITLE
feat(kotoba): add in-language ADBC status/error binding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@
 # under the License.
 
 *.stdout.txt linguist-generated
+*.kotoba linguist-language=Clojure
 c/vendor/* linguist-vendored
 go/adbc/drivermgr/arrow-adbc/adbc.h linguist-generated
 go/adbc/drivermgr/arrow-adbc/adbc_driver_manager.h linguist-generated

--- a/.github/workflows/kotoba.yml
+++ b/.github/workflows/kotoba.yml
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Kotoba
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "kotoba/**"
+      - "ci/scripts/kotoba_*.sh"
+      - ".github/workflows/kotoba.yml"
+  push:
+    branches-ignore:
+      - "dependabot/**"
+    paths:
+      - "kotoba/**"
+      - "ci/scripts/kotoba_*.sh"
+      - ".github/workflows/kotoba.yml"
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}-kotoba
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash -l -eo pipefail {0}
+
+jobs:
+  kotoba:
+    name: Kotoba 0.7.2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Setup node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Install Kotoba 0.7.2
+        run: ./ci/scripts/kotoba_install.sh "${HOME}/.local/kotoba-0.7.2"
+      - name: Compile and run fixtures
+        run: ./ci/scripts/kotoba_test.sh "${{ github.workspace }}"

--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,9 @@ target/
 /c/subprojects/*
 !/c/subprojects/*.wrap
 
+# Kotoba wasm artifacts
+kotoba/**/*.wasm
+
 # Node.js specific ignores
 javascript/**/node_modules/
 javascript/**/target/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -457,6 +457,18 @@ $ ./ci/scripts/python_typecheck.sh $(pwd)
 
 The Ruby libraries are bindings around the GLib libraries.
 
+### Kotoba
+
+The Kotoba binding is an in-language ADBC status/error guest compiled to
+WebAssembly. It cannot FFI ``libadbc``; the host owns drivers. v1 is a mock
+connection fixture with no real database.
+
+Install [Kotoba](https://github.com/kotoba-lang/kotoba) 0.7.2, then:
+
+```shell
+$ ./ci/scripts/kotoba_test.sh $(pwd)
+```
+
 ### Rust
 
 The Rust components are a standard Rust project.
@@ -527,6 +539,7 @@ Please use the following commit types: `build`, `chore`, `ci`, `docs`,
 
 Please use the following scopes:
 
+- `kotoba`: the Kotoba wasm guest binding.
 - `c/driver/postgresql`, `java/driver-manager`, …: for a component and
   all its bindings.  For example, `c/driver-manager` covers the C/C++
   driver manager and its GLib and Python bindings, while

--- a/ci/scripts/kotoba_install.sh
+++ b/ci/scripts/kotoba_install.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+# Pin the Kotoba compiler used by the kotoba/ binding.
+KOTOBA_VERSION="${KOTOBA_VERSION:-0.7.2}"
+KOTOBA_PREFIX="${1:-${HOME}/.local/kotoba-${KOTOBA_VERSION}}"
+KOTOBA_ARCHIVE="kotoba-linux-amd64.tar.gz"
+KOTOBA_URL="https://github.com/kotoba-lang/kotoba/releases/download/v${KOTOBA_VERSION}/${KOTOBA_ARCHIVE}"
+KOTOBA_SHA256="95e225461e1b8a21849b251e8c8b654693d2c8a516b258532771651e978e1977"
+
+if [[ -x "${KOTOBA_PREFIX}/kotoba" ]]; then
+  echo "Using existing ${KOTOBA_PREFIX}/kotoba"
+else
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "${tmpdir}"' EXIT
+  curl -fsSL -o "${tmpdir}/${KOTOBA_ARCHIVE}" "${KOTOBA_URL}"
+  echo "${KOTOBA_SHA256}  ${tmpdir}/${KOTOBA_ARCHIVE}" | sha256sum -c -
+  mkdir -p "${KOTOBA_PREFIX}"
+  tar -xzf "${tmpdir}/${KOTOBA_ARCHIVE}" -C "${KOTOBA_PREFIX}"
+fi
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  echo "${KOTOBA_PREFIX}" >> "${GITHUB_PATH}"
+fi
+export PATH="${KOTOBA_PREFIX}:${PATH}"
+command -v kotoba

--- a/ci/scripts/kotoba_test.sh
+++ b/ci/scripts/kotoba_test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+source_dir="${1:-$(pwd)}"
+kotoba_dir="${source_dir}/kotoba"
+out_dir="${2:-${source_dir}/build/kotoba}"
+
+if ! command -v kotoba >/dev/null 2>&1; then
+  echo "kotoba is required (v0.7.2)" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "node is required to run Kotoba i64-v1 wasm fixtures" >&2
+  exit 1
+fi
+
+mkdir -p "${out_dir}"
+
+expect_wasm() {
+  python3 -c '
+import json, pathlib, sys
+result = json.load(sys.stdin)
+ok = result.get("kotoba.cli/ok?")
+code = result.get("kotoba.cli/code")
+if not ok:
+    print(result, file=sys.stderr)
+    raise SystemExit(f"compile failed: {code}")
+profile = result.get("kotoba.cli/data", {}).get("value-profile")
+if profile != "i64-v1":
+    raise SystemExit(f"expected i64-v1, got {profile}")
+path = pathlib.Path(sys.argv[1])
+data = path.read_bytes()
+if data[:4] != b"\x00asm":
+    raise SystemExit(f"{path} is not a wasm module")
+print(f"emitted {code} profile={profile} bytes={len(data)}")
+' "$1"
+}
+
+compile_entry() {
+  local entry="$1"
+  local output="$2"
+  echo "compile ${entry} -> ${output}"
+  kotoba compile "${entry}" \
+    --source-path "${kotoba_dir}" \
+    --unpinned \
+    --target wasm \
+    -o "${output}" \
+    --json | expect_wasm "${output}"
+}
+
+compile_project() {
+  local output="$1"
+  echo "compile project ${kotoba_dir}/kotoba-project.edn -> ${output}"
+  kotoba compile \
+    --project "${kotoba_dir}/kotoba-project.edn" \
+    --target wasm \
+    -o "${output}" \
+    --json | expect_wasm "${output}"
+}
+
+run_fixture() {
+  local wasm="$1"
+  node "${source_dir}/kotoba/run_fixture.mjs" "${wasm}"
+}
+
+compile_entry "${kotoba_dir}/adbc/status.kotoba" "${out_dir}/status.wasm"
+compile_entry "${kotoba_dir}/adbc/error.kotoba" "${out_dir}/error.wasm"
+compile_entry "${kotoba_dir}/adbc/connection.kotoba" "${out_dir}/connection.wasm"
+
+compile_entry "${kotoba_dir}/fixtures/status.kotoba" "${out_dir}/fixture-status.wasm"
+compile_entry "${kotoba_dir}/fixtures/error.kotoba" "${out_dir}/fixture-error.wasm"
+compile_entry "${kotoba_dir}/fixtures/mock_connection.kotoba" "${out_dir}/fixture-mock-connection.wasm"
+
+compile_project "${out_dir}/project.wasm"
+
+run_fixture "${out_dir}/fixture-status.wasm"
+run_fixture "${out_dir}/fixture-error.wasm"
+run_fixture "${out_dir}/fixture-mock-connection.wasm"
+run_fixture "${out_dir}/project.wasm"
+
+echo "kotoba fixtures passed"

--- a/docs/source/client_libraries.rst
+++ b/docs/source/client_libraries.rst
@@ -73,6 +73,10 @@ The client library package for each language:
      - npm
      - ``@apache-arrow/adbc-driver-manager``
      - :doc:`JavaScript Quickstart <javascript/quickstart>`
+   * - Kotoba
+     - kotoba 0.7.2
+     - in-tree ``kotoba/`` (wasm guest)
+     - :doc:`Kotoba Quickstart <kotoba/quickstart>`
    * - R
      - CRAN / conda
      - ``adbcdrivermanager``

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,7 +62,7 @@ Getting Started
       :link: client_libraries
       :link-type: doc
 
-      Use ADBC from C/C++, C#, Go, Java, JavaScript, Python, R, Ruby, and Rust.
+      Use ADBC from C/C++, C#, Go, Java, JavaScript, Kotoba, Python, R, Ruby, and Rust.
 
    .. grid-item-card:: :octicon:`tools` Writing Drivers
       :link: driver/authoring
@@ -106,7 +106,7 @@ Why ADBC?
       :link: client_libraries
       :link-type: doc
 
-      Work in C/C++, C#, Go, Java, JavaScript / TypeScript, Python, R, Ruby,
+      Work in C/C++, C#, Go, Java, JavaScript / TypeScript, Kotoba, Python, R, Ruby,
       Rust, and more. Use idiomatic APIs like DBAPI in Python,
       ``database/sql`` in Go, and DBI in R.
 
@@ -221,6 +221,7 @@ More Resources
    Go <https://pkg.go.dev/github.com/apache/arrow-adbc/go/adbc>
    Java <java/index>
    JavaScript <javascript/index>
+   Kotoba <kotoba/index>
    Python <python/index>
    R <r/index>
    Ruby <ruby/index>

--- a/docs/source/kotoba/index.rst
+++ b/docs/source/kotoba/index.rst
@@ -1,0 +1,33 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+======
+Kotoba
+======
+
+The ADBC Kotoba binding is an in-language guest API compiled to WebAssembly
+with `Kotoba <https://kotoba-lang.org>`_ 0.7.2.
+
+Kotoba programs cannot FFI ``libadbc``. v1 therefore ships only ADBC status
+and error codes plus a mock connection fixture. There is no real database.
+The host owns drivers and maps a URI to an integer kind before calling into
+the wasm module.
+
+.. toctree::
+   :maxdepth: 2
+
+   quickstart

--- a/docs/source/kotoba/quickstart.rst
+++ b/docs/source/kotoba/quickstart.rst
@@ -1,0 +1,47 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+..
+..   http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+==========
+Quickstart
+==========
+
+Install Kotoba 0.7.2, then compile a ``.kotoba`` entry point to wasm:
+
+.. code-block:: shell
+
+   kotoba compile kotoba/adbc/status.kotoba --target wasm -o status.wasm
+
+The mock connection fixture compiles the library graph and exports ``main``,
+which returns ``0`` when connect/close/query status codes match ``adbc.h``:
+
+.. code-block:: shell
+
+   kotoba compile kotoba/fixtures/mock_connection.kotoba \
+     --source-path kotoba --unpinned --target wasm -o mock.wasm
+
+From the repository root you can compile every module and run the fixtures:
+
+.. code-block:: shell
+
+   ./ci/scripts/kotoba_test.sh "$(pwd)"
+
+Status codes are the integer values from ``adbc.h``. An error is packed as
+``(status * 100000) + vendor_code``. SQLSTATE and message strings stay on
+the host.
+
+See the `Kotoba source tree <https://github.com/apache/arrow-adbc/tree/main/kotoba>`_
+for the modules and fixtures.

--- a/kotoba/README.md
+++ b/kotoba/README.md
@@ -1,0 +1,53 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Arrow Database Connectivity for Kotoba
+
+In-language ADBC status and error types for [Kotoba](https://kotoba-lang.org),
+compiled to WebAssembly with Kotoba 0.7.2.
+
+Kotoba guests cannot FFI `libadbc`. This v1 binding is a small guest-side
+status/error encoding plus a mock connection fixture. There is no real
+database. The host owns drivers and maps a URI to an integer kind before
+calling into the wasm module.
+
+## Layout
+
+- `adbc/status.kotoba` — `AdbcStatusCode` values from `adbc.h`
+- `adbc/error.kotoba` — packed status + vendor code
+- `adbc/connection.kotoba` — mock connect/close/query
+- `fixtures/` — executable wasm fixtures (`main` returns `0` on success)
+
+## Requirements
+
+- [Kotoba](https://github.com/kotoba-lang/kotoba) 0.7.2
+- Node.js 18+ (to instantiate the i64-v1 wasm fixtures)
+
+```shell
+# From the repository root
+./ci/scripts/kotoba_test.sh "$(pwd)"
+```
+
+Or compile a single entry point:
+
+```shell
+kotoba compile kotoba/adbc/status.kotoba --target wasm -o status.wasm
+kotoba compile kotoba/fixtures/mock_connection.kotoba \
+  --source-path kotoba --unpinned --target wasm -o mock.wasm
+```

--- a/kotoba/adbc/connection.kotoba
+++ b/kotoba/adbc/connection.kotoba
@@ -1,0 +1,50 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
+
+(ns adbc.connection
+  (:require [adbc.status :as status])
+  (:export [uri-empty uri-mock uri-unknown
+            closed open
+            connect close query]))
+
+;; Mock connection fixture. There is no real database and no libadbc FFI.
+;; The host owns drivers and maps a URI to one of these integer kinds
+;; before calling into the wasm guest.
+
+(defn uri-empty [] :i64 0)
+(defn uri-mock [] :i64 1)
+(defn uri-unknown [] :i64 2)
+
+(defn closed [] :i64 0)
+(defn open [] :i64 1)
+
+(defn connect [uri-kind :i64] :i64
+  (if (= uri-kind 1)
+    (status/ok)
+    (if (= uri-kind 0)
+      (status/invalid-argument)
+      (status/not-implemented))))
+
+(defn close [state :i64] :i64
+  (if (= state 1)
+    (status/ok)
+    (status/invalid-state)))
+
+(defn query [state :i64] :i64
+  (if (= state 1)
+    (status/not-implemented)
+    (status/invalid-state)))

--- a/kotoba/adbc/error.kotoba
+++ b/kotoba/adbc/error.kotoba
@@ -1,0 +1,39 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
+
+(ns adbc.error
+  (:require [adbc.status :as status])
+  (:export [pack from-status status-of vendor-of ok?]))
+
+;; In-language ADBC error for the i64-v1 wasm profile.
+;; Packed as (status * 100000) + vendor-code, with vendor-code in 0..99999.
+;; SQLSTATE and message text stay on the host; this guest cannot FFI libadbc.
+
+(defn pack [code :i64 vendor :i64] :i64
+  (+ (* code 100000) vendor))
+
+(defn from-status [code :i64] :i64
+  (pack code 0))
+
+(defn status-of [err :i64] :i64
+  (quot err 100000))
+
+(defn vendor-of [err :i64] :i64
+  (- err (* (quot err 100000) 100000)))
+
+(defn ok? [err :i64] :i64
+  (status/ok? (status-of err)))

--- a/kotoba/adbc/status.kotoba
+++ b/kotoba/adbc/status.kotoba
@@ -1,0 +1,45 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
+
+(ns adbc.status
+  (:export [ok unknown not-implemented not-found already-exists
+            invalid-argument invalid-state invalid-data integrity
+            internal io cancelled timeout unauthenticated unauthorized
+            ok?]))
+
+;; ADBC status codes from adbc.h (AdbcStatusCode). Kept as i64 so this
+;; module compiles to the kotoba i64-v1 wasm profile with no host imports.
+;; Kotoba cannot FFI libadbc; the host owns drivers.
+
+(defn ok [] :i64 0)
+(defn unknown [] :i64 1)
+(defn not-implemented [] :i64 2)
+(defn not-found [] :i64 3)
+(defn already-exists [] :i64 4)
+(defn invalid-argument [] :i64 5)
+(defn invalid-state [] :i64 6)
+(defn invalid-data [] :i64 7)
+(defn integrity [] :i64 8)
+(defn internal [] :i64 9)
+(defn io [] :i64 10)
+(defn cancelled [] :i64 11)
+(defn timeout [] :i64 12)
+(defn unauthenticated [] :i64 13)
+(defn unauthorized [] :i64 14)
+
+(defn ok? [code :i64] :i64
+  (if (= code 0) 1 0))

--- a/kotoba/fixtures/error.kotoba
+++ b/kotoba/fixtures/error.kotoba
@@ -1,0 +1,43 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
+
+(ns fixtures.error
+  (:require [adbc.status :as status]
+            [adbc.error :as error])
+  (:export [main]))
+
+;; Returns 0 when packed ADBC errors round-trip status and vendor_code.
+
+(defn main [] :i64
+  (let [err (error/pack (status/invalid-argument) 42)
+        ok (error/from-status (status/ok))]
+    (if (= (error/status-of err) (status/invalid-argument))
+      (if (= (error/vendor-of err) 42)
+        (if (= (error/ok? err) 0)
+          (if (= (error/status-of ok) (status/ok))
+            (if (= (error/vendor-of ok) 0)
+              (if (= (error/ok? ok) 1)
+                (if (= (error/status-of (error/from-status (status/not-implemented)))
+                       (status/not-implemented))
+                  0
+                  7)
+                6)
+              5)
+            4)
+          3)
+        2)
+      1)))

--- a/kotoba/fixtures/mock_connection.kotoba
+++ b/kotoba/fixtures/mock_connection.kotoba
@@ -1,0 +1,40 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
+
+(ns fixtures.mock-connection
+  (:require [adbc.status :as status]
+            [adbc.connection :as conn])
+  (:export [main]))
+
+;; Mock connection fixture: no real database. Host owns drivers.
+
+(defn main [] :i64
+  (if (= (conn/connect (conn/uri-mock)) (status/ok))
+    (if (= (conn/connect (conn/uri-empty)) (status/invalid-argument))
+      (if (= (conn/connect (conn/uri-unknown)) (status/not-implemented))
+        (if (= (conn/close (conn/open)) (status/ok))
+          (if (= (conn/close (conn/closed)) (status/invalid-state))
+            (if (= (conn/query (conn/open)) (status/not-implemented))
+              (if (= (conn/query (conn/closed)) (status/invalid-state))
+                0
+                7)
+              6)
+            5)
+          4)
+        3)
+      2)
+    1))

--- a/kotoba/fixtures/status.kotoba
+++ b/kotoba/fixtures/status.kotoba
@@ -1,0 +1,59 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
+
+(ns fixtures.status
+  (:require [adbc.status :as status])
+  (:export [main]))
+
+;; Returns 0 when every AdbcStatusCode matches adbc.h.
+
+(defn main [] :i64
+  (if (= (status/ok) 0)
+    (if (= (status/unknown) 1)
+      (if (= (status/not-implemented) 2)
+        (if (= (status/not-found) 3)
+          (if (= (status/already-exists) 4)
+            (if (= (status/invalid-argument) 5)
+              (if (= (status/invalid-state) 6)
+                (if (= (status/invalid-data) 7)
+                  (if (= (status/integrity) 8)
+                    (if (= (status/internal) 9)
+                      (if (= (status/io) 10)
+                        (if (= (status/cancelled) 11)
+                          (if (= (status/timeout) 12)
+                            (if (= (status/unauthenticated) 13)
+                              (if (= (status/unauthorized) 14)
+                                (if (= (status/ok? 0) 1)
+                                  (if (= (status/ok? 1) 0)
+                                    0
+                                    102)
+                                  101)
+                                14)
+                              13)
+                            12)
+                          11)
+                        10)
+                      9)
+                    8)
+                  7)
+                6)
+              5)
+            4)
+          3)
+        2)
+      1)
+    100))

--- a/kotoba/kotoba-project.edn
+++ b/kotoba/kotoba-project.edn
@@ -1,0 +1,28 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
+
+{:kotoba.project/root fixtures.mock-connection
+ :kotoba.project/modules
+ {adbc.status "adbc/status.kotoba"
+  adbc.error "adbc/error.kotoba"
+  adbc.connection "adbc/connection.kotoba"
+  fixtures.status "fixtures/status.kotoba"
+  fixtures.error "fixtures/error.kotoba"
+  fixtures.mock-connection "fixtures/mock_connection.kotoba"}
+ :kotoba.project/package-lock "kotoba.lock.edn"
+ :kotoba.project/trust "kotoba.trust.edn"
+ :kotoba.project/dependency-manifests {}}

--- a/kotoba/kotoba.lock.edn
+++ b/kotoba/kotoba.lock.edn
@@ -1,0 +1,19 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
+
+{:kotoba.lock/version 1
+ :deps []}

--- a/kotoba/kotoba.trust.edn
+++ b/kotoba/kotoba.trust.edn
@@ -1,0 +1,18 @@
+;; Licensed to the Apache Software Foundation (ASF) under one
+;; or more contributor license agreements.  See the NOTICE file
+;; distributed with this work for additional information
+;; regarding copyright ownership.  The ASF licenses this file
+;; to you under the Apache License, Version 2.0 (the
+;; "License"); you may not use this file except in compliance
+;; with the License.  You may obtain a copy of the License at
+;;
+;;   http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing,
+;; software distributed under the License is distributed on an
+;; "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+;; KIND, either express or implied.  See the License for the
+;; specific language governing permissions and limitations
+;; under the License.
+
+{:declared-capabilities []}

--- a/kotoba/run_fixture.mjs
+++ b/kotoba/run_fixture.mjs
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import fs from "node:fs";
+
+const path = process.argv[2];
+if (!path) {
+  console.error("usage: node kotoba/run_fixture.mjs <module.wasm>");
+  process.exit(2);
+}
+
+const bytes = fs.readFileSync(path);
+const { instance } = await WebAssembly.instantiate(bytes);
+if (typeof instance.exports.main !== "function") {
+  console.error(`${path}: missing exported main`);
+  process.exit(1);
+}
+
+const result = instance.exports.main();
+const value = typeof result === "bigint" ? result : BigInt(result);
+if (value !== 0n) {
+  console.error(`${path}: fixture failed main=${value}`);
+  process.exit(1);
+}
+
+console.log(`fixture ok ${path}`);


### PR DESCRIPTION
Add a first-class Kotoba guest binding next to the existing language trees.

## What this is

Kotoba cannot FFI `libadbc`. v1 is a small in-language ADBC surface:

- `AdbcStatusCode` values from `adbc.h`
- a packed error (`status * 100000 + vendor_code`)
- a mock connection fixture (no real database)

The host owns drivers and maps a URI to an integer kind before calling into the wasm guest.

## How it is built

`.kotoba` source compiles to wasm with [Kotoba 0.7.2](https://github.com/kotoba-lang/kotoba/releases/tag/v0.7.2). Fixtures export `main` and return `0` on success.

```
./ci/scripts/kotoba_test.sh "$(pwd)"
```

Kotoba CI on the fork is green: https://github.com/kotoba-lang/arrow-adbc/actions/workflows/kotoba.yml

Fork review: https://github.com/kotoba-lang/arrow-adbc/pull/1

An ASF ICLA may be required before this can be accepted. Happy to file a JIRA/GitHub issue first if maintainers want that.

## Test plan

- [x] `./ci/scripts/kotoba_test.sh` — compile + four fixtures return 0
- [x] Fork workflow `Kotoba` succeeded
- [ ] Reviewers: same script with kotoba 0.7.2 on `PATH`