### PR TITLE
fix(c/driver/postgresql): add missing space in error messages

### DIFF
--- a/c/driver/postgresql/result_helper.cc
+++ b/c/driver/postgresql/result_helper.cc
@@ -40,7 +40,7 @@ Status PqResultHelper::PrepareInternal(int n_params, const Oid* param_oids) cons
   PGresult* result =
       PQprepare(conn_, /*stmtName=*/"", query_.c_str(), n_params, param_oids);
   if (PQresultStatus(result) != PGRES_COMMAND_OK) {
-    auto status = MakeStatus(result, "Failed to prepare query: {}\nQuery was:{}",
+    auto status = MakeStatus(result, "Failed to prepare query: {}\nQuery was: {}",
                              PQerrorMessage(conn_), query_.c_str());
     PQclear(result);
     return status;
@@ -61,7 +61,7 @@ Status PqResultHelper::DescribePrepared() {
   result_ = PQdescribePrepared(conn_, /*stmtName=*/"");
   if (PQresultStatus(result_) != PGRES_COMMAND_OK) {
     Status status = MakeStatus(
-        result_, "[libpq] Failed to describe prepared statement: {}\nQuery was:{}",
+        result_, "[libpq] Failed to describe prepared statement: {}\nQuery was: {}",
         PQerrorMessage(conn_), query_.c_str());
     ClearResult();
     return status;

--- a/c/driver/postgresql/statement.cc
+++ b/c/driver/postgresql/statement.cc
@@ -765,7 +765,7 @@ AdbcStatusCode PostgresStatement::ExecuteIngest(struct ArrowArrayStream* stream,
   PGresult* result = PQexec(connection_->conn(), query.c_str());
   if (PQresultStatus(result) != PGRES_COPY_IN) {
     AdbcStatusCode code =
-        MakeStatus(result, "[libpq] COPY query failed: {}\nQuery was:{}",
+        MakeStatus(result, "[libpq] COPY query failed: {}\nQuery was: {}",
                    PQerrorMessage(connection_->conn()), query)
             .ToAdbc(error);
     PQclear(result);


### PR DESCRIPTION
While using the 1.12.0 version of the postgresql driver, I saw an error message that was missing a space after "Query was:". 

For example,

```text
Query was:SELECT * FROM repro_param_types WHERE int_col & $1 > 0. SQLSTATE: 42883
```

I then grepped the codebase for instances of this and fixed each so there's a space after all "Query was:" instances in the driver.