### PR TITLE
fix(c/validation): compare widened ingestion values

### DIFF
--- a/c/validation/adbc_validation_statement.cc
+++ b/c/validation/adbc_validation_statement.cc
@@ -85,6 +85,43 @@ void StatementTest::TestRelease() {
   ASSERT_EQ(NULL, statement.private_data);
 }
 
+namespace {
+
+bool CanCompareIngestValues(ArrowType input, ArrowType output) {
+  if (input == output) return true;
+
+  switch (input) {
+    case NANOARROW_TYPE_BOOL:
+      return output == NANOARROW_TYPE_INT8 || output == NANOARROW_TYPE_INT16 ||
+             output == NANOARROW_TYPE_INT32 || output == NANOARROW_TYPE_INT64;
+    case NANOARROW_TYPE_INT8:
+    case NANOARROW_TYPE_UINT8:
+      return output == NANOARROW_TYPE_INT16 || output == NANOARROW_TYPE_INT32 ||
+             output == NANOARROW_TYPE_INT64;
+    case NANOARROW_TYPE_INT16:
+    case NANOARROW_TYPE_UINT16:
+      return output == NANOARROW_TYPE_INT32 || output == NANOARROW_TYPE_INT64;
+    case NANOARROW_TYPE_INT32:
+    case NANOARROW_TYPE_UINT32:
+      return output == NANOARROW_TYPE_INT64;
+    case NANOARROW_TYPE_HALF_FLOAT:
+      return output == NANOARROW_TYPE_FLOAT || output == NANOARROW_TYPE_DOUBLE;
+    case NANOARROW_TYPE_FLOAT:
+      return output == NANOARROW_TYPE_DOUBLE;
+    case NANOARROW_TYPE_LARGE_STRING:
+    case NANOARROW_TYPE_STRING_VIEW:
+      return output == NANOARROW_TYPE_STRING;
+    case NANOARROW_TYPE_LARGE_BINARY:
+    case NANOARROW_TYPE_BINARY_VIEW:
+    case NANOARROW_TYPE_FIXED_SIZE_BINARY:
+      return output == NANOARROW_TYPE_BINARY;
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
 template <typename CType>
 void StatementTest::TestSqlIngestType(SchemaField field,
                                       const std::vector<std::optional<CType>>& values,
@@ -175,8 +212,7 @@ void StatementTest::TestSqlIngestType(SchemaField field,
     ASSERT_EQ(values.size(), reader.array->length);
     ASSERT_EQ(1, reader.array->n_children);
 
-    if (round_trip_field.type == field.type) {
-      // XXX: for now we can't compare values; we would need casting
+    if (CanCompareIngestValues(field.type, round_trip_field.type)) {
       ASSERT_NO_FATAL_FAILURE(
           CompareArray<CType>(reader.array_view->children[0], values));
     }


### PR DESCRIPTION
Compare ingestion values and nulls after lossless numeric widening and string/binary normalization, fixing checks skipped when Arrow types differ.

The `CompareArray` comparison function seems to handle the comparisons just fine here.