### PR TITLE
fix(c/driver/sqlite): accept unprefixed named parameters

### DIFF
--- a/c/driver/sqlite/sqlite_test.cc
+++ b/c/driver/sqlite/sqlite_test.cc
@@ -1121,6 +1121,24 @@ TEST_F(SqliteReaderTest, BindByNameKeepsExactPrefixPrecedence) {
   ASSERT_NO_FATAL_FAILURE(CompareArray<int64_t>(reader.array_view->children[1], {1}));
 }
 
+TEST_F(SqliteReaderTest, BindByNameRejectsDuplicateResolvedIndex) {
+  Handle<struct ArrowSchema> schema;
+  Handle<struct ArrowArray> batch;
+  ASSERT_THAT(adbc_validation::MakeSchema(&schema.value, {{"a", NANOARROW_TYPE_INT64},
+                                                          {":a", NANOARROW_TYPE_INT64}}),
+              IsOkErrno());
+  ASSERT_THAT((adbc_validation::MakeBatch<int64_t, int64_t>(&schema.value, &batch.value,
+                                                            nullptr, {1}, {2})),
+              IsOkErrno());
+  ASSERT_NO_FATAL_FAILURE(Bind(&batch.value, &schema.value, true));
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db, "SELECT :a, @b", -1, &stmt, nullptr));
+  char finished = 0;
+  ASSERT_EQ(ADBC_STATUS_INVALID_ARGUMENT,
+            InternalAdbcSqliteBinderBindNext(&binder, db, stmt, &finished, &error));
+  ASSERT_THAT(error.message,
+              ::testing::HasSubstr("both resolve to SQLite parameter `:a`"));
+}
+
 TEST_F(SqliteReaderTest, MultiValueParams) {
   // Regression test for apache/arrow-adbc#734
   adbc_validation::StreamReader reader;

--- a/c/driver/sqlite/sqlite_test.cc
+++ b/c/driver/sqlite/sqlite_test.cc
@@ -1062,6 +1062,65 @@ TEST_F(SqliteReaderTest, BindByName) {
   ASSERT_NO_FATAL_FAILURE(CompareArray<int64_t>(reader.array_view->children[1], {1}));
 }
 
+class SqliteUnprefixedNameTest : public SqliteReaderTest,
+                                 public ::testing::WithParamInterface<const char*> {};
+
+TEST_P(SqliteUnprefixedNameTest, BindByNameWithoutPrefix) {
+  adbc_validation::StreamReader reader;
+  Handle<struct ArrowSchema> schema;
+  Handle<struct ArrowArray> batch;
+  ASSERT_THAT(adbc_validation::MakeSchema(&schema.value, {{"b", NANOARROW_TYPE_INT64},
+                                                          {"a", NANOARROW_TYPE_INT64}}),
+              IsOkErrno());
+  ASSERT_THAT((adbc_validation::MakeBatch<int64_t, int64_t>(&schema.value, &batch.value,
+                                                            nullptr, {1, 3}, {2, 4})),
+              IsOkErrno());
+  ASSERT_NO_FATAL_FAILURE(Bind(&batch.value, &schema.value, true));
+  ASSERT_NO_FATAL_FAILURE(Exec(GetParam(), 2, &reader));
+  ASSERT_NO_FATAL_FAILURE(reader.Next());
+  ASSERT_NO_FATAL_FAILURE(CompareArray<int64_t>(reader.array_view->children[0], {2, 4}));
+  ASSERT_NO_FATAL_FAILURE(CompareArray<int64_t>(reader.array_view->children[1], {1, 3}));
+}
+
+INSTANTIATE_TEST_SUITE_P(Prefixes, SqliteUnprefixedNameTest,
+                         ::testing::Values("SELECT :a, :b", "SELECT @a, @b",
+                                           "SELECT $a, $b", "SELECT :a, @b"));
+
+TEST_F(SqliteReaderTest, BindByNameRejectsAmbiguousUnprefixedName) {
+  Handle<struct ArrowSchema> schema;
+  Handle<struct ArrowArray> batch;
+  ASSERT_THAT(adbc_validation::MakeSchema(&schema.value, {{"a", NANOARROW_TYPE_INT64}}),
+              IsOkErrno());
+  ASSERT_THAT(
+      adbc_validation::MakeBatch<int64_t>(&schema.value, &batch.value, nullptr, {42}),
+      IsOkErrno());
+  ASSERT_NO_FATAL_FAILURE(Bind(&batch.value, &schema.value, true));
+  ASSERT_EQ(SQLITE_OK, sqlite3_prepare_v2(db, "SELECT :a, @a", -1, &stmt, nullptr));
+  char finished = 0;
+  ASSERT_EQ(ADBC_STATUS_INVALID_ARGUMENT,
+            InternalAdbcSqliteBinderBindNext(&binder, db, stmt, &finished, &error));
+  ASSERT_THAT(error.message, ::testing::HasSubstr("ambiguous parameter `a`"));
+  ASSERT_EQ(ADBC_STATUS_INVALID_ARGUMENT,
+            InternalAdbcSqliteBinderBindNext(&binder, db, stmt, &finished, &error));
+}
+
+TEST_F(SqliteReaderTest, BindByNameKeepsExactPrefixPrecedence) {
+  adbc_validation::StreamReader reader;
+  Handle<struct ArrowSchema> schema;
+  Handle<struct ArrowArray> batch;
+  ASSERT_THAT(adbc_validation::MakeSchema(&schema.value, {{"@a", NANOARROW_TYPE_INT64},
+                                                          {":a", NANOARROW_TYPE_INT64}}),
+              IsOkErrno());
+  ASSERT_THAT((adbc_validation::MakeBatch<int64_t, int64_t>(&schema.value, &batch.value,
+                                                            nullptr, {1}, {2})),
+              IsOkErrno());
+  ASSERT_NO_FATAL_FAILURE(Bind(&batch.value, &schema.value, true));
+  ASSERT_NO_FATAL_FAILURE(Exec("SELECT :a, @a", 2, &reader));
+  ASSERT_NO_FATAL_FAILURE(reader.Next());
+  ASSERT_NO_FATAL_FAILURE(CompareArray<int64_t>(reader.array_view->children[0], {2}));
+  ASSERT_NO_FATAL_FAILURE(CompareArray<int64_t>(reader.array_view->children[1], {1}));
+}
+
 TEST_F(SqliteReaderTest, MultiValueParams) {
   // Regression test for apache/arrow-adbc#734
   adbc_validation::StreamReader reader;

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -343,6 +343,25 @@ AdbcStatusCode InternalAdbcSqliteBinderBindNext(struct AdbcSqliteBinder* binder,
       binder->param_indices[i] =
           sqlite3_bind_parameter_index(stmt, binder->schema.children[i]->name);
       if (binder->param_indices[i] == 0) {
+        // Accept names without a prefix when the match is unique. Exact names
+        // above retain precedence and their existing behavior.
+        for (int parameter = 1; parameter <= sqlite3_bind_parameter_count(stmt);
+             parameter++) {
+          const char* name = sqlite3_bind_parameter_name(stmt, parameter);
+          if (name != NULL && (name[0] == ':' || name[0] == '@' || name[0] == '$') &&
+              strcmp(name + 1, binder->schema.children[i]->name) == 0) {
+            if (binder->param_indices[i] != 0) {
+              binder->param_indices[0] = 0;
+              InternalAdbcSetError(error, "ambiguous parameter `%s`; include its prefix",
+                                   binder->schema.children[i]->name);
+              return ADBC_STATUS_INVALID_ARGUMENT;
+            }
+            binder->param_indices[i] = parameter;
+          }
+        }
+      }
+      if (binder->param_indices[i] == 0) {
+        binder->param_indices[0] = 0;
         InternalAdbcSetError(error, "could not find parameter `%s`",
                              binder->schema.children[i]->name);
         return ADBC_STATUS_INVALID_ARGUMENT;

--- a/c/driver/sqlite/statement_reader.c
+++ b/c/driver/sqlite/statement_reader.c
@@ -366,6 +366,18 @@ AdbcStatusCode InternalAdbcSqliteBinderBindNext(struct AdbcSqliteBinder* binder,
                              binder->schema.children[i]->name);
         return ADBC_STATUS_INVALID_ARGUMENT;
       }
+      for (int previous = 0; previous < i; previous++) {
+        if (binder->param_indices[previous] == binder->param_indices[i]) {
+          const char* name = sqlite3_bind_parameter_name(stmt, binder->param_indices[i]);
+          binder->param_indices[0] = 0;
+          InternalAdbcSetError(
+              error,
+              "parameter fields `%s` and `%s` both resolve to SQLite parameter `%s`",
+              binder->schema.children[previous]->name, binder->schema.children[i]->name,
+              name);
+          return ADBC_STATUS_INVALID_ARGUMENT;
+        }
+      }
     }
   }
 

--- a/docs/source/driver/sqlite.rst
+++ b/docs/source/driver/sqlite.rst
@@ -138,6 +138,17 @@ shared across all connections.
 Supported Features
 ==================
 
+Named Parameters
+----------------
+
+When binding by name, parameter names may include their ``:``, ``@``, or ``$``
+prefix, or omit it when the remaining name identifies a unique SQL parameter.
+For example, Python's ``cursor.execute("SELECT :a", {"a": 1})`` and
+``cursor.execute("SELECT :a", {":a": 1})`` are both supported.
+Exact prefixed names take precedence. If a query contains both ``:a`` and
+``@a``, an unprefixed ``a`` is ambiguous and must be replaced by the exact
+prefixed names.
+
 Bulk Ingestion
 --------------
 

--- a/python/adbc_driver_sqlite/tests/test_dbapi.py
+++ b/python/adbc_driver_sqlite/tests/test_dbapi.py
@@ -35,6 +35,41 @@ def test_query_trivial(sqlite) -> None:
         assert cur.fetchone() == (1,)
 
 
+@pytest.mark.parametrize("prefix", [":", "@", "$"])
+@pytest.mark.parametrize("include_prefix", [False, True])
+def test_named_parameters(sqlite, prefix: str, include_prefix: bool) -> None:
+    # Regression test for apache/arrow-adbc#3520.
+    name_prefix = prefix if include_prefix else ""
+    with sqlite.cursor() as cur:
+        cur.execute(
+            f"SELECT {prefix}a, {prefix}b, {prefix}a",
+            {f"{name_prefix}b": 2, f"{name_prefix}a": 1},
+        )
+        assert cur.fetchone() == (1, 2, 1)
+
+
+def test_named_parameters_mixed_prefixes(sqlite) -> None:
+    with sqlite.cursor() as cur:
+        cur.execute("SELECT :a, @b, $c", {"c": 3, "b": 2, "a": 1})
+        assert cur.fetchone() == (1, 2, 3)
+
+
+def test_named_parameters_ambiguous(sqlite) -> None:
+    with sqlite.cursor() as cur:
+        with pytest.raises(dbapi.ProgrammingError, match="ambiguous parameter `a`"):
+            cur.execute("SELECT :a, @a", {"a": 1, "@a": 2})
+        cur.execute("SELECT :a, @a", {"@a": 2, ":a": 1})
+        assert cur.fetchone() == (1, 2)
+
+
+def test_named_parameters_missing(sqlite) -> None:
+    with sqlite.cursor() as cur:
+        with pytest.raises(
+            dbapi.ProgrammingError, match="could not find parameter `b`"
+        ):
+            cur.execute("SELECT :a", {"b": 1})
+
+
 def test_autocommit(tmp_path: Path) -> None:
     # apache/arrow-adbc#599
     db = tmp_path / "tmp.sqlite"

--- a/python/adbc_driver_sqlite/tests/test_dbapi.py
+++ b/python/adbc_driver_sqlite/tests/test_dbapi.py
@@ -62,6 +62,15 @@ def test_named_parameters_ambiguous(sqlite) -> None:
         assert cur.fetchone() == (1, 2)
 
 
+def test_named_parameters_duplicate_resolved_index(sqlite) -> None:
+    with sqlite.cursor() as cur:
+        with pytest.raises(
+            dbapi.ProgrammingError,
+            match="both resolve to SQLite parameter `:a`",
+        ):
+            cur.execute("SELECT :a, @b", {"a": 1, ":a": 2})
+
+
 def test_named_parameters_missing(sqlite) -> None:
     with sqlite.cursor() as cur:
         with pytest.raises(


### PR DESCRIPTION
## Summary

Accept unprefixed names for SQLite's `:`, `@`, and `$` named parameters when the match is unique. Exact prefixed names keep their existing behavior; ambiguous unprefixed names produce an explicit error. Positional binding and parameter-count validation are unchanged.

AI disclosure: OpenAI Codex generated this implementation, tests, and PR description; automated validation is listed above.

Closes #3520
