### PR TITLE
chore(go/adbc): allow symbol table and debug info to be included in go libraries

### DIFF
--- a/csharp/src/Drivers/Interop/FlightSql/Build-FlightSqlDriver.ps1
+++ b/csharp/src/Drivers/Interop/FlightSql/Build-FlightSqlDriver.ps1
@@ -35,29 +35,36 @@ $location = Get-Location
 
 $file = "libadbc_driver_flightsql.dll"
 
-if(Test-Path $file)
-{
+if (Test-Path $file) {
     exit
 }
 
-cd ..\..\..\..\..\go\adbc\pkg
+try {
+    Set-Location ..\..\..\..\..\go\adbc\pkg
 
-make $file
+    # Ensure full symbols and debug info
+    $env:INCLUDE_SYMBOL_TABLES="true"
+    $env:INCLUDE_DEBUG_INFO="true"
 
-if(Test-Path $file)
-{
-    $processes = Get-Process | Where-Object { $_.Modules.ModuleName -contains $file }
+    make $file
 
-    if ($processes.Count -eq 0) {
-        try {
-        # File is not being used, copy it to the destination
-            Copy-Item -Path $file -Destination $location
-            Write-Host "File copied successfully."
+    if (Test-Path $file) {
+        $processes = Get-Process | Where-Object { $_.Modules.ModuleName -contains $file }
+
+        if ($processes.Count -eq 0) {
+            try {
+                # File is not being used, copy it to the destination
+                Copy-Item -Path $file -Destination $location
+                Write-Host "File copied successfully."
+            }
+            catch {
+                Write-Host "Caught error: $_"
+            }
         }
-        catch {
-            Write-Host "Caught error: $_"
+        else {
+            Write-Host "File is being used by another process. Cannot copy."
         }
-    } else {
-        Write-Host "File is being used by another process. Cannot copy."
     }
+} finally {
+    Set-Location $location
 }

--- a/csharp/src/Drivers/Interop/FlightSql/Build-FlightSqlDriver.ps1
+++ b/csharp/src/Drivers/Interop/FlightSql/Build-FlightSqlDriver.ps1
@@ -42,10 +42,6 @@ if (Test-Path $file) {
 try {
     Set-Location ..\..\..\..\..\go\adbc\pkg
 
-    # Ensure full symbols and debug info
-    $env:INCLUDE_SYMBOL_TABLES="true"
-    $env:INCLUDE_DEBUG_INFO="true"
-
     make $file
 
     if (Test-Path $file) {

--- a/go/adbc/pkg/Makefile
+++ b/go/adbc/pkg/Makefile
@@ -37,6 +37,15 @@ endif
 GIT_VERSION ?= unknown
 VERSION=$(subst go/adbc/,,$(GIT_VERSION))
 
+EXCLUDE_SYMBOL_TABLES ?= -s
+ifeq ($(INCLUDE_SYMBOL_TABLES),true)
+	EXCLUDE_SYMBOL_TABLES =
+endif
+EXCLUDE_DEBUG_INFO ?= -w
+ifeq ($(INCLUDE_DEBUG_INFO),true)
+	EXCLUDE_DEBUG_INFO =
+endif
+
 # Expand dynamically libadbc_driver_.SUFFIX
 DRIVERS := $(addsuffix .$(SUFFIX),$(addprefix libadbc_driver_,$(MANAGERS)))
 
@@ -48,7 +57,7 @@ DRIVERS := $(addsuffix .$(SUFFIX),$(addprefix libadbc_driver_,$(MANAGERS)))
 all: $(DRIVERS)
 
 libadbc_driver_%.$(SUFFIX): % ../driver/% ../go.mod ../go.sum
-	$(GO_BUILD) -buildvcs=true -tags driverlib -o $@ -buildmode=c-shared -ldflags "-s -w -X github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase.infoDriverVersion=$(VERSION)" ./$*
+	$(GO_BUILD) -buildvcs=true -tags driverlib -o $@ -buildmode=c-shared -ldflags "$(EXCLUDE_SYMBOL_TABLES) $(EXCLUDE_DEBUG_INFO) -X github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase.infoDriverVersion=$(VERSION)" ./$*
 	$(RM) $(basename $@).h
 
 regenerate:

--- a/go/adbc/pkg/Makefile
+++ b/go/adbc/pkg/Makefile
@@ -37,15 +37,6 @@ endif
 GIT_VERSION ?= unknown
 VERSION=$(subst go/adbc/,,$(GIT_VERSION))
 
-EXCLUDE_SYMBOL_TABLES ?= -s
-ifeq ($(INCLUDE_SYMBOL_TABLES),true)
-	EXCLUDE_SYMBOL_TABLES =
-endif
-EXCLUDE_DEBUG_INFO ?= -w
-ifeq ($(INCLUDE_DEBUG_INFO),true)
-	EXCLUDE_DEBUG_INFO =
-endif
-
 # Expand dynamically libadbc_driver_.SUFFIX
 DRIVERS := $(addsuffix .$(SUFFIX),$(addprefix libadbc_driver_,$(MANAGERS)))
 
@@ -57,7 +48,7 @@ DRIVERS := $(addsuffix .$(SUFFIX),$(addprefix libadbc_driver_,$(MANAGERS)))
 all: $(DRIVERS)
 
 libadbc_driver_%.$(SUFFIX): % ../driver/% ../go.mod ../go.sum
-	$(GO_BUILD) -buildvcs=true -tags driverlib -o $@ -buildmode=c-shared -ldflags "$(EXCLUDE_SYMBOL_TABLES) $(EXCLUDE_DEBUG_INFO) -X github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase.infoDriverVersion=$(VERSION)" ./$*
+	$(GO_BUILD) -buildvcs=true -tags driverlib -o $@ -buildmode=c-shared -ldflags "-X github.com/apache/arrow-adbc/go/adbc/driver/internal/driverbase.infoDriverVersion=$(VERSION)" ./$*
 	$(RM) $(basename $@).h
 
 regenerate:


### PR DESCRIPTION
This pull request makes improvements to the build process for the FlightSQL driver, particularly around error handling, working directory management, and build flags. The most important changes are as follows:

**PowerShell Script Improvements:**

* Added a `try/finally` block in `Build-FlightSqlDriver.ps1` to ensure the working directory is restored after building, improving reliability and preventing side effects if the script fails. [[1]](diffhunk://#diff-0594c154e1ea558437d54a8e4eaa644b9913f10b495452226afa4f360380066bL38-R47) [[2]](diffhunk://#diff-0594c154e1ea558437d54a8e4eaa644b9913f10b495452226afa4f360380066bL60-R66)
* Refactored and cleaned up conditional statements for better readability and maintainability in `Build-FlightSqlDriver.ps1`. [[1]](diffhunk://#diff-0594c154e1ea558437d54a8e4eaa644b9913f10b495452226afa4f360380066bL38-R47) [[2]](diffhunk://#diff-0594c154e1ea558437d54a8e4eaa644b9913f10b495452226afa4f360380066bL60-R66)

**Go Build Process:**

* Removed the `-s -w` linker flags from the Go build command in `Makefile` to simplify the build and potentially improve debugging.