### PR TITLE
fix(csharp): update Microsoft.SourceLink.GitHub for vulnerability

### DIFF
--- a/csharp/Directory.Packages.props
+++ b/csharp/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="Google.Cloud.BigQuery.V2" Version="3.11.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.303" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="OpenTelemetry" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.12.0" />


### PR DESCRIPTION
This pull request includes a minor dependency update, specifically bumping the version of a single package to ensure the project uses the latest features and fixes.

* Upgraded the `Microsoft.SourceLink.GitHub` package from version `10.0.301` to `10.0.303` in `Directory.Packages.props`.